### PR TITLE
HCF-370 Switch to Docker Hub from private registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@ TARGET_DIR=$(PWD)/target
 
 UBUNTU_IMAGE=ubuntu:14.04.2
 
-REGISTRY_HOST?=15.126.242.125:5000
-
 COMPONENTS=uaa stats runner router postgres nats loggregator_trafficcontroller hm9000 ha_proxy etcd doppler consul clock_global api_worker api smoke_tests acceptance_tests
 
 include version.mk
@@ -111,10 +109,10 @@ generate_config_base: fetch_fissle fetch_cf_release
 
 publish_images: compile_images
 	for component in $(COMPONENTS); do \
-		docker tag -f fissile-$$component:$(CF_RELEASE)-$(APP_VERSION) $(REGISTRY_HOST)/hcf/cf-v$(CF_RELEASE)-$$component:$(APP_VERSION) && \
-		docker tag -f fissile-$$component:$(CF_RELEASE)-$(APP_VERSION) $(REGISTRY_HOST)/hcf/cf-v$(CF_RELEASE)-$$component:latest-$(BRANCH) && \
-		docker push $(REGISTRY_HOST)/hcf/cf-v$(CF_RELEASE)-$$component:$(APP_VERSION) && \
-		docker push $(REGISTRY_HOST)/hcf/cf-v$(CF_RELEASE)-$$component:latest-$(BRANCH) ; \
+		docker tag -f fissile-$$component:$(CF_RELEASE)-$(APP_VERSION) helioncf/cf-$$component:$(APP_VERSION) && \
+		docker tag -f fissile-$$component:$(CF_RELEASE)-$(APP_VERSION) helioncf/cf-$$component:latest-$(BRANCH) && \
+		docker push helioncf/cf-$$component:$(APP_VERSION) && \
+		docker push helioncf/cf-$$component:latest-$(BRANCH) ; \
 	done
 
 dist: generate_config_base

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,5 +1,3 @@
-export REGISTRY:=15.126.242.125:5000
-
 .PHONY: hcf-consul-base hcf-consul-client hcf-consul-server hcf-cfssl
 
 include ../version.mk

--- a/images/hcf-cfssl/Makefile
+++ b/images/hcf-cfssl/Makefile
@@ -8,7 +8,7 @@ APP_VERSION=$(VERSION)-$(BUILD)
 
 all: build dist
 
-IMAGE_NAME=hcf/hcf-cfssl-build
+IMAGE_NAME=helioncf/hcf-cfssl-build
 
 clean:
 	-docker rmi -f $(IMAGE_NAME)

--- a/images/hcf-consul-base/Makefile
+++ b/images/hcf-consul-base/Makefile
@@ -8,15 +8,15 @@ APP_VERSION=$(VERSION)-$(BUILD)
 
 all: build tag push
 
-IMAGE_NAME=hcf/consul-base
+IMAGE_NAME=helioncf/hcf-consul-base
 
 build:
 	docker build -t $(IMAGE_NAME) .
 
 tag:
-	docker tag -f $(IMAGE_NAME) $(REGISTRY)/$(IMAGE_NAME):$(APP_VERSION)
-	docker tag -f $(IMAGE_NAME) $(REGISTRY)/$(IMAGE_NAME):latest-$(BRANCH)
+	docker tag -f $(IMAGE_NAME) $(IMAGE_NAME):$(APP_VERSION)
+	docker tag -f $(IMAGE_NAME) $(IMAGE_NAME):latest-$(BRANCH)
 
 push:
-	docker push $(REGISTRY)/$(IMAGE_NAME):$(APP_VERSION)
-	docker push $(REGISTRY)/$(IMAGE_NAME):latest-$(BRANCH)	
+	docker push $(IMAGE_NAME):$(APP_VERSION)
+	docker push $(IMAGE_NAME):latest-$(BRANCH)	

--- a/images/hcf-consul-client/Dockerfile
+++ b/images/hcf-consul-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 15.126.242.125:5000/hcf/consul-base
+FROM helioncf/hcf-consul-base
 MAINTAINER hcf-dev@hpe.com
 LABEL version="1.0"
 ENTRYPOINT ["/opt/consul/consul"]

--- a/images/hcf-consul-client/Makefile
+++ b/images/hcf-consul-client/Makefile
@@ -8,15 +8,15 @@ APP_VERSION=$(VERSION)-$(BUILD)
 
 all: build tag push
 
-IMAGE_NAME=hcf/consul-client
+IMAGE_NAME=helioncf/hcf-consul-client
 
 build:
 	docker build -t $(IMAGE_NAME) .
 
 tag:
