### PR TITLE
Fix health checks for network overlays.

### DIFF
--- a/bootstrap-scripts/check_health.bash
+++ b/bootstrap-scripts/check_health.bash
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
-monit_user="$1"
-monit_pass="$2"
-monit_addr="$3"
-monit_port="$4"
-shift 4
+set -e
+
+consul_addr="http://localhost:8501"
+monit_user=$(curl -s ${consul_addr}/v1/kv/hcf/user/hcf/monit/user?raw | sed 's/"//g')
+monit_pass=$(curl -s ${consul_addr}/v1/kv/hcf/user/hcf/monit/password?raw | sed 's/"//g')
+monit_port=$(curl -s ${consul_addr}/v1/kv/hcf/user/hcf/monit/port?raw | sed 's/"//g')
+monit_addr="$1"
+shift 1
 job_names="$@"
 
 is_unhealthy=0

--- a/bootstrap-scripts/service_registration.bash
+++ b/bootstrap-scripts/service_registration.bash
@@ -2,59 +2,70 @@
 
 set -e
 
-monit_user='monit'
-monit_pass='monitpass'
-monit_addr=$(/opt/hcf/bin/get_ip)
-curl -X PUT -d '"nats"' http://127.0.0.1:8501/v1/kv/hcf/user/nats/user
-curl -X PUT -d '"goodpass"' http://127.0.0.1:8501/v1/kv/hcf/user/nats/password
-curl -X PUT -d '"'${monit_user}'"' http://127.0.0.1:8501/v1/kv/hcf/user/hcf/monit/user
-curl -X PUT -d '"'${monit_pass}'"' http://127.0.0.1:8501/v1/kv/hcf/user/hcf/monit/password
+dea_count="$1"
+if [[ -z "$dea_count" ]]; then
+  echo "Usage: service_registration.bash <dea_count>"
+  exit 1
+fi
 
