### PR TITLE
HCF-358 Embed registry host and docker tag in gato wrapper script

### DIFF
--- a/terraform-scripts/hcf/hcf.tf
+++ b/terraform-scripts/hcf/hcf.tf
@@ -12,6 +12,15 @@ resource "template_file" "domain" {
     }
 }
 
+resource "template_file" "gato_wrapper" {
+    filename = "${path.module}/templates/gato-wrapper.tpl"
+
+    vars {
+        registry_host = "${var.registry_host}"
+        build = "${var.build}"
+    }
+}
+
 resource "openstack_compute_secgroup_v2" "hcf-container-host-secgroup" {
     name = "${var.cluster-prefix}-container-host"
     description = "HCF Container Hosts"
@@ -100,6 +109,14 @@ resource "openstack_compute_instance_v2" "hcf-core-host" {
     provisioner "file" {
         source = "scripts/"
         destination = "/opt/hcf/bin/"
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+            "cat > /opt/hcf/bin/gato <<'EOF'",
+            "${template_file.gato_wrapper.rendered}",
+            "EOF"
+        ]
     }
 
     provisioner "remote-exec" {

--- a/terraform-scripts/hcf/templates/gato-wrapper.tpl
+++ b/terraform-scripts/hcf/templates/gato-wrapper.tpl
@@ -4,7 +4,7 @@ gato_status=`docker inspect -f "{{.State.Running}}" hcf-gato 2> /dev/null`
 
 if [[ "$?" == "1" || $gato_status == 'false' ]] ; then
   docker rm --force hcf-gato 2> /dev/null 1> /dev/null
-  docker run --interactive --name hcf-gato --entrypoint="bash" --net=hcf -d -v /opt/hcf/etc/gato:/root/.gato 15.126.242.125:5000/hcf/hcf-gato -i > /dev/null
+  docker run --interactive --name hcf-gato --entrypoint="bash" --net=hcf -d -v /opt/hcf/etc/gato:/root/.gato ${registry_host}/hcf/hcf-gato:${build} -i > /dev/null
 fi
 
 case `tty` in


### PR DESCRIPTION
This lets us actually run the correct image in development builds.