-	docker tag -f $(IMAGE_NAME) $(REGISTRY)/$(IMAGE_NAME):$(APP_VERSION)
-	docker tag -f $(IMAGE_NAME) $(REGISTRY)/$(IMAGE_NAME):latest-$(BRANCH)
+	docker tag -f $(IMAGE_NAME) $(IMAGE_NAME):$(APP_VERSION)
+	docker tag -f $(IMAGE_NAME) $(IMAGE_NAME):latest-$(BRANCH)
 
 push:
-	docker push $(REGISTRY)/$(IMAGE_NAME):$(APP_VERSION)
-	docker push $(REGISTRY)/$(IMAGE_NAME):latest-$(BRANCH)	
+	docker push $(IMAGE_NAME):$(APP_VERSION)
+	docker push $(IMAGE_NAME):latest-$(BRANCH)	

--- a/images/hcf-consul-server/Dockerfile
+++ b/images/hcf-consul-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM 15.126.242.125:5000/hcf/consul-base
+FROM helioncf/hcf-consul-base
 MAINTAINER hcf-dev@hpe.com
 LABEL version="1.0"
 EXPOSE 8300 8301 8302 8400 8500 8600 

--- a/images/hcf-consul-server/Makefile
+++ b/images/hcf-consul-server/Makefile
@@ -8,15 +8,15 @@ APP_VERSION=$(VERSION)-$(BUILD)
 
 all: build tag push
 
-IMAGE_NAME=hcf/consul-server
+IMAGE_NAME=helioncf/hcf-consul-server
 
 build:
 	docker build -t $(IMAGE_NAME) .
 
 tag:
-	docker tag -f $(IMAGE_NAME) $(REGISTRY)/$(IMAGE_NAME):$(APP_VERSION)
-	docker tag -f $(IMAGE_NAME) $(REGISTRY)/$(IMAGE_NAME):latest-$(BRANCH)
+	docker tag -f $(IMAGE_NAME) $(IMAGE_NAME):$(APP_VERSION)
+	docker tag -f $(IMAGE_NAME) $(IMAGE_NAME):latest-$(BRANCH)
 
 push:
-	docker push $(REGISTRY)/$(IMAGE_NAME):$(APP_VERSION)
-	docker push $(REGISTRY)/$(IMAGE_NAME):latest-$(BRANCH)	
+	docker push $(IMAGE_NAME):$(APP_VERSION)
+	docker push $(IMAGE_NAME):latest-$(BRANCH)	

--- a/terraform-scripts/hcf-proxied/hcf.tf
+++ b/terraform-scripts/hcf-proxied/hcf.tf
@@ -244,10 +244,8 @@ echo 'export https_proxy="${var.https_proxy}"' | sudo tee -a /etc/default/docker
 echo 'export no_proxy="${var.no_proxy},${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}"' | sudo tee -a /etc/default/docker
 
 sudo usermod -aG docker ubuntu
-# allow us to pull from the docker registry
-# TODO: this needs to be removed when we publish to Docker Hub
 
-echo DOCKER_OPTS=\"--cluster-store=etcd://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:3379 --cluster-advertise=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 --label=com.docker.network.driver.overlay.bind_interface=eth0 --insecure-registry=${var.registry_host} -H=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 -H=unix:///var/run/docker.sock -s=devicemapper -g=/data/docker \" | sudo tee -a /etc/default/docker
+echo DOCKER_OPTS=\"--cluster-store=etcd://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:3379 --cluster-advertise=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 --label=com.docker.network.driver.overlay.bind_interface=eth0 -H=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 -H=unix:///var/run/docker.sock -s=devicemapper -g=/data/docker \" | sudo tee -a /etc/default/docker
 
 # enable cgroup memory and swap accounting
 sudo sed -idockerbak 's/GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX=\"cgroup_enable=memory swapaccount=1\"/' /etc/default/grub
@@ -260,11 +258,29 @@ sudo reboot && sleep 10
 EOF
     }
 
+    # 
+    # sign in to docker hub if username / password is provided
+    #
+    provisioner "remote-exec" {
+        inline = <<EOF
+set -e
+
+DOCKER_USERNAME=${var.docker_username}
+
+if [ "$DOCKER_USERNAME" != "" ] ; then
+    echo "Logging in to Docker Hub for image pulls"
+
+    docker login "-e=${var.docker_email}" "-u=${var.docker_username}" "-p=${var.docker_password}"
+fi
+
+EOF
+    }
+
     #
     # gato
     #
     provisioner "remote-exec" {
-        inline = ["docker pull ${var.registry_host}/hcf/hcf-gato:${var.build} | tee /tmp/hcf-gato-output"]
+        inline = ["docker pull helioncf/hcf-gato:${var.build} | tee /tmp/hcf-gato-output"]
     }
 
     #