-function register_service_and_monit {
-  monit_port="$1"
-  service_name="$2"
+consul_addr="http://localhost:8501"
+monit_user=$(curl -s ${consul_addr}/v1/kv/hcf/user/hcf/monit/user?raw | sed 's/"//g')
+monit_pass=$(curl -s ${consul_addr}/v1/kv/hcf/user/hcf/monit/password?raw | sed 's/"//g')
+monit_port=$(curl -s ${consul_addr}/v1/kv/hcf/user/hcf/monit/port?raw | sed 's/"//g')
+
+function register_role {
+  role_index="$1"
+  role_name="$2"
+  tag_name="$2"
+  if [[ -1 != ${role_index} ]]; then
+    role_name="${role_name}-${role_index}"
+  fi
+
+  monit_addr="cf-${role_name}.hcf"
   shift 2
   job_names="$@"
 
-  # Register service with health check
-  curl -X PUT -d '@-' http://127.0.0.1:8501/v1/agent/service/register <<EOM
+  # Register role with health check
+  curl -s -X PUT -d '@-' ${consul_addr}/v1/agent/service/register > /dev/null <<EOM
   {
-    "name": "${service_name}", "tags": ["${service_name}"],
+    "name": "${role_name}", "tags": ["${tag_name}"],
     "check": {
-      "id": "${service_name}_check", "interval": "30s",
-      "script": "/opt/hcf/bin/check_health.bash ${monit_user} ${monit_pass} ${monit_addr} ${monit_port} consul_agent metron_agent ${job_names}"
+      "id": "${role_name}_check", "interval": "30s",
+      "script": "/opt/hcf/bin/check_health.bash ${monit_addr} consul_agent metron_agent ${job_names}"
     }
   }
 EOM
 
-  # Register monit service with health check
-  curl -X PUT -d '@-' http://localhost:8501/v1/agent/service/register <<EOM
+  # Register monit role with health check
+  curl -s -X PUT -d '@-' ${consul_addr}/v1/agent/service/register > /dev/null <<EOM
   {
-    "name": "${service_name}_monit", "tags": ["monit"],
+    "name": "${role_name}_monit", "tags": ["monit"],
     "port": ${monit_port},
     "check": {
-      "id": "${service_name}_monit_check", "interval": "30s",
+      "id": "${role_name}_monit_check", "interval": "30s",
       "http": "http://${monit_user}:${monit_pass}@${monit_addr}:${monit_port}/_status"
     }
   }
 EOM
-
-  # Register monit port
-  curl -X PUT -d "${monit_port}" "http://127.0.0.1:8501/v1/kv/hcf/role/${service_name}/hcf/monit/port"
 }
 
-register_service_and_monit "2830" "consul"
-register_service_and_monit "2831" "nats" "nats" "nats_stream_forwarder"
-register_service_and_monit "2832" "etcd" "etcd" "etcd_metrics_server"
-register_service_and_monit "2833" "stats" "collector"
-register_service_and_monit "2834" "ha_proxy" "haproxy" "consul_template"
-register_service_and_monit "2835" "postgres" "postgres"
-register_service_and_monit "2836" "uaa" "uaa" "uaa_cf-registrar"
-register_service_and_monit "2837" "api" "cloud_controller_migration" "cloud_controller_ng" "cloud_controller_worker_local_1" "cloud_controller_worker_local_2" "nginx_cc" "routing-api" "statsd-injector"
-register_service_and_monit "2838" "clock_global" "cloud_controller_clock"
-register_service_and_monit "2839" "api_worker" "cloud_controller_worker_1"
-register_service_and_monit "2840" "hm9000" "hm9000_analyzer" "hm9000_api_server" "hm9000_evacuator" "hm9000_fetcher" "hm9000_listener" "hm9000_metrics_server" "hm9000_sender" "hm9000_shredder"
-register_service_and_monit "2841" "doppler" "doppler" "syslog_drain_binder"
-register_service_and_monit "2842" "loggregator_trafficcontroller" "loggregator_trafficcontroller"
-register_service_and_monit "2843" "router" "gorouter"
-register_service_and_monit "2844" "runner" "dea_next" "dea_logging_agent"
+register_role -1 "consul"
+register_role -1 "nats" "nats" "nats_stream_forwarder"
+register_role -1 "etcd" "etcd" "etcd_metrics_server"
+register_role -1 "stats" "collector"
+register_role -1 "ha_proxy" "haproxy" "consul_template"
+register_role -1 "postgres" "postgres"
+register_role -1 "uaa" "uaa" "uaa_cf-registrar"
+register_role -1 "api" "cloud_controller_migration" "cloud_controller_ng" "cloud_controller_worker_local_1" "cloud_controller_worker_local_2" "nginx_cc" "routing-api" "statsd-injector"
+register_role -1 "clock_global" "cloud_controller_clock"
+register_role -1 "api_worker" "cloud_controller_worker_1"
+register_role -1 "hm9000" "hm9000_analyzer" "hm9000_api_server" "hm9000_evacuator" "hm9000_fetcher" "hm9000_listener" "hm9000_metrics_server" "hm9000_sender" "hm9000_shredder"
+register_role -1 "doppler" "doppler" "syslog_drain_binder"
+register_role -1 "loggregator_trafficcontroller" "loggregator_trafficcontroller"
+register_role -1 "router" "gorouter"
+
+i=0
+while [[ $i != $dea_count ]]; do
+  register_role "$i" "runner" "dea_next" "dea_logging_agent"
+  ((++i))
+done

--- a/terraform-scripts/hcf/variables.tf
+++ b/terraform-scripts/hcf/variables.tf
@@ -126,6 +126,16 @@ variable "nats_password" {
 	default = "nats_password"
 }
 
+variable "monit_user" {
+  default = "monit_user"
+}
+variable "monit_password" {
+  default = "monit_password"
+}
+variable "monit_port" {
+  default = "2822"
+}
+
 variable "router_cipher_suites" {
 	default = "TLS_RSA_WITH_RC4_128_SHA:TLS_RSA_WITH_AES_128_CBC_SHA"
 }


### PR DESCRIPTION
- Use CF "role" instead of consul "service" terminology in most places.
- Implement role index for multiple of the same role.
- Set the nats, monit user/password in one place in the TF scripts
  overridable by a variable.
- Lookup the monit details from consul instead of passing it in on the
  command line.
