### PR TITLE
Stop using --net=host

### DIFF
--- a/bootstrap-scripts/get_ip
+++ b/bootstrap-scripts/get_ip
@@ -1,0 +1,2 @@
+#!/bin/bash
+ip addr show dev eth0 | grep "inet " | cut -d ' ' -f 6  | cut -f 1 -d '/'


### PR DESCRIPTION
Removes --net=host on hcf-consul. All containers still start. Places a
shell script to help tease out the container host's IP address.