@@ -301,7 +317,7 @@ EOF
         inline = <<EOF
 set -e
 sudo mv /tmp/consul.json /opt/hcf/etc/consul.json
-cid=$(docker run -d --net=bridge --privileged=true --restart=unless-stopped -p 8401:8401 -p 8501:8501 -p 8601:8601 -p 8310:8310 -p 8311:8311 -p 8312:8312 --name hcf-consul-server -v /opt/hcf/bin:/opt/hcf/bin -v /opt/hcf/etc:/opt/hcf/etc -v /data/hcf-consul:/opt/hcf/share/consul -t ${var.registry_host}/hcf/consul-server:${var.build} -bootstrap -client=0.0.0.0 --config-file /opt/hcf/etc/consul.json | tee /tmp/hcf-consul-server-output)
+cid=$(docker run -d --net=bridge --privileged=true --restart=unless-stopped -p 8401:8401 -p 8501:8501 -p 8601:8601 -p 8310:8310 -p 8311:8311 -p 8312:8312 --name hcf-consul-server -v /opt/hcf/bin:/opt/hcf/bin -v /opt/hcf/etc:/opt/hcf/etc -v /data/hcf-consul:/opt/hcf/share/consul -t helioncf/hcf-consul-server:${var.build} -bootstrap -client=0.0.0.0 --config-file /opt/hcf/etc/consul.json | tee /tmp/hcf-consul-server-output)
 docker network connect hcf $cid
 EOF
     }
@@ -468,7 +484,7 @@ EOF
 
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-consul -v /data/cf-consul:/var/vcap/store -t ${var.registry_host}/hcf/cf-v${var.cf-release}-consul:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-consul-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-consul -v /data/cf-consul:/var/vcap/store -t helioncf/cf-consul:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-consul-output"
         ]
     }
 
@@ -479,7 +495,7 @@ EOF
     # start the api server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-api -v /data/cf-api:/var/vcap/nfs/shared -t ${var.registry_host}/hcf/cf-v${var.cf-release}-api:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-api-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-api -v /data/cf-api:/var/vcap/nfs/shared -t helioncf/cf-api:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-api-output"
         ]        
     }
 
@@ -490,7 +506,7 @@ EOF
     # start the nats server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-nats -t ${var.registry_host}/hcf/cf-v${var.cf-release}-nats:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-nats-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-nats -t helioncf/cf-nats:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-nats-output"
         ]
     }
 
@@ -507,7 +523,7 @@ EOF
 
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-etcd -v /data/cf-etcd:/var/vcap/store -t ${var.registry_host}/hcf/cf-v${var.cf-release}-etcd:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-etcd-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-etcd -v /data/cf-etcd:/var/vcap/store -t helioncf/cf-etcd:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-etcd-output"
         ]
     }
 
@@ -524,7 +540,7 @@ EOF
 
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-postgres -v /data/cf-postgres:/var/vcap/store -t ${var.registry_host}/hcf/cf-v${var.cf-release}-postgres:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-postgres-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-postgres -v /data/cf-postgres:/var/vcap/store -t helioncf/cf-postgres:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-postgres-output"
         ]        
     }
 
@@ -535,7 +551,7 @@ EOF
     # start the stats server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-stats -t ${var.registry_host}/hcf/cf-v${var.cf-release}-stats:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-stats-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-stats -t helioncf/cf-stats:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-stats-output"
         ]        
     }
 
@@ -546,7 +562,7 @@ EOF
     # start the router server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-router -t ${var.registry_host}/hcf/cf-v${var.cf-release}-router:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-router-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-router -t helioncf/cf-router:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-router-output"
         ]        
     }
 
@@ -558,7 +574,7 @@ EOF
     provisioner "remote-exec" {
         inline = <<EOF
 set -e
-cid=$(docker run -d --net=bridge -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} -p 80:80 -p 443:443 -p 4443:4443 --name cf-ha_proxy -t ${var.registry_host}/hcf/cf-v${var.cf-release}-ha_proxy:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-haproxy-output)
+cid=$(docker run -d --net=bridge -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} -p 80:80 -p 443:443 -p 4443:4443 --name cf-ha_proxy -t helioncf/cf-ha_proxy:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-haproxy-output)
 docker network connect hcf $cid
 EOF
     }
@@ -570,7 +586,7 @@ EOF
     # start the uaa server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-uaa -t ${var.registry_host}/hcf/cf-v${var.cf-release}-uaa:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-uaa-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-uaa -t helioncf/cf-uaa:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-uaa-output"
         ]        
     }
 
@@ -581,7 +597,7 @@ EOF
     # start the clock_global server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-clock_global -t ${var.registry_host}/hcf/cf-v${var.cf-release}-clock_global:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-clock_global-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-clock_global -t helioncf/cf-clock_global:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-clock_global-output"
         ]        
     }
 
