### PR TITLE
HCF-393 Clean up varibles.tf to remove things that break the cluster.

### DIFF
--- a/terraform-scripts/hcf-proxied/hcf.tf
+++ b/terraform-scripts/hcf-proxied/hcf.tf
@@ -375,8 +375,7 @@ export CONSUL=http://`/opt/hcf/bin/get_ip`:8501
 
 /opt/hcf/bin/set-config $CONSUL hcf/user/etcd_metrics_server/nats/machines '["nats.service.cf.internal"]'
 /opt/hcf/bin/set-config $CONSUL hcf/user/etcd_metrics_server/nats/username \"${var.nats_user}\"
-/opt/hcf/bin/set-config $CONSUL hcf/user/etcd_metrics_server/password \"${var.nats_password}\"
-/opt/hcf/bin/set-config $CONSUL hcf/user/etcd_metrics_server/machines '["nats.service.cf.internal"]'
+/opt/hcf/bin/set-config $CONSUL hcf/user/etcd_metrics_server/nats/password \"${var.nats_password}\"
 
 openssl genrsa -out ~/.ssh/jwt_signing.pem -passout pass:"${var.signing_key_passphrase}" 4096
 openssl rsa -in ~/.ssh/jwt_signing.pem -outform PEM -passin pass:"${var.signing_key_passphrase}" -pubout -out ~/.ssh/jwt_signing.pub
@@ -402,7 +401,7 @@ openssl rsa -in ~/.ssh/jwt_signing.pem -outform PEM -passin pass:"${var.signing_
 /opt/hcf/bin/set-config $CONSUL hcf/user/uaa/clients/gorouter/secret \"${var.uaa_clients_gorouter_secret}\"
 /opt/hcf/bin/set-config $CONSUL hcf/user/uaa/scim/users '["${var.cluster_admin_username}|${var.cluster_admin_password}|${var.cluster_admin_authorities}"]'
 
-/opt/hcf/bin/set-config $CONSUL hcf/user/uaadb/roles '[{"name": "${var.uaadb_username}", "password": "${var.uaadb_password}", "tag": "${var.uaadb_tag}"}]'
+/opt/hcf/bin/set-config $CONSUL hcf/user/uaadb/roles '[{"name": "${var.uaadb_username}", "password": "${var.uaadb_password}", "tag": "admin"}]'
 /opt/hcf/bin/set-config $CONSUL hcf/user/domain \"${template_file.domain.rendered}\"
 
 /opt/hcf/bin/set-config $CONSUL hcf/user/doppler/zone \"${var.doppler_zone}\"
@@ -424,7 +423,7 @@ rm $TEMP_CERT
 /opt/hcf/bin/set-config $CONSUL hcf/user/loggregator_endpoint/shared_secret \"${var.loggregator_shared_secret}\"
 /opt/hcf/bin/set-config $CONSUL hcf/user/doppler_endpoint/shared_secret \"${var.loggregator_shared_secret}\"
 
-/opt/hcf/bin/set-config $CONSUL hcf/user/ccdb/roles '[{"name": "${var.ccdb_role_name}", "password": "${var.ccdb_role_password}", "tag": "${var.ccdb_role_tag}"}]'
+/opt/hcf/bin/set-config $CONSUL hcf/user/ccdb/roles '[{"name": "${var.ccdb_role_name}", "password": "${var.ccdb_role_password}", "tag": "admin"}]'
 
 # TODO: replace this with Swift settings
 # /opt/hcf/bin/set-config $CONSUL hcf/user/cc/resource_pool/fog_connection '{}'
@@ -452,7 +451,7 @@ rm $TEMP_CERT
 /opt/hcf/bin/set-config $CONSUL hcf/user/databases/address \"postgres.service.cf.internal\"
 /opt/hcf/bin/set-config $CONSUL hcf/user/databases/databases '[{"citext":true, "name":"ccdb", "tag":"cc"}, {"citext":true, "name":"uaadb", "tag":"uaa"}]'
 /opt/hcf/bin/set-config $CONSUL hcf/user/databases/port '5524'
