### PR TITLE
HCF-404: Pin version for cf-{acceptance,smoke}-tests to build version

### DIFF
--- a/terraform-scripts/hcf-proxied/hcf.tf
+++ b/terraform-scripts/hcf-proxied/hcf.tf
@@ -22,6 +22,22 @@ resource "template_file" "gato_wrapper" {
     }
 }
 
+resource "template_file" "run-acceptance-tests" {
+    template = "${path.module}/templates/run-acceptance-tests.bash.tpl"
+
+    vars {
+        build = "${var.build}"
+    }
+}
+
+resource "template_file" "run-smoke-tests" {
+    template = "${path.module}/templates/run-smoke-tests.bash.tpl"
+
+    vars {
+        build = "${var.build}"
+    }
+}
+
 resource "openstack_compute_secgroup_v2" "hcf-container-host-secgroup" {
     name = "${var.cluster-prefix}-container-host"
     description = "HCF Container Hosts"
@@ -139,6 +155,22 @@ EOF
         inline = [
             "cat > /opt/hcf/bin/gato <<'EOF'",
             "${template_file.gato_wrapper.rendered}",
+            "EOF"
+        ]
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+            "cat > /opt/hcf/bin/run-acceptance-tests.bash <<'EOF'",
+            "${template_file.run-acceptance-tests.rendered}",
+            "EOF"
+        ]
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+            "cat > /opt/hcf/bin/run-smoke-tests.bash <<'EOF'",
+            "${template_file.run-smoke-tests.rendered}",
             "EOF"
         ]
     }

--- a/terraform-scripts/hcf-proxied/templates/run-acceptance-tests.bash.tpl
+++ b/terraform-scripts/hcf-proxied/templates/run-acceptance-tests.bash.tpl
@@ -3,8 +3,10 @@
 
 set -e 
 
