### PR TITLE
Prevent runner from disabling the host's apparmor

### DIFF
--- a/config-opinions/cf-v217/prevent_apparmor_disable.sh
+++ b/config-opinions/cf-v217/prevent_apparmor_disable.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# runner attempts to disable apparmor which ends up disabling it on the host
+# preventing other containers from starting. It checks for this init script
+# before doing so, so we move it to a different location.
+mv /etc/init.d/apparmor /etc/init.d/apparmor_host

--- a/config-opinions/cf-v217/role-manifest.yml
+++ b/config-opinions/cf-v217/role-manifest.yml
@@ -99,6 +99,7 @@ roles:
   - name: metron_agent
 - name: runner
   scripts:
+  - prevent_apparmor_disable.sh
   - fix_local_ip_for_overlay_networking.sh
   - fix_warden_local_ip_for_overlay_networking.sh  
   - write_dns_health_check_runner.sh


### PR DESCRIPTION
- Without this docker run commands to fail with an esoteric error after
  runner starts up and disables apparmor.
