### PR TITLE
Remove unused variables from the variables file.

### DIFF
--- a/terraform-scripts/hcf/variables.tf
+++ b/terraform-scripts/hcf/variables.tf
@@ -17,9 +17,6 @@ variable "cf-release" {
 }
 
 variable "openstack_network_id" {}
-variable "openstack_auth_url" {}
-variable "openstack_tenant" {}
-variable "openstack_username" {}
 variable "openstack_network_id" {}
 variable "openstack_keypair" {}
 


### PR DESCRIPTION
By defining these variables in the file, the user was forced to provide them, even though
they would not be used (the env vars from openstackrc would be used instead). This was
confusing.
