### PR TITLE
Build the rest of the components.

### DIFF
--- a/version.mk
+++ b/version.mk
@@ -1,1 +1,1 @@
-VERSION?=1.0.0-$(shell date +%Y%m%d_%H%M%S)
+VERSION:=1.0.0-$(shell date -u +%Y%m%d_%H%M%S)


### PR DESCRIPTION
Also, split the cf-release download into two distinct tasks,
one that downloads the cf-release from bosh.io and caches it in Swift,
and one that downloads from Swift. The default is now to download the
cf-release from Swift for performance reasons.
