### PR TITLE
Make health checks more robust

### DIFF
--- a/bootstrap-scripts/check_health.bash
+++ b/bootstrap-scripts/check_health.bash
@@ -9,7 +9,12 @@ job_names="$@"
 is_unhealthy=0
 
 for service_name in ${job_names}; do
-  service_health=$(curl -s -u "${monit_user}:${monit_pass}" "http://127.0.0.1:${monit_port}/_status?format=xml" | xmlstarlet sel -t -m "monit/service[name='${service_name}']" -v status)
+  monit_status=$(curl -s -u "${monit_user}:${monit_pass}" "http://127.0.0.1:${monit_port}/_status?format=xml")
+  if [[ "$?" != 0 ]]; then
+    echo "failed to reach monit at: http://127.0.0.1:${monit_port} using provided username and password"
+    exit 2
+  fi
+  service_health=$(echo "${monit_status}" | xmlstarlet sel -t -m "monit/service[name='${service_name}']" -v status)
   echo "${service_name} => ${service_health}"
   if [[ 0 != "${service_health}" ]]; then
     is_unhealthy=2

--- a/images/hcf-consul-base/Dockerfile
+++ b/images/hcf-consul-base/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:trusty
 MAINTAINER hcf-dev@hpe.com
 LABEL version="1.0"
-RUN apt-get install -y curl wget unzip jq xmlstarlet
+RUN apt-get update && apt-get install -y curl wget unzip jq xmlstarlet
 RUN wget -O /tmp/consul.zip https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip
 RUN mkdir /opt/consul && unzip -d /opt/consul /tmp/consul.zip && rm /tmp/consul.zip


### PR DESCRIPTION
- Make the output on a monit-failing health check more useful instead of
  spewing XML errors.
- Fix the consul base image (needed apt-get update to find cool packages)
