### PR TITLE
Pull Docker from the docker apt repo, so we can control the version

### DIFF
--- a/bootstrap-scripts/consul.json
+++ b/bootstrap-scripts/consul.json
@@ -1,0 +1,15 @@
+{
+  "data_dir": "/opt/hcf/share/consul",
+  "log_level": "INFO",
+  "node_name": "hcf-main",
+  "server": true,
+  "ports": {
+     "dns": 8601,
+     "http": 8501,
+     "https": -1,
+     "rpc": 8401,
+     "serf_lan": 8311,
+     "serf_wan": 8312,
+     "server": 8310
+  }
+}

--- a/terraform-scripts/hcf/overrides.tfvars.sample
+++ b/terraform-scripts/hcf/overrides.tfvars.sample
@@ -1,0 +1,7 @@
+openstack_availability_zone = "az1"
+openstack_keypair = "<your keypair>"
+openstack_network_id = "<your network id>"
+key_file = "<your local private key file location>"
+
+router_ssl_cert_file = "foo" # will fill in later with actual cert location
+router_ssl_key_file = "foo" # will fill in later with actual cert location

--- a/terraform-scripts/hcf/variables.tf
+++ b/terraform-scripts/hcf/variables.tf
@@ -19,6 +19,7 @@ variable "cf-release" {
 variable "openstack_network_id" {}
 variable "openstack_network_id" {}
 variable "openstack_keypair" {}
+variable "openstack_availability_zone" {}
 
 variable "openstack_flavor_id" {
 	default = "102"
@@ -34,6 +35,10 @@ variable "openstack_floating_ip_pool" {
 
 variable "dea_count" {
 	default = "1"
+}
+
+variable "core_volume_size" {
+	default = "40"
 }
 
 # Secrets


### PR DESCRIPTION
Attach a blockstorage volume to your core node (defaults to 40 gb)

Configure hcf-consul to start on port 8501

Start cf-consul, attaching a volume

Start cf-etcd, attaching a volume

Start cf-nfs, attaching a volume

Start cf-postgres, attaching a volume
