### PR TITLE
Don't try to add routes for ha_proxy

### DIFF
--- a/config-opinions/cf-v217/role-manifest.yml
+++ b/config-opinions/cf-v217/role-manifest.yml
@@ -54,8 +54,6 @@ roles:
   - name: consul_agent
   - name: metron_agent
 - name: ha_proxy
-  scripts:
-  - fix_local_ip_for_overlay_networking.sh
   jobs:
   - name: haproxy
   - name: consul_agent


### PR DESCRIPTION
It needs to start in a different way, with eth0 NOT being the overlay network.
