### PR TITLE
Run our nats server, passing the consul IP address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,6 @@ compile_images: base_image
 
 publish_images: compile_images
 	@for component in $(COMPONENTS); do \
-		docker tag fissile:cf-$(CF_RELEASE)-$$component $(REGISTRY_HOST)/hcf:cf-$(CF_RELEASE)-$$component; \
-		docker push $(REGISTRY_HOST)/hcf:cf-$(CF_RELEASE)-$$component; \
+		docker tag -f fissile:cf-v$(CF_RELEASE)-$$component $(REGISTRY_HOST)/hcf/cf-v$(CF_RELEASE)-$$component; \
+		docker push $(REGISTRY_HOST)/hcf/cf-v$(CF_RELEASE)-$$component; \
 	done

--- a/bootstrap-scripts/consullin.bash
+++ b/bootstrap-scripts/consullin.bash
@@ -14,7 +14,9 @@ if [[ "$CONSUL_ADDRESS" != */ ]]; then
   CONSUL_ADDRESS="$CONSUL_ADDRESS/"
 fi
 
-set -x
+if [ "$DEBUG" != "" ] ; then
+  set -x
+fi
 
 mkdir -p $TMP_CONFIG_DIR
 tar xzf "$FISSILE_CFG_PACK" -C "$TMP_CONFIG_DIR"

--- a/terraform-scripts/hcf/scripts
+++ b/terraform-scripts/hcf/scripts
@@ -1,0 +1,1 @@
+../../bootstrap-scripts/

--- a/terraform-scripts/hcf/variables.tf
+++ b/terraform-scripts/hcf/variables.tf
@@ -12,6 +12,10 @@ variable "key_file" {
 	description = "Private key file for newly created hosts"
 }
 
+variable "cf-release" {
+	default = "217"
+}
+
 variable "openstack_network_id" {}
 variable "openstack_auth_url" {}
 variable "openstack_tenant" {}
@@ -134,3 +138,4 @@ variable "uaa_clients_gorouter_secret" {
 variable "uaa_scim_users" {
 	default = "admin|fakepassword|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose"
 }
+


### PR DESCRIPTION
Will start natsd, but it will fail because configuration parameters for nats are missing from consul.

Need to start populating consul with the required "dark" options.
