### PR TITLE
Fixing broken monit config

### DIFF
--- a/bootstrap-scripts/service_registration.bash
+++ b/bootstrap-scripts/service_registration.bash
@@ -58,3 +58,4 @@ register_service_and_monit "2841" "doppler" "doppler" "syslog_drain_binder"
 register_service_and_monit "2842" "loggregator_trafficcontroller" "loggregator_trafficcontroller"
 register_service_and_monit "2843" "router" "gorouter"
 register_service_and_monit "2844" "runner" "dea_next" "dea_logging_agent"
+# 2855 and 2856 are used for smoke and acceptance tests.

--- a/terraform-scripts/hcf/hcf-test.tf.disabled
+++ b/terraform-scripts/hcf/hcf-test.tf.disabled
@@ -74,20 +74,22 @@ set -e
 export CONSUL=http://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:8501
 
 /opt/hcf/bin/set-config $CONSUL hcf/user/acceptance_tests/api "api.${openstack_networking_floatingip_v2.hcf-core-host-fip.address}.${var.domain}"
-/opt/hcf/bin/set-config $CONSUL hcf/user/acceptance_tests/admin_user admin # TODO: get from existing config
-/opt/hcf/bin/set-config $CONSUL hcf/user/acceptance_tests/admin_password fakepassword # TODO: get from existing config
+/opt/hcf/bin/set-config $CONSUL hcf/user/acceptance_tests/admin_user "${var.cluster_admin_username}"
+/opt/hcf/bin/set-config $CONSUL hcf/user/acceptance_tests/admin_password "${var.cluster_admin_password}"
 /opt/hcf/bin/set-config $CONSUL hcf/user/acceptance_tests/apps_domain "[${openstack_networking_floatingip_v2.hcf-core-host-fip.address}.${var.domain}]"	
 /opt/hcf/bin/set-config $CONSUL hcf/user/acceptance_tests/skip_ssl_validation true # TODO: get from existing config
 /opt/hcf/bin/set-config $CONSUL hcf/user/acceptance_tests/system_domain "${openstack_networking_floatingip_v2.hcf-core-host-fip.address}.${var.domain}"
 /opt/hcf/bin/set-config $CONSUL hcf/user/acceptance_tests/client_secret "$(curl $CONSUL/v1/kv/hcf/user/uaa/clients/gorouter/secret?raw)"
-		
+/opt/hcf/bin/set-config $CONSUL hcf/role/acceptance_tests/hcf/monit/port "2855"
+
 /opt/hcf/bin/set-config $CONSUL hcf/user/smoke_tests/api "api.${openstack_networking_floatingip_v2.hcf-core-host-fip.address}.${var.domain}"
-/opt/hcf/bin/set-config $CONSUL hcf/user/smoke_tests/user admin # TODO: get from existing config
-/opt/hcf/bin/set-config $CONSUL hcf/user/smoke_tests/password fakepassword # TODO: get from existing config
+/opt/hcf/bin/set-config $CONSUL hcf/user/smoke_tests/user "${var.cluster_admin_username}"
+/opt/hcf/bin/set-config $CONSUL hcf/user/smoke_tests/password "${var.cluster_admin_password}"
 /opt/hcf/bin/set-config $CONSUL hcf/user/smoke_tests/apps_domain "[${openstack_networking_floatingip_v2.hcf-core-host-fip.address}.${var.domain}]"
 /opt/hcf/bin/set-config $CONSUL hcf/user/smoke_tests/org CF-SMOKE-ORG
 /opt/hcf/bin/set-config $CONSUL hcf/user/smoke_tests/space CF-SMOKE-SPACE
 /opt/hcf/bin/set-config $CONSUL hcf/user/smoke_tests/skip_ssl_validation true # TODO: get from existing config
+/opt/hcf/bin/set-config $CONSUL hcf/role/smoke_tests/hcf/monit/port "2856"
 
 EOF
 


### PR DESCRIPTION
Even though the smoke/acceptance tests don't /use/ monit, it's still set up on the container and thus config is required.
