### PR TITLE
Expose dockerd on TCP and UNIX sockets

### DIFF
--- a/terraform-scripts/hcf/hcf.tf
+++ b/terraform-scripts/hcf/hcf.tf
@@ -133,7 +133,7 @@ sudo apt-get install -y docker-engine=1.8.3-0~trusty
 sudo usermod -aG docker ubuntu
 # allow us to pull from the docker registry
 # TODO: this needs to be removed when we publish to Docker Hub
-echo DOCKER_OPTS=\"--insecure-registry ${var.registry_host} -s devicemapper -g /data/docker\" | sudo tee -a /etc/default/docker
+echo DOCKER_OPTS=\"--insecure-registry ${var.registry_host} -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock -s devicemapper -g /data/docker\" | sudo tee -a /etc/default/docker
 # We have to reboot since this switches our kernel.        
 sudo reboot && sleep 10
 EOF


### PR DESCRIPTION
Exposes the docker daemon on both port 2375 (the default) and the UNIX socket.
