### PR TITLE
Generate config base during build

### DIFF
--- a/terraform-scripts/hcf/.gitignore
+++ b/terraform-scripts/hcf/.gitignore
@@ -1,3 +1,4 @@
 *.tfvars
 .terraform
 hcf-test.tf
+hcf-config.tar.gz

--- a/terraform-scripts/hcf/hcf.tf
+++ b/terraform-scripts/hcf/hcf.tf
@@ -254,11 +254,15 @@ docker network connect hcf $cid
 EOF
     }
 
+    provisioner "file" {
+        source = "hcf-config.tar.gz"
+        destination = "/tmp/hcf-config.tar.gz"
+    }
+
     provisioner "remote-exec" {
         inline = [
-        "curl -L https://region-b.geo-1.objects.hpcloudsvc.com/v1/10990308817909/pelerinul/hcf.tar.gz -o /tmp/hcf-config-base.tgz",
         "bash /opt/hcf/bin/wait_for_consul.bash http://`/opt/hcf/bin/get_ip`:8501",
-        "bash /opt/hcf/bin/consullin.bash http://`/opt/hcf/bin/get_ip`:8501 /tmp/hcf-config-base.tgz"
+        "bash /opt/hcf/bin/consullin.bash http://`/opt/hcf/bin/get_ip`:8501 /tmp/hcf-config.tar.gz"
         ]
     }
 


### PR DESCRIPTION
Previously, the config base was compiled once by Vlad and uploaded to
Swift. Each subsequent installation used that pre-compiled config base.

Now, we compile the config-base at every build, and embed it in the
hcf.tar.gz file that is distributed to users.

If you do not want to run a full build, but want to deploy via
 Terraform, you need to grab a compiled hcf-config.tar.gz from Jenkins.
