### PR TITLE
Commenting out (currently) unused components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ UBUNTU_IMAGE=ubuntu:14.04.2
 
 REGISTRY_HOST?=15.126.242.125:5000
 
-COMPONENTS=uaa stats smoke_tests runner router postgres nats loggregator_trafficcontroller loggregator hm9000 ha_proxy etcd doppler consul clock_global api_worker api acceptance_tests
+# smoke_tests acceptance_tests
+COMPONENTS=uaa stats runner router postgres nats loggregator_trafficcontroller loggregator hm9000 ha_proxy etcd doppler consul clock_global api_worker api
 
 include version.mk
 


### PR DESCRIPTION
We're not running acceptance_tests or smoke_tests yet, so they just add to build time.
