### PR TITLE
HCF-364 improve wildcard domain handling

### DIFF
--- a/terraform-scripts/hcf/hcf.tf
+++ b/terraform-scripts/hcf/hcf.tf
@@ -7,8 +7,8 @@ resource "template_file" "domain" {
 
     vars {
         domain = "${var.domain}"
-        wildcard_dns_domain_regexp = "${var.wildcard_dns_domain_regexp}"
         floating_domain = "${openstack_networking_floatingip_v2.hcf-core-host-fip.address}.${var.domain}"
+        wildcard_dns = "${var.wildcard_dns}"
     }
 }
 

--- a/terraform-scripts/hcf/templates/domain.tpl
+++ b/terraform-scripts/hcf/templates/domain.tpl
@@ -1,1 +1,1 @@
-${replace(domain, format("/^%s$/", wildcard_dns_domain_regexp), floating_domain)}
+${element(split("|", "${domain}|${floating_domain}"), wildcard_dns)}

--- a/terraform-scripts/hcf/variables.tf
+++ b/terraform-scripts/hcf/variables.tf
@@ -53,10 +53,6 @@ variable "dns_server" {
 	default = "8.8.8.8"
 }
 
-variable "wildcard_dns_domain_regexp" {
-	default = "xip\.io"
-}
-
 variable "dea_count" {
 	default = "1"
 }
@@ -113,6 +109,10 @@ variable "uaadb_tag" {
 
 variable "domain" {
 	default = "xip.io"
+}
+
+variable "wildcard_dns" {
+	default = 1
 }
 
 variable "loggregator_shared_secret" {


### PR DESCRIPTION
I have this working currently by adding a new variable:

```
variable "wildcard_dns_domain_regexp" {
    default = "xip\.io"
}
```

Unfortunately this then requires you to specify your domain twice in the overrides if it is xip-style. Once just written out and again as a regexp. Not happy with this as a solution but can't come up with anything better at the moment.

```
domain = "helion-cf.io"
wildcard_dns_domain_regexp = "helion\-cf\.io"
```