@@ -592,7 +608,7 @@ EOF
     # start the api_worker server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-api_worker -v /data/cf-api:/var/vcap/nfs/shared -t ${var.registry_host}/hcf/cf-v${var.cf-release}-api_worker:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-api_worker-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-api_worker -v /data/cf-api:/var/vcap/nfs/shared -t helioncf/cf-api_worker:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-api_worker-output"
         ]        
     }
 
@@ -603,7 +619,7 @@ EOF
     # start the hm9000 server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-hm9000 -t ${var.registry_host}/hcf/cf-v${var.cf-release}-hm9000:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-hm9000-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-hm9000 -t helioncf/cf-hm9000:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-hm9000-output"
         ]        
     }
 
@@ -614,7 +630,7 @@ EOF
     # start the doppler server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-doppler -t ${var.registry_host}/hcf/cf-v${var.cf-release}-doppler:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-doppler-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-doppler -t helioncf/cf-doppler:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-doppler-output"
         ]        
     }
 
@@ -625,7 +641,7 @@ EOF
     # start the loggregator_trafficcontroller server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-loggregator_trafficcontroller -t ${var.registry_host}/hcf/cf-v${var.cf-release}-loggregator_trafficcontroller:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-loggregator_trafficcontroller-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-loggregator_trafficcontroller -t helioncf/cf-loggregator_trafficcontroller:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-loggregator_trafficcontroller-output"
         ]        
     }
 
@@ -727,9 +743,8 @@ echo 'export https_proxy="${var.https_proxy}"' | sudo tee -a /etc/default/docker
 echo 'export no_proxy="${var.no_proxy},${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}"' | sudo tee -a /etc/default/docker
 
 sudo usermod -aG docker ubuntu
-# allow us to pull from the docker registry
-# TODO: this needs to be removed when we publish to Docker Hub
-echo DOCKER_OPTS=\"--cluster-store=etcd://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:3379 --cluster-advertise=${self.network.0.fixed_ip_v4}:2376 --label=com.docker.network.driver.overlay.bind_interface=eth0 --label=com.docker.network.driver.overlay.neighbor_ip=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 --insecure-registry=${var.registry_host} -H=${self.network.0.fixed_ip_v4}:2376 -H=unix:///var/run/docker.sock -s=devicemapper\" | sudo tee -a /etc/default/docker
+
+echo DOCKER_OPTS=\"--cluster-store=etcd://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:3379 --cluster-advertise=${self.network.0.fixed_ip_v4}:2376 --label=com.docker.network.driver.overlay.bind_interface=eth0 --label=com.docker.network.driver.overlay.neighbor_ip=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 -H=${self.network.0.fixed_ip_v4}:2376 -H=unix:///var/run/docker.sock -s=devicemapper\" | sudo tee -a /etc/default/docker
 
 # enable cgroup memory and swap accounting
 sudo sed -idockerbak 's/GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX=\"cgroup_enable=memory swapaccount=1\"/' /etc/default/grub
@@ -740,25 +755,43 @@ sudo reboot && sleep 10
 EOF
     }
 
+    # 
+    # sign in to docker hub if username / password is provided
+    #
+    provisioner "remote-exec" {
+        inline = <<EOF
+set -e
+
+DOCKER_USERNAME=${var.docker_username}
+
+if [ "$DOCKER_USERNAME" != "" ] ; then
+    echo "Logging in to Docker Hub for image pulls"
+
+    docker login "-e=${var.docker_email}" "-u=${var.docker_username}" "-p=${var.docker_password}"
+fi
+
+EOF
+    }
+
     #
     # gato
     #
     provisioner "remote-exec" {
-        inline = ["docker pull ${var.registry_host}/hcf/hcf-gato:${var.build} | tee /tmp/hcf-gato-output"]
+        inline = ["docker pull helioncf/hcf-gato:${var.build} | tee /tmp/hcf-gato-output"]
     }
     
     #
     # acceptance test image
     #
     provisioner "remote-exec" {
-        inline = ["docker pull ${var.registry_host}/hcf/cf-v217-acceptance_tests:${var.build} | tee /tmp/hcf-acceptance_tests-output"]
+        inline = ["docker pull helioncf/cf-acceptance_tests:${var.build} | tee /tmp/hcf-acceptance_tests-output"]
     }
 
     #
     # smoke test image
     #
     provisioner "remote-exec" {
-        inline = ["docker pull ${var.registry_host}/hcf/cf-v217-smoke_tests:${var.build} | tee /tmp/hcf-smoke_tests-output"]
+        inline = ["docker pull helioncf/cf-smoke_tests:${var.build} | tee /tmp/hcf-smoke_tests-output"]
     }
 
     #