-/opt/hcf/bin/set-config $CONSUL hcf/user/databases/roles '[{"name": "${var.ccdb_role_name}", "password": "${var.ccdb_role_password}","tag": "${var.ccdb_role_tag}"}, {"name": "${var.uaadb_username}", "password": "${var.uaadb_password}", "tag":"${var.uaadb_tag}"}]'
+/opt/hcf/bin/set-config $CONSUL hcf/user/databases/roles '[{"name": "${var.ccdb_role_name}", "password": "${var.ccdb_role_password}","tag": "admin"}, {"name": "${var.uaadb_username}", "password": "${var.uaadb_password}", "tag":"admin"}]'
 
 /opt/hcf/bin/set-config $CONSUL hcf/user/cc/staging_upload_user \"${var.staging_upload_user}\"
 /opt/hcf/bin/set-config $CONSUL hcf/user/cc/staging_upload_password \"${var.staging_upload_password}\"

--- a/terraform-scripts/hcf-proxied/variables.tf
+++ b/terraform-scripts/hcf-proxied/variables.tf
@@ -3,12 +3,6 @@ variable "cluster-prefix" {
 	default = "hcf"
 }
 
-variable "container-host-count" {
-	default = "1"
-	# default really should be 3
-	description = "Number of container hosts to create"
-}
-
 variable "key_file" {
 	description = "Private key file for newly created hosts"
 }
