### PR TITLE
Update Security Group To Use Group ID.

### DIFF
--- a/terraform-scripts/hcf/hcf.tf
+++ b/terraform-scripts/hcf/hcf.tf
@@ -3,7 +3,7 @@ provider "openstack" {
 }
 
 resource "openstack_compute_secgroup_v2" "hcf-container-host-secgroup" {
-    name = "hcf-container-host"
+    name = "hcf-container-host-secgroup"
     description = "HCF Container Hosts"
     rule {
         from_port = 1


### PR DESCRIPTION
Security group name is not unique.

Note that `name` is a required field, and there isn't an `ID` field.