@@ -768,7 +801,7 @@ EOF
     # start the runner server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cap-add=ALL -v /lib/modules:/lib/modules --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-runner-${count.index} -t ${var.registry_host}/hcf/cf-v${var.cf-release}-runner:${var.build} http://hcf-consul-server.hcf:8501 hcf ${count.index} | tee /tmp/cf-runner-${count.index}-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cap-add=ALL -v /lib/modules:/lib/modules --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-runner-${count.index} -t helioncf/cf-runner:${var.build} http://hcf-consul-server.hcf:8501 hcf ${count.index} | tee /tmp/cf-runner-${count.index}-output"
         ]        
     }
 }

--- a/terraform-scripts/hcf-proxied/variables.tf
+++ b/terraform-scripts/hcf-proxied/variables.tf
@@ -1,7 +1,3 @@
-variable "registry_host" {
-	default = "15.126.242.125:5000"
-}
-
 variable "cluster-prefix" {
 	description = "Prefix prepended to all cluster resources (volumes, hostnames, security groups)"
 	default = "hcf"
@@ -210,4 +206,19 @@ variable "overlay_gateway" {
 
 variable "docker_version" {
 	default = "1.9.1-0~trusty"
+}
+
+variable "docker_username" {
+	description = "Docker Hub username (optional)"
+	default = ""
+}
+
+variable "docker_password" {
+	description = "Docker Hub password (optional)"
+	default = ""	
+}
+
+variable "docker_email" {
+	description = "Docker Hub email address (optional)"
+	default = ""		
 }

--- a/terraform-scripts/hcf/hcf-test.tf.disabled
+++ b/terraform-scripts/hcf/hcf-test.tf.disabled
@@ -53,9 +53,7 @@ sudo apt-get update
 sudo apt-get purge -y lxc-docker*
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-engine=1.8.3-0~trusty
 sudo usermod -aG docker ubuntu
-# allow us to pull from the docker registry
-# TODO: this needs to be removed when we publish to Docker Hub
-echo DOCKER_OPTS=\"--insecure-registry ${var.registry_host} -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock -s devicemapper -g /data/docker\" | sudo tee -a /etc/default/docker
+echo DOCKER_OPTS=\"-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock -s devicemapper -g /data/docker\" | sudo tee -a /etc/default/docker
 
 # enable cgroup memory and swap accounting
 sudo sed -idockerbak 's/GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX=\"cgroup_enable=memory swapaccount=1\"/' /etc/default/grub
@@ -101,7 +99,7 @@ EOF
     # start the smoke tests
     provisioner "remote-exec" {
         inline = [
-        "docker run --cgroup-parent=instance --dns=127.0.0.1 --dns=${var.dns_server} --name cf-smoke_tests -t ${var.registry_host}/hcf/cf-v${var.cf-release}-smoke_tests:latest http://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:8501 hcf 99"
+        "docker run --cgroup-parent=instance --dns=127.0.0.1 --dns=${var.dns_server} --name cf-smoke_tests -t helioncf/cf-smoke_tests:latest http://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:8501 hcf 99"
         ]        
     }
 
@@ -112,7 +110,7 @@ EOF
     # start the acceptance tests
     provisioner "remote-exec" {
         inline = [
-        "docker run --cgroup-parent=instance --dns=127.0.0.1 --dns=${var.dns_server} --name cf-acceptance_tests -t ${var.registry_host}/hcf/cf-v${var.cf-release}-acceptance_tests:latest http://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:8501 hcf 98"
+        "docker run --cgroup-parent=instance --dns=127.0.0.1 --dns=${var.dns_server} --name cf-acceptance_tests -t helioncf/cf-acceptance_tests:latest http://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:8501 hcf 98"
         ]        
     }
 

--- a/terraform-scripts/hcf/hcf.tf
+++ b/terraform-scripts/hcf/hcf.tf
@@ -16,7 +16,6 @@ resource "template_file" "gato_wrapper" {
     filename = "${path.module}/templates/gato-wrapper.tpl"
 
     vars {
-        registry_host = "${var.registry_host}"
         build = "${var.build}"
     }
 }
@@ -234,10 +233,8 @@ sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-engine=${var.docker_version}
 
 sudo usermod -aG docker ubuntu
-# allow us to pull from the docker registry
-# TODO: this needs to be removed when we publish to Docker Hub
 
-echo DOCKER_OPTS=\"--cluster-store=etcd://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:3379 --cluster-advertise=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 --label=com.docker.network.driver.overlay.bind_interface=eth0 --insecure-registry=${var.registry_host} -H=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 -H=unix:///var/run/docker.sock -s=devicemapper -g=/data/docker \" | sudo tee -a /etc/default/docker
+echo DOCKER_OPTS=\"--cluster-store=etcd://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:3379 --cluster-advertise=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 --label=com.docker.network.driver.overlay.bind_interface=eth0 -H=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 -H=unix:///var/run/docker.sock -s=devicemapper -g=/data/docker \" | sudo tee -a /etc/default/docker
 
 # enable cgroup memory and swap accounting
 sudo sed -idockerbak 's/GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX=\"cgroup_enable=memory swapaccount=1\"/' /etc/default/grub
@@ -250,11 +247,29 @@ sudo reboot && sleep 10
 EOF
     }
 
+    # 
+    # sign in to docker hub if username / password is provided
+    #
+    provisioner "remote-exec" {
+        inline = <<EOF
+set -e
+
+DOCKER_USERNAME=${var.docker_username}
+
+if [ "$DOCKER_USERNAME" != "" ] ; then
+    echo "Logging in to Docker Hub for image pulls"
+
+    docker login "-e=${var.docker_email}" "-u=${var.docker_username}" "-p=${var.docker_password}"
+fi
+
+EOF
+    }
+
     #
     # gato
     #
     provisioner "remote-exec" {
-        inline = ["docker pull ${var.registry_host}/hcf/hcf-gato:${var.build} | tee /tmp/hcf-gato-output"]
+        inline = ["docker pull helioncf/hcf-gato:${var.build} | tee /tmp/hcf-gato-output"]
     }
 
     #
@@ -291,7 +306,7 @@ EOF
         inline = <<EOF
 set -e
 sudo mv /tmp/consul.json /opt/hcf/etc/consul.json
-cid=$(docker run -d --net=bridge --privileged=true --restart=unless-stopped -p 8401:8401 -p 8501:8501 -p 8601:8601 -p 8310:8310 -p 8311:8311 -p 8312:8312 --name hcf-consul-server -v /opt/hcf/bin:/opt/hcf/bin -v /opt/hcf/etc:/opt/hcf/etc -v /data/hcf-consul:/opt/hcf/share/consul -t ${var.registry_host}/hcf/consul-server:${var.build} -bootstrap -client=0.0.0.0 --config-file /opt/hcf/etc/consul.json | tee /tmp/hcf-consul-server-output)
+cid=$(docker run -d --net=bridge --privileged=true --restart=unless-stopped -p 8401:8401 -p 8501:8501 -p 8601:8601 -p 8310:8310 -p 8311:8311 -p 8312:8312 --name hcf-consul-server -v /opt/hcf/bin:/opt/hcf/bin -v /opt/hcf/etc:/opt/hcf/etc -v /data/hcf-consul:/opt/hcf/share/consul -t helioncf/hcf-consul-server:${var.build} -bootstrap -client=0.0.0.0 --config-file /opt/hcf/etc/consul.json | tee /tmp/hcf-consul-server-output)
 docker network connect hcf $cid
 EOF
     }
