### PR TITLE
Revert "Change dea to a medium."

### DIFF
--- a/terraform-scripts/hcf/variables.tf
+++ b/terraform-scripts/hcf/variables.tf
@@ -37,7 +37,7 @@ variable "openstack_region" {
 variable "openstack_flavor_id" {
 	default = {
 		core = "103" # standard.large   8GB
-		dea  = "102" # standard.medium  4GB
+		dea  = "103" # standard.large   8GB
 		test = "101" # standard.small   2GB
 	}
 }


### PR DESCRIPTION
Reverts hpcloud/hcf-infrastructure#93

Opening this up because during test runs, performance is sluggish and some tests timeout. 
We may have more tests failing if we reduce DEA size.

Don't merge this until we reach a conclusion.
