### PR TITLE
HCF-417 : Quote a potentially empty argument to -z

### DIFF
--- a/config-opinions/cf-v222/clear_tmp_warden_cgroup.sh
+++ b/config-opinions/cf-v222/clear_tmp_warden_cgroup.sh
@@ -7,6 +7,6 @@
 # This code finishes the job. If other stuff ends up in this directory, all bets are off.
 
 cgroup_path=/tmp/warden/cgroup
-if [[ -d $cgroup_path && -z `ls -A $cgroup_path` ]] ; then
+if [[ -d $cgroup_path && -z "$(ls -A $cgroup_path)" ]] ; then
     rmdir $cgroup_path
 fi


### PR DESCRIPTION
I don't know about this.  I created an empty directory and ran this code:

if [[ -z $(ls -A /tmp/empty-dir) ]] ; then
echo ok
fi

and it echo'ed "ok" with no errors.  But here's the change to end arguments.
Note that the change is still in a versioned-directory...
