### PR TITLE
Adding an artifact that packages up CloudFlare's SSL toolkit.

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -1,6 +1,6 @@
 export REGISTRY:=15.126.242.125:5000
 
-.PHONY: hcf-consul-base hcf-consul-client hcf-consul-server
+.PHONY: hcf-consul-base hcf-consul-client hcf-consul-server hcf-cfssl
 
 include ../version.mk
 
@@ -8,7 +8,7 @@ BRANCH:=$(shell git rev-parse --short HEAD)
 BUILD:=$(shell whoami)-$(BRANCH)-$(shell date -u +%Y%m%d%H%M%S)
 APP_VERSION=$(VERSION)-$(BUILD)
 
-all: hcf-consul-base hcf-consul-client hcf-consul-server
+all: hcf-consul-base hcf-consul-client hcf-consul-server hcf-cfssl
 
 hcf-consul-base:
 	make -C hcf-consul-base BRANCH=$(BRANCH) BUILD=$(BUILD) APP_VERSION=$(APP_VERSION)
@@ -18,3 +18,6 @@ hcf-consul-client:
 
 hcf-consul-server:
 	make -C hcf-consul-server BRANCH=$(BRANCH) BUILD=$(BUILD) APP_VERSION=$(APP_VERSION)
+
+hcf-cfssl:
+	make -C hcf-cfssl BRANCH=$(BRANCH) BUILD=$(BUILD) APP_VERSION=$(APP_VERSION)

--- a/images/hcf-cfssl/.gitignore
+++ b/images/hcf-cfssl/.gitignore
@@ -1,0 +1,2 @@
+dist/
+_work/

--- a/images/hcf-cfssl/Dockerfile
+++ b/images/hcf-cfssl/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:trusty
+MAINTAINER hcf-dev@hpe.com
+LABEL version="1.0"
+RUN apt-get update && apt-get install -y curl wget unzip build-essential libltdl-dev git && \
+	curl -L https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz -o /tmp/golang.tar.gz && \
+	cd /usr/local && sudo tar zxvf /tmp/golang.tar.gz && \
+	GOPATH=$HOME PATH=/usr/local/go/bin:$GOPATH/bin:$PATH go get -u github.com/cloudflare/cfssl/cmd/... && \
+	GOPATH=$HOME PATH=/usr/local/go/bin:$GOPATH/bin:$PATH cfssl version
+RUN echo gopath = $HOME
+RUN ls -l $HOME/bin

--- a/images/hcf-cfssl/Makefile
+++ b/images/hcf-cfssl/Makefile
@@ -1,0 +1,32 @@
+.PHONY: clean build dist
+
+include ../../version.mk
+
+BRANCH:=$(shell git rev-parse --short HEAD)
+BUILD:=$(shell whoami)-$(BRANCH)-$(shell date -u +%Y%m%d%H%M%S)
+APP_VERSION=$(VERSION)-$(BUILD)
+
+all: build dist
+
+IMAGE_NAME=hcf/hcf-cfssl-build
+
+clean:
+	-docker rmi -f $(IMAGE_NAME)
+	-docker rm -f $(IMAGE_NAME)
+	-rm -rf dist
+	-rm -rf _work
+
+build:
+	docker build -t $(IMAGE_NAME) .
+
+dist:
+	$(eval CONTAINER_ID="$(shell docker create $(IMAGE_NAME))")
+	
+	mkdir -p _work/hcf-cfssl
+	mkdir -p dist
+
+	docker cp $(CONTAINER_ID):/root/bin/. _work/hcf-cfssl
+
+	cd _work ; tar czvf ../dist/hcf-cfssl-$(APP_VERSION).tar.gz hcf-cfssl/
+
+	docker rm $(CONTAINER_ID)


### PR DESCRIPTION
This will replace the certificate generation scripts with CloudFlare's
toolkit, to make it easier to manage all the certs for the cluster.