@@ -89,18 +83,12 @@ variable "ccdb_role_name" {
 variable "ccdb_role_password" {
 	default = "admin_password"
 }
-variable "ccdb_role_tag" {
-	default = "admin"
-}
 
 variable "uaadb_username" {
 	default = "uaaadmin"
 }
 variable "uaadb_password" {
 	default = "uaaadmin_password"
-}
-variable "uaadb_tag" {
-	default = "admin"
 }
 
 variable "domain" {

--- a/terraform-scripts/hcf/hcf.tf
+++ b/terraform-scripts/hcf/hcf.tf
@@ -349,8 +349,7 @@ export CONSUL=http://`/opt/hcf/bin/get_ip`:8501
 
 /opt/hcf/bin/set-config $CONSUL hcf/user/etcd_metrics_server/nats/machines '["nats.service.cf.internal"]'
 /opt/hcf/bin/set-config $CONSUL hcf/user/etcd_metrics_server/nats/username \"${var.nats_user}\"
-/opt/hcf/bin/set-config $CONSUL hcf/user/etcd_metrics_server/password \"${var.nats_password}\"
-/opt/hcf/bin/set-config $CONSUL hcf/user/etcd_metrics_server/machines '["nats.service.cf.internal"]'
+/opt/hcf/bin/set-config $CONSUL hcf/user/etcd_metrics_server/nats/password \"${var.nats_password}\"
 
 openssl genrsa -out ~/.ssh/jwt_signing.pem -passout pass:"${var.signing_key_passphrase}" 4096
 openssl rsa -in ~/.ssh/jwt_signing.pem -outform PEM -passin pass:"${var.signing_key_passphrase}" -pubout -out ~/.ssh/jwt_signing.pub
@@ -376,7 +375,7 @@ openssl rsa -in ~/.ssh/jwt_signing.pem -outform PEM -passin pass:"${var.signing_
 /opt/hcf/bin/set-config $CONSUL hcf/user/uaa/clients/gorouter/secret \"${var.uaa_clients_gorouter_secret}\"
 /opt/hcf/bin/set-config $CONSUL hcf/user/uaa/scim/users '["${var.cluster_admin_username}|${var.cluster_admin_password}|${var.cluster_admin_authorities}"]'
 
-/opt/hcf/bin/set-config $CONSUL hcf/user/uaadb/roles '[{"name": "${var.uaadb_username}", "password": "${var.uaadb_password}", "tag": "${var.uaadb_tag}"}]'
+/opt/hcf/bin/set-config $CONSUL hcf/user/uaadb/roles '[{"name": "${var.uaadb_username}", "password": "${var.uaadb_password}", "tag": "admin"}]'
 /opt/hcf/bin/set-config $CONSUL hcf/user/domain \"${template_file.domain.rendered}\"
 
 /opt/hcf/bin/set-config $CONSUL hcf/user/doppler/zone \"${var.doppler_zone}\"
@@ -398,7 +397,7 @@ rm $TEMP_CERT
 /opt/hcf/bin/set-config $CONSUL hcf/user/loggregator_endpoint/shared_secret \"${var.loggregator_shared_secret}\"
 /opt/hcf/bin/set-config $CONSUL hcf/user/doppler_endpoint/shared_secret \"${var.loggregator_shared_secret}\"
 
-/opt/hcf/bin/set-config $CONSUL hcf/user/ccdb/roles '[{"name": "${var.ccdb_role_name}", "password": "${var.ccdb_role_password}", "tag": "${var.ccdb_role_tag}"}]'
+/opt/hcf/bin/set-config $CONSUL hcf/user/ccdb/roles '[{"name": "${var.ccdb_role_name}", "password": "${var.ccdb_role_password}", "tag": "admin"}]'
 
 # TODO: replace this with Swift settings
 # /opt/hcf/bin/set-config $CONSUL hcf/user/cc/resource_pool/fog_connection '{}'
@@ -426,7 +425,7 @@ rm $TEMP_CERT
 /opt/hcf/bin/set-config $CONSUL hcf/user/databases/address \"postgres.service.cf.internal\"
 /opt/hcf/bin/set-config $CONSUL hcf/user/databases/databases '[{"citext":true, "name":"ccdb", "tag":"cc"}, {"citext":true, "name":"uaadb", "tag":"uaa"}]'
 /opt/hcf/bin/set-config $CONSUL hcf/user/databases/port '5524'
-/opt/hcf/bin/set-config $CONSUL hcf/user/databases/roles '[{"name": "${var.ccdb_role_name}", "password": "${var.ccdb_role_password}","tag": "${var.ccdb_role_tag}"}, {"name": "${var.uaadb_username}", "password": "${var.uaadb_password}", "tag":"${var.uaadb_tag}"}]'
+/opt/hcf/bin/set-config $CONSUL hcf/user/databases/roles '[{"name": "${var.ccdb_role_name}", "password": "${var.ccdb_role_password}","tag": "admin"}, {"name": "${var.uaadb_username}", "password": "${var.uaadb_password}", "tag":"admin"}]'
 
 /opt/hcf/bin/set-config $CONSUL hcf/user/cc/staging_upload_user \"${var.staging_upload_user}\"
 /opt/hcf/bin/set-config $CONSUL hcf/user/cc/staging_upload_password \"${var.staging_upload_password}\"

--- a/terraform-scripts/hcf/variables.tf
+++ b/terraform-scripts/hcf/variables.tf
@@ -3,12 +3,6 @@ variable "cluster-prefix" {
 	default = "hcf"
 }
 
-variable "container-host-count" {
-	default = "1"
-	# default really should be 3
-	description = "Number of container hosts to create"
-}
-
 variable "key_file" {
 	description = "Private key file for newly created hosts"
 }
@@ -89,18 +83,12 @@ variable "ccdb_role_name" {
 variable "ccdb_role_password" {
 	default = "admin_password"
 }
-variable "ccdb_role_tag" {
-	default = "admin"
-}
 
 variable "uaadb_username" {
 	default = "uaaadmin"
 }
 variable "uaadb_password" {
 	default = "uaaadmin_password"
-}
-variable "uaadb_tag" {
-	default = "admin"
 }
 
 variable "domain" {


### PR DESCRIPTION
These configs cannot actually be modified.
- `etcd_metrics_server/machines` is unused. (`etcd_metrics_server/nats/machines` is set three lines up.)
- `etcd_metrics_server/password` is missing `nats`.
- `ccdb_role_tag` and `uaadb_tag` must have the value `admin`; they're used in the [ccng erb template](https://github.com/cloudfoundry/cloud_controller_ng/blob/1cf56e361b6f64b1c982d15550ab0d3c068872a8/bosh-templates/cloud_controller_api.yml.erb#L165) and [uaa erb template](https://github.com/cloudfoundry/cf-release/blob/v217/jobs/uaa/templates/uaa.yml.erb#L3), respectively.
- `container-host-count` is unused.  I think it's meant to be what `dea_count` does now.