@@ -458,7 +473,7 @@ EOF
 
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-consul -v /data/cf-consul:/var/vcap/store -t ${var.registry_host}/hcf/cf-v${var.cf-release}-consul:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-consul-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-consul -v /data/cf-consul:/var/vcap/store -t helioncf/cf-consul:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-consul-output"
         ]
     }
 
@@ -469,7 +484,7 @@ EOF
     # start the api server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-api -v /data/cf-api:/var/vcap/nfs/shared -t ${var.registry_host}/hcf/cf-v${var.cf-release}-api:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-api-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-api -v /data/cf-api:/var/vcap/nfs/shared -t helioncf/cf-api:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-api-output"
         ]        
     }
 
@@ -480,7 +495,7 @@ EOF
     # start the nats server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-nats -t ${var.registry_host}/hcf/cf-v${var.cf-release}-nats:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-nats-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-nats -t helioncf/cf-nats:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-nats-output"
         ]
     }
 
@@ -497,7 +512,7 @@ EOF
 
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-etcd -v /data/cf-etcd:/var/vcap/store -t ${var.registry_host}/hcf/cf-v${var.cf-release}-etcd:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-etcd-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-etcd -v /data/cf-etcd:/var/vcap/store -t helioncf/cf-etcd:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-etcd-output"
         ]
     }
 
@@ -514,7 +529,7 @@ EOF
 
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-postgres -v /data/cf-postgres:/var/vcap/store -t ${var.registry_host}/hcf/cf-v${var.cf-release}-postgres:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-postgres-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-postgres -v /data/cf-postgres:/var/vcap/store -t helioncf/cf-postgres:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-postgres-output"
         ]        
     }
 
