### PR TITLE
HCF-366 Lock down docker version to 1.9.1

### DIFF
--- a/terraform-scripts/hcf-proxied/hcf.tf
+++ b/terraform-scripts/hcf-proxied/hcf.tf
@@ -171,6 +171,11 @@ EOF
     provisioner "remote-exec" {
         inline = <<EOF
 set -e
+
+# the default Ubuntu mirror provided in the images is slow slow slow
+sudo sed -ik8bak 's/az1\.clouds\.archive\.ubuntu\.com\/ubuntu/mirrors\.rit\.edu\/ubuntu-archive/g' /etc/apt/sources.list
+sudo sed -ik8bak 's/security\.ubuntu\.com\/ubuntu/mirrors\.rit\.edu\/ubuntu-archive/g' /etc/apt/sources.list
+
 echo "Update Ubuntu"
 sudo apt-get update 
 sudo DEBIAN_FRONTEND=noninteractive apt-get dselect-upgrade -y
@@ -227,7 +232,11 @@ EOF
 set -e
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget quota
 
-curl -sSL https://test.docker.com/ | sh
+echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee /etc/apt/sources.list.d/docker.list
+
+sudo apt-key adv --keyserver hkp://na.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-engine=${var.docker_version}
 
 # Set up docker proxy. Needs to happen after docker install so we don't get prompted about the config file
 echo 'export http_proxy="${var.http_proxy}"' | sudo tee -a /etc/default/docker
@@ -686,6 +695,11 @@ EOF
     provisioner "remote-exec" {
         inline = <<EOF
 set -e
+
+# the default Ubuntu mirror provided in the images is slow slow slow
+sudo sed -ik8bak 's/az1\.clouds\.archive\.ubuntu\.com\/ubuntu/mirrors\.rit\.edu\/ubuntu-archive/g' /etc/apt/sources.list
+sudo sed -ik8bak 's/security\.ubuntu\.com\/ubuntu/mirrors\.rit\.edu\/ubuntu-archive/g' /etc/apt/sources.list
+
 echo "Update Ubuntu"
 sudo apt-get update 
 sudo DEBIAN_FRONTEND=noninteractive apt-get dselect-upgrade -y
@@ -701,7 +715,11 @@ EOF
 set -e
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget quota
 
-curl -sSL https://test.docker.com/ | sh
+echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee /etc/apt/sources.list.d/docker.list
+
+sudo apt-key adv --keyserver hkp://na.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-engine=${var.docker_version}
 
 # Set up docker proxy. Needs to happen after docker install so we don't get prompted about the config file
 echo 'export http_proxy="${var.http_proxy}"' | sudo tee -a /etc/default/docker

--- a/terraform-scripts/hcf-proxied/variables.tf
+++ b/terraform-scripts/hcf-proxied/variables.tf
@@ -207,3 +207,7 @@ variable "overlay_subnet" {
 variable "overlay_gateway" {
 	default = "192.168.252.1"
 }
+
+variable "docker_version" {
+	default = "1.9.1-0~trusty"
+}

--- a/terraform-scripts/hcf/hcf.tf
+++ b/terraform-scripts/hcf/hcf.tf
@@ -149,10 +149,16 @@ EOF
     provisioner "remote-exec" {
         inline = <<EOF
 set -e
+
+# the default Ubuntu mirror provided in the images is slow slow slow
+sudo sed -ik8bak 's/az1\.clouds\.archive\.ubuntu\.com\/ubuntu/mirrors\.rit\.edu\/ubuntu-archive/g' /etc/apt/sources.list
+sudo sed -ik8bak 's/security\.ubuntu\.com\/ubuntu/mirrors\.rit\.edu\/ubuntu-archive/g' /etc/apt/sources.list
+
 echo "Update Ubuntu"
 sudo apt-get update 
 sudo DEBIAN_FRONTEND=noninteractive apt-get dselect-upgrade -y
 echo "Install a kernel with quota support"
+sudo apt-get update 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-generic-lts-vivid linux-image-extra-virtual-lts-vivid
 sudo reboot && sleep 10
 EOF
@@ -204,7 +210,11 @@ EOF
 set -e
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget quota
 
-curl -sSL https://test.docker.com/ | sh
+echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee /etc/apt/sources.list.d/docker.list
+
+sudo apt-key adv --keyserver hkp://na.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-engine=${var.docker_version}
 
 sudo usermod -aG docker ubuntu
 # allow us to pull from the docker registry
@@ -636,10 +646,16 @@ resource "openstack_compute_instance_v2" "hcf-dea-host" {
     provisioner "remote-exec" {
         inline = <<EOF
 set -e
+
+# the default Ubuntu mirror provided in the images is slow slow slow
+sudo sed -ik8bak 's/az1\.clouds\.archive\.ubuntu\.com\/ubuntu/mirrors\.rit\.edu\/ubuntu-archive/g' /etc/apt/sources.list
+sudo sed -ik8bak 's/security\.ubuntu\.com\/ubuntu/mirrors\.rit\.edu\/ubuntu-archive/g' /etc/apt/sources.list
+
 echo "Update Ubuntu"
 sudo apt-get update 
 sudo DEBIAN_FRONTEND=noninteractive apt-get dselect-upgrade -y
 echo "Install a kernel with quota support"
+sudo apt-get update 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-generic-lts-vivid linux-image-extra-virtual-lts-vivid
 sudo reboot && sleep 10
 EOF
@@ -650,7 +666,11 @@ EOF
 set -e
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget quota
 
-curl -sSL https://test.docker.com/ | sh
+echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee /etc/apt/sources.list.d/docker.list
+
+sudo apt-key adv --keyserver hkp://na.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-engine=${var.docker_version}
 
 sudo usermod -aG docker ubuntu
 # allow us to pull from the docker registry

--- a/terraform-scripts/hcf/variables.tf
+++ b/terraform-scripts/hcf/variables.tf
@@ -207,3 +207,7 @@ variable "overlay_subnet" {
 variable "overlay_gateway" {
 	default = "192.168.252.1"
 }
+
+variable "docker_version" {
+	default = "1.9.1-0~trusty"
+}


### PR DESCRIPTION
Uses the apt repository to install Docker, set to version 1.9.1

Changes the default Ubuntu repository to the RIT mirror, it's fast
and reliable. The default cloud Ubuntu repository is incredibly flaky.
