### PR TITLE
Fixes the -n is deprecated warning

### DIFF
--- a/bootstrap-scripts/gato
+++ b/bootstrap-scripts/gato
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run -net=hcf -i -t -v /opt/hcf/etc/gato:/root/.gato 15.126.242.125:5000/hcf/hcf-gato $*
+docker run --net=hcf -i -t -v /opt/hcf/etc/gato:/root/.gato 15.126.242.125:5000/hcf/hcf-gato $*


### PR DESCRIPTION
I keep using a single - where I mean a double - in docker.
