### PR TITLE
Make gato a cheetah

### DIFF
--- a/bootstrap-scripts/gato
+++ b/bootstrap-scripts/gato
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
 
-docker run --net=hcf -i -t -v /opt/hcf/etc/gato:/root/.gato 15.126.242.125:5000/hcf/hcf-gato $*
+gato_status=`docker inspect -f "{{.State.Running}}" hcf-gato`
+
+if [[ "$?" == "1" || $gato_status == 'false' ]] ; then
+  docker rm --force hcf-gato 2> /dev/null 1> /dev/null
+  docker run -it --name hcf-gato --entrypoint="bash" --net=hcf -d -v /opt/hcf/etc/gato:/root/.gato 15.126.242.125:5000/hcf/hcf-gato -i > /dev/null
+fi
+
+docker exec hcf-gato gato $*


### PR DESCRIPTION
Instead of using docker run each time the user runs gato, run an hcf-gato container in the backend, and use docker exec on susequent runs