@@ -525,7 +540,7 @@ EOF
     # start the stats server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-stats -t ${var.registry_host}/hcf/cf-v${var.cf-release}-stats:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-stats-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-stats -t helioncf/cf-stats:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-stats-output"
         ]        
     }
 
@@ -536,7 +551,7 @@ EOF
     # start the router server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-router -t ${var.registry_host}/hcf/cf-v${var.cf-release}-router:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-router-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-router -t helioncf/cf-router:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-router-output"
         ]        
     }
 
@@ -548,7 +563,7 @@ EOF
     provisioner "remote-exec" {
         inline = <<EOF
 set -e
-cid=$(docker run -d --net=bridge -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} -p 80:80 -p 443:443 -p 4443:4443 --name cf-ha_proxy -t ${var.registry_host}/hcf/cf-v${var.cf-release}-ha_proxy:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-haproxy-output)
+cid=$(docker run -d --net=bridge -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} -p 80:80 -p 443:443 -p 4443:4443 --name cf-ha_proxy -t helioncf/cf-ha_proxy:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-haproxy-output)
 docker network connect hcf $cid
 EOF
     }
@@ -560,7 +575,7 @@ EOF
     # start the uaa server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-uaa -t ${var.registry_host}/hcf/cf-v${var.cf-release}-uaa:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-uaa-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-uaa -t helioncf/cf-uaa:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-uaa-output"
         ]        
     }
 
@@ -571,7 +586,7 @@ EOF
     # start the clock_global server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-clock_global -t ${var.registry_host}/hcf/cf-v${var.cf-release}-clock_global:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-clock_global-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-clock_global -t helioncf/cf-clock_global:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-clock_global-output"
         ]        
     }
 
@@ -582,7 +597,7 @@ EOF
     # start the api_worker server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-api_worker -v /data/cf-api:/var/vcap/nfs/shared -t ${var.registry_host}/hcf/cf-v${var.cf-release}-api_worker:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-api_worker-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-api_worker -v /data/cf-api:/var/vcap/nfs/shared -t helioncf/cf-api_worker:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-api_worker-output"
         ]        
     }
 
@@ -593,7 +608,7 @@ EOF
     # start the hm9000 server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-hm9000 -t ${var.registry_host}/hcf/cf-v${var.cf-release}-hm9000:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-hm9000-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-hm9000 -t helioncf/cf-hm9000:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-hm9000-output"
         ]        
     }
 
@@ -604,7 +619,7 @@ EOF
     # start the doppler server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-doppler -t ${var.registry_host}/hcf/cf-v${var.cf-release}-doppler:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-doppler-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-doppler -t helioncf/cf-doppler:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-doppler-output"
         ]        
     }
 
@@ -615,7 +630,7 @@ EOF
     # start the loggregator_trafficcontroller server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-loggregator_trafficcontroller -t ${var.registry_host}/hcf/cf-v${var.cf-release}-loggregator_trafficcontroller:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-loggregator_trafficcontroller-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-loggregator_trafficcontroller -t helioncf/cf-loggregator_trafficcontroller:${var.build} http://hcf-consul-server.hcf:8501 hcf 0 | tee /tmp/cf-loggregator_trafficcontroller-output"
         ]        
     }
 }
@@ -690,9 +705,8 @@ sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-engine=${var.docker_version}
 
 sudo usermod -aG docker ubuntu
-# allow us to pull from the docker registry
-# TODO: this needs to be removed when we publish to Docker Hub
-echo DOCKER_OPTS=\"--cluster-store=etcd://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:3379 --cluster-advertise=${self.network.0.fixed_ip_v4}:2376 --label=com.docker.network.driver.overlay.bind_interface=eth0 --label=com.docker.network.driver.overlay.neighbor_ip=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 --insecure-registry=${var.registry_host} -H=${self.network.0.fixed_ip_v4}:2376 -H=unix:///var/run/docker.sock -s=devicemapper\" | sudo tee -a /etc/default/docker
+
+echo DOCKER_OPTS=\"--cluster-store=etcd://${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:3379 --cluster-advertise=${self.network.0.fixed_ip_v4}:2376 --label=com.docker.network.driver.overlay.bind_interface=eth0 --label=com.docker.network.driver.overlay.neighbor_ip=${openstack_compute_instance_v2.hcf-core-host.network.0.fixed_ip_v4}:2376 -H=${self.network.0.fixed_ip_v4}:2376 -H=unix:///var/run/docker.sock -s=devicemapper\" | sudo tee -a /etc/default/docker
 
 # enable cgroup memory and swap accounting
 sudo sed -idockerbak 's/GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX=\"cgroup_enable=memory swapaccount=1\"/' /etc/default/grub
