### PR TITLE
Improve consul check from proxied envs

### DIFF
--- a/bootstrap-scripts/wait_for_consul.bash
+++ b/bootstrap-scripts/wait_for_consul.bash
@@ -8,8 +8,13 @@ fi
 
 CONSUL_ADDRESS="$1"
 
-until [[ $(curl -s "$CONSUL_ADDRESS/v1/status/leader") =~ [:digit]+ ]]; do
+# Response from server will be either:
+#  * nothing (server not up)
+#  * "" (leader not elected)
+#  * "{ip}:{port}" (leader elected, ready)
+until [[ $(curl -s "$CONSUL_ADDRESS/v1/status/leader") =~ ^\"[0-9.:]+\" ]]; do
 	echo "Waiting for consul to come online"
 	sleep 1
 done
 echo "Consul up!"
+


### PR DESCRIPTION
I was having an issue where a proxy was returning an error message including a digit, and this test was erroneously passing.
