### PR TITLE
HCF-299 Allow custom non-xip.io domains

### DIFF
--- a/terraform-scripts/hcf/outputs.tf
+++ b/terraform-scripts/hcf/outputs.tf
@@ -1,3 +1,3 @@
 output "api_endpoint" {
-    value = "https://api.${openstack_networking_floatingip_v2.hcf-core-host-fip.address}.${var.domain}"
+    value = "https://api.${template_file.domain.rendered}"
 }

--- a/terraform-scripts/hcf/templates/domain.tpl
+++ b/terraform-scripts/hcf/templates/domain.tpl
@@ -1,0 +1,1 @@
+${replace(domain, "/^xip\.io$/", floating_domain)}


### PR DESCRIPTION
If the user supplies a custom domain in overrides.tfvars, don't prepend the
floating IP address to it.  Note that this does not emit the correct URL at
the end of the process yet.

Do not merge yet; the output at the end of the build is incorrect.