@@ -703,25 +717,43 @@ sudo reboot && sleep 10
 EOF
     }
 
+    # 
+    # sign in to docker hub if username / password is provided
+    #
+    provisioner "remote-exec" {
+        inline = <<EOF
+set -e
+
+DOCKER_USERNAME=${var.docker_username}
+
+if [ "$DOCKER_USERNAME" != "" ] ; then
+    echo "Logging in to Docker Hub for image pulls"
+
+    docker login "-e=${var.docker_email}" "-u=${var.docker_username}" "-p=${var.docker_password}"
+fi
+
+EOF
+    }
+
     #
     # gato
     #
     provisioner "remote-exec" {
-        inline = ["docker pull ${var.registry_host}/hcf/hcf-gato:${var.build} | tee /tmp/hcf-gato-output"]
+        inline = ["docker pull helioncf/hcf-gato:${var.build} | tee /tmp/hcf-gato-output"]
     }
     
     #
     # acceptance test image
     #
     provisioner "remote-exec" {
-        inline = ["docker pull ${var.registry_host}/hcf/cf-v217-acceptance_tests:${var.build} | tee /tmp/hcf-acceptance_tests-output"]
+        inline = ["docker pull helioncf/cf-acceptance_tests:${var.build} | tee /tmp/hcf-acceptance_tests-output"]
     }
 
     #
     # smoke test image
     #
     provisioner "remote-exec" {
-        inline = ["docker pull ${var.registry_host}/hcf/cf-v217-smoke_tests:${var.build} | tee /tmp/hcf-smoke_tests-output"]
+        inline = ["docker pull helioncf/cf-smoke_tests:${var.build} | tee /tmp/hcf-smoke_tests-output"]
     }
 
     #
@@ -731,7 +763,7 @@ EOF
     # start the runner server
     provisioner "remote-exec" {
         inline = [
-        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cap-add=ALL -v /lib/modules:/lib/modules --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-runner-${count.index} -t ${var.registry_host}/hcf/cf-v${var.cf-release}-runner:${var.build} http://hcf-consul-server.hcf:8501 hcf ${count.index} | tee /tmp/cf-runner-${count.index}-output"
+        "docker run -d --net=hcf -e 'HCF_NETWORK=overlay' -e 'HCF_OVERLAY_GATEWAY=${var.overlay_gateway}' --privileged=true --cap-add=ALL -v /lib/modules:/lib/modules --cgroup-parent=instance --restart=unless-stopped --dns=127.0.0.1 --dns=${var.dns_server} --name cf-runner-${count.index} -t helioncf/cf-runner:${var.build} http://hcf-consul-server.hcf:8501 hcf ${count.index} | tee /tmp/cf-runner-${count.index}-output"
         ]        
     }
 }

--- a/terraform-scripts/hcf/templates/gato-wrapper.tpl
+++ b/terraform-scripts/hcf/templates/gato-wrapper.tpl
@@ -4,7 +4,7 @@ gato_status=`docker inspect -f "{{.State.Running}}" hcf-gato 2> /dev/null`
 
 if [[ "$?" == "1" || $gato_status == 'false' ]] ; then
   docker rm --force hcf-gato 2> /dev/null 1> /dev/null
-  docker run --interactive --name hcf-gato --entrypoint="bash" --net=hcf -d -v /opt/hcf/etc/gato:/root/.gato ${registry_host}/hcf/hcf-gato:${build} -i > /dev/null
+  docker run --interactive --name hcf-gato --entrypoint="bash" --net=hcf -d -v /opt/hcf/etc/gato:/root/.gato helioncf/hcf-gato:${build} -i > /dev/null
 fi
 
 case `tty` in

--- a/terraform-scripts/hcf/variables.tf
+++ b/terraform-scripts/hcf/variables.tf
@@ -1,7 +1,3 @@
-variable "registry_host" {
-	default = "15.126.242.125:5000"
-}
-
 variable "cluster-prefix" {
 	description = "Prefix prepended to all cluster resources (volumes, hostnames, security groups)"
 	default = "hcf"
@@ -210,4 +206,19 @@ variable "overlay_gateway" {
 
 variable "docker_version" {
 	default = "1.9.1-0~trusty"
+}
+
+variable "docker_username" {
+	description = "Docker Hub username (optional)"
+	default = ""
+}
+
+variable "docker_password" {
+	description = "Docker Hub password (optional)"
+	default = ""	
+}
+
+variable "docker_email" {
+	description = "Docker Hub email address (optional)"
+	default = ""		
 }


### PR DESCRIPTION
Push images to Docker Hub instead of our private registry.

This requires you to login to docker hub outside of the Makefile
intentionally, as a means to avoid checking in Docker Hub credentials.
