### PR TITLE
HCF-400 HCF-Infrastructure version pinning makes gato wrapper fail

### DIFF
--- a/terraform-scripts/hcf-proxied/hcf.tf
+++ b/terraform-scripts/hcf-proxied/hcf.tf
@@ -18,7 +18,7 @@ resource "template_file" "gato_wrapper" {
     template = "${path.module}/templates/gato-wrapper.tpl"
 
     vars {
-        build = "${var.build}"
+        gato-build = "${var.gato-build}"
     }
 }
 

--- a/terraform-scripts/hcf-proxied/templates/gato-wrapper.tpl
+++ b/terraform-scripts/hcf-proxied/templates/gato-wrapper.tpl
@@ -4,7 +4,7 @@ gato_status=`docker inspect -f "{{.State.Running}}" hcf-gato 2> /dev/null`
 
 if [[ "$?" == "1" || $gato_status == 'false' ]] ; then
   docker rm --force hcf-gato 2> /dev/null 1> /dev/null
-  docker run --interactive --name hcf-gato --entrypoint="bash" --net=hcf -d -v /opt/hcf/etc/gato:/root/.gato helioncf/hcf-gato:${build} -i > /dev/null
+  docker run --interactive --name hcf-gato --entrypoint="bash" --net=hcf -d -v /opt/hcf/etc/gato:/root/.gato helioncf/hcf-gato:${gato-build} -i > /dev/null
 fi
 
 case `tty` in

--- a/terraform-scripts/hcf-proxied/version.tf
+++ b/terraform-scripts/hcf-proxied/version.tf
@@ -3,3 +3,7 @@
 variable "build" {
 	default = "latest"
 }
+
+variable "gato-build" {
+	default = "latest"
+}

--- a/terraform-scripts/hcf/hcf.tf
+++ b/terraform-scripts/hcf/hcf.tf
@@ -18,7 +18,7 @@ resource "template_file" "gato_wrapper" {
     template = "${path.module}/templates/gato-wrapper.tpl"
 
     vars {
-        build = "${var.build}"
+        gato-build = "${var.gato-build}"
     }
 }
 

--- a/terraform-scripts/hcf/templates/gato-wrapper.tpl
+++ b/terraform-scripts/hcf/templates/gato-wrapper.tpl
@@ -5,7 +5,7 @@ gato_status=`docker inspect -f "{{.State.Running}}" hcf-gato 2> /dev/null`
 
 if [[ "$?" == "1" || $gato_status == 'false' ]] ; then
   docker rm --force hcf-gato 2> /dev/null 1> /dev/null
-  docker run --interactive --name hcf-gato --entrypoint="bash" --net=hcf -d -v /opt/hcf/etc/gato:/root/.gato helioncf/hcf-gato:${build} -i > /dev/null
+  docker run --interactive --name hcf-gato --entrypoint="bash" --net=hcf -d -v /opt/hcf/etc/gato:/root/.gato helioncf/hcf-gato:${gato-build} -i > /dev/null
 fi
 
 case `tty` in

--- a/terraform-scripts/hcf/version.tf
+++ b/terraform-scripts/hcf/version.tf
@@ -3,3 +3,7 @@
 variable "build" {
 	default = "latest"
 }
+
+variable "gato-build" {
+	default = "latest"
+}


### PR DESCRIPTION
Fetch the gato version, nearly identical to how we fetch the configgin
and fissile builds. This will fetch it from docker, and retrieve the
version from the call. This has one drawback, it's slightly fragile, but
in a way that does not impact the customer, since that version check is
at build time.

This will create a separate variable, gato-build, which contains the
gato build number.