-IMAGE=helioncf/cf-acceptance_tests
-CONSUL=http://127.0.0.1:8501
+# Default to using the same image tag as cf-api
+IMAGE_TAG="$${IMAGE_TAG:-${build}}"
+IMAGE=helioncf/cf-acceptance_tests:$${IMAGE_TAG}
+CONSUL="$${CONSUL:-http://127.0.0.1:8501}"
 
 confset () {
   /opt/hcf/bin/set-config $CONSUL $@ 2>/dev/null 1> /dev/null
@@ -33,13 +35,13 @@ API=$(confget hcf/user/cc/srv_api_uri)
 CLIENT_SECRET=$(confget hcf/user/uaa/clients/gorouter/secret)
 SKIP_SSL_VALIDATION=$(confget hcf/user/ssl/skip_cert_verify)
 
-confset hcf/user/acceptance_tests/api "${API}"
-confset hcf/user/acceptance_tests/admin_user "${ADMIN_USER}"
-confset hcf/user/acceptance_tests/admin_password "${ADMIN_PASSWORD}"
-confset hcf/user/acceptance_tests/apps_domain "${APPS_DOMAIN}"	
-confset hcf/user/acceptance_tests/skip_ssl_validation "${SKIP_SSL_VALIDATION}"
-confset hcf/user/acceptance_tests/system_domain "${SYSTEM_DOMAIN}"
-confset hcf/user/acceptance_tests/client_secret "${CLIENT_SECRET}"
+confset hcf/user/acceptance_tests/api "$${API}"
+confset hcf/user/acceptance_tests/admin_user "$${ADMIN_USER}"
+confset hcf/user/acceptance_tests/admin_password "$${ADMIN_PASSWORD}"
+confset hcf/user/acceptance_tests/apps_domain "$${APPS_DOMAIN}"
+confset hcf/user/acceptance_tests/skip_ssl_validation "$${SKIP_SSL_VALIDATION}"
+confset hcf/user/acceptance_tests/system_domain "$${SYSTEM_DOMAIN}"
+confset hcf/user/acceptance_tests/client_secret "$${CLIENT_SECRET}"
 
 confset hcf/user/acceptance_tests/include_sso "true"
 confset hcf/user/acceptance_tests/include_operator "false"

--- a/terraform-scripts/hcf-proxied/templates/run-smoke-tests.bash.tpl
+++ b/terraform-scripts/hcf-proxied/templates/run-smoke-tests.bash.tpl
@@ -3,8 +3,10 @@
 
 set -e 
 
-IMAGE=helioncf/cf-smoke_tests
-CONSUL=http://127.0.0.1:8501
+# Default to using the same image tag as cf-api
+IMAGE_TAG="$${IMAGE_TAG:-${build}}"
+IMAGE=helioncf/cf-smoke_tests:$${IMAGE_TAG}
+CONSUL="$${CONSUL:-http://127.0.0.1:8501}"
 
 confset () {
   /opt/hcf/bin/set-config $CONSUL $@ 2>/dev/null 1> /dev/null
@@ -35,13 +37,13 @@ SKIP_SSL_VALIDATION=$(confget hcf/user/ssl/skip_cert_verify)
 ORG=CF-SMOKE-ORG
 SPACE=CF-SMOKE-SPACE
 
-confset hcf/user/smoke_tests/api "${API}"
-confset hcf/user/smoke_tests/user "${ADMIN_USER}"
-confset hcf/user/smoke_tests/password "${ADMIN_PASSWORD}"
-confset hcf/user/smoke_tests/apps_domain "${APPS_DOMAIN}"
-confset hcf/user/smoke_tests/org "${ORG}"
-confset hcf/user/smoke_tests/space "${SPACE}"
-confset hcf/user/smoke_tests/skip_ssl_validation ${SKIP_SSL_VALIDATION}
+confset hcf/user/smoke_tests/api "$${API}"
+confset hcf/user/smoke_tests/user "$${ADMIN_USER}"
+confset hcf/user/smoke_tests/password "$${ADMIN_PASSWORD}"
+confset hcf/user/smoke_tests/apps_domain "$${APPS_DOMAIN}"
+confset hcf/user/smoke_tests/org "$${ORG}"
+confset hcf/user/smoke_tests/space "$${SPACE}"
+confset hcf/user/smoke_tests/skip_ssl_validation $${SKIP_SSL_VALIDATION}
 
 {
   set -e

--- a/terraform-scripts/hcf/hcf.tf
+++ b/terraform-scripts/hcf/hcf.tf
@@ -22,6 +22,22 @@ resource "template_file" "gato_wrapper" {
     }
 }
 
+resource "template_file" "run-acceptance-tests" {
+    template = "${path.module}/templates/run-acceptance-tests.bash.tpl"
+
+    vars {
+        build = "${var.build}"
+    }
+}
+
+resource "template_file" "run-smoke-tests" {
+    template = "${path.module}/templates/run-smoke-tests.bash.tpl"
+
+    vars {
+        build = "${var.build}"
+    }
+}
+
 resource "openstack_compute_secgroup_v2" "hcf-container-host-secgroup" {
     name = "${var.cluster-prefix}-container-host"
     description = "HCF Container Hosts"
@@ -116,6 +132,22 @@ resource "openstack_compute_instance_v2" "hcf-core-host" {
         inline = [
             "cat > /opt/hcf/bin/gato <<'EOF'",
             "${template_file.gato_wrapper.rendered}",
+            "EOF"
+        ]
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+            "cat > /opt/hcf/bin/run-acceptance-tests.bash <<'EOF'",
+            "${template_file.run-acceptance-tests.rendered}",
+            "EOF"
+        ]
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+            "cat > /opt/hcf/bin/run-smoke-tests.bash <<'EOF'",
+            "${template_file.run-smoke-tests.rendered}",
             "EOF"
         ]
     }

--- a/terraform-scripts/hcf/templates/run-acceptance-tests.bash.tpl
+++ b/terraform-scripts/hcf/templates/run-acceptance-tests.bash.tpl
@@ -1,0 +1,77 @@
+#/bin/bash
+# © Copyright 2015 Hewlett Packard Enterprise Development LP
+
+set -e 
+
+# Default to using the same image tag as cf-api
+IMAGE_TAG="$${IMAGE_TAG:-${build}}"
+IMAGE=helioncf/cf-acceptance_tests:$${IMAGE_TAG}
+CONSUL="$${CONSUL:-http://127.0.0.1:8501}"
+
+confset () {
+  /opt/hcf/bin/set-config $CONSUL $@ 2>/dev/null 1> /dev/null
+}
+
+confdel () {
+  curl -s -X DELETE $CONSUL/v1/kv/$1?recurse > /dev/null
+}
+
+confget () {
+  curl -s $CONSUL/v1/kv/$1?raw
+}
+
+echo -n "HCF admin account username: "
+read ADMIN_USER
+echo -n "HCF admin account password: "
+read -s ADMIN_PASSWORD
+
+echo -e "\n"
+echo "Setting up config values ..."
+
+SYSTEM_DOMAIN=$(confget hcf/user/system_domain)
+APPS_DOMAIN=$(confget hcf/user/app_domains)
+API=$(confget hcf/user/cc/srv_api_uri)
+
+CLIENT_SECRET=$(confget hcf/user/uaa/clients/gorouter/secret)
+SKIP_SSL_VALIDATION=$(confget hcf/user/ssl/skip_cert_verify)
+
+confset hcf/user/acceptance_tests/api "$${API}"
+confset hcf/user/acceptance_tests/admin_user "$${ADMIN_USER}"
+confset hcf/user/acceptance_tests/admin_password "$${ADMIN_PASSWORD}"
+confset hcf/user/acceptance_tests/apps_domain "$${APPS_DOMAIN}"
+confset hcf/user/acceptance_tests/skip_ssl_validation "$${SKIP_SSL_VALIDATION}"
+confset hcf/user/acceptance_tests/system_domain "$${SYSTEM_DOMAIN}"
+confset hcf/user/acceptance_tests/client_secret "$${CLIENT_SECRET}"
+
+confset hcf/user/acceptance_tests/include_sso "true"
+confset hcf/user/acceptance_tests/include_operator "false"
+confset hcf/user/acceptance_tests/include_logging "true"
+confset hcf/user/acceptance_tests/include_security_groups "true"
+confset hcf/user/acceptance_tests/include_internet_dependent "true"
+confset hcf/user/acceptance_tests/include_services "true"
+confset hcf/user/acceptance_tests/include_v3 "false"
+confset hcf/user/acceptance_tests/include_routing "false"
+confset hcf/user/acceptance_tests/use_diego "false"
+
+confset hcf/user/acceptance_tests/nodes "1"
+confset hcf/user/acceptance_tests/verbose "false"
+
+{
+  set -e
+  mkdir -p $(pwd)/hcf/tests/acceptance
+
+  docker run \
+    -it \
+    --net hcf \
+    --name acceptance_tests \
+    -v $(pwd)/hcf/tests/acceptance/:/var/vcap/sys/log/ \
+    $IMAGE \
+    http://hcf-consul-server.hcf:8501
+} || {
+  echo "Failed."
+}
+
+echo "Cleaning up ..."
+confdel hcf/user/acceptance_tests
+docker rm --force acceptance_tests
+

--- a/terraform-scripts/hcf/templates/run-smoke-tests.bash.tpl
+++ b/terraform-scripts/hcf/templates/run-smoke-tests.bash.tpl
@@ -1,0 +1,66 @@
+#/bin/bash
+# © Copyright 2015 Hewlett Packard Enterprise Development LP
+
+set -e 
+
+# Default to using the same image tag as cf-api
+IMAGE_TAG="$${IMAGE_TAG:-${build}}"
+IMAGE=helioncf/cf-smoke_tests:$${IMAGE_TAG}
+CONSUL="$${CONSUL:-http://127.0.0.1:8501}"
+
+confset () {
+  /opt/hcf/bin/set-config $CONSUL $@ 2>/dev/null 1> /dev/null
+}
+
+confdel () {
+  curl -s -X DELETE $CONSUL/v1/kv/$1?recurse > /dev/null
+}
+
+confget () {
+  curl -s $CONSUL/v1/kv/$1?raw
+}
+
+echo -n "HCF admin account username: "
+read ADMIN_USER
+echo -n "HCF admin account password: "
+read -s ADMIN_PASSWORD
+
+echo -e "\n"
+echo "Setting up config values ..."
+
+SYSTEM_DOMAIN=$(confget hcf/user/system_domain)
+APPS_DOMAIN=$(confget hcf/user/app_domains)
+API=$(confget hcf/user/cc/srv_api_uri)
+
+CLIENT_SECRET=$(confget hcf/user/uaa/clients/gorouter/secret)
+SKIP_SSL_VALIDATION=$(confget hcf/user/ssl/skip_cert_verify)
+ORG=CF-SMOKE-ORG
+SPACE=CF-SMOKE-SPACE
+
+confset hcf/user/smoke_tests/api "$${API}"
+confset hcf/user/smoke_tests/user "$${ADMIN_USER}"
+confset hcf/user/smoke_tests/password "$${ADMIN_PASSWORD}"
+confset hcf/user/smoke_tests/apps_domain "$${APPS_DOMAIN}"
+confset hcf/user/smoke_tests/org "$${ORG}"
+confset hcf/user/smoke_tests/space "$${SPACE}"
+confset hcf/user/smoke_tests/skip_ssl_validation $${SKIP_SSL_VALIDATION}
+
+{
+  set -e
+  mkdir -p $(pwd)/hcf/tests/smoke
+  
+  docker run \
+    -it \
+    --net hcf \
+    --name smoke_tests \
+    -v $(pwd)/hcf/tests/smoke/:/var/vcap/sys/log/ \
+    $IMAGE \
+    http://hcf-consul-server.hcf:8501
+} || {
+  echo "Failed."
+}
+
+echo "Cleaning up ..."
+confdel hcf/user/smoke_tests
+docker rm --force smoke_tests
+


### PR DESCRIPTION
Docker image versions are overridable in case that is useful.  Share templates between proxied and non-proxied to prevent drift.
