### PR TITLE
HCF-494 Reduce container privileges

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -61,7 +61,16 @@ do
       touch $store_dir/fake_nfs_share/.nfs_test
       extra="-v ${store_dir}/fake_nfs_share:/var/vcap/nfs/shared"
       ;;
-   "api_worker")
+    "doppler")
+      extra="--privileged"
+      ;;
+    "loggregator_trafficcontroller")
+      extra="--privileged"
+      ;;
+    "router")
+      extra="--privileged"
+      ;;
+    "api_worker")
       mkdir -p $store_dir/fake_nfs_share
       touch $store_dir/fake_nfs_share/.nfs_test
       extra="-v $store_dir/fake_nfs_share:/var/vcap/nfs/shared"
@@ -69,11 +78,8 @@ do
     "ha_proxy")
       extra="-p 80:80 -p 443:443 -p 4443:4443 -p 2222:2222"
       ;;
-    "runner")
-      extra="--cap-add=ALL -v /lib/modules:/lib/modules"
-      ;;
     "diego_cell")
-      extra="--cap-add=ALL -v /lib/modules:/lib/modules"
+      extra="--privileged --cap-add=ALL -v /lib/modules:/lib/modules"
       ;;
     "cf-usb")
       mkdir -p $store_dir/fake_cf_usb_nfs_share

--- a/container-host-files/opt/hcf/bin/common.sh
+++ b/container-host-files/opt/hcf/bin/common.sh
@@ -55,7 +55,7 @@ function start_role {
 
   docker run -it -d --name $name \
     --net=hcf \
-    --privileged \
+    --cap-add=NET_ADMIN --cap-add=NET_RAW \
     --label=fissile_role=$role \
     --dns=127.0.0.1 --dns=8.8.8.8 \
     --cgroup-parent=instance \
@@ -81,7 +81,7 @@ function start_hcf_consul() {
   fi
 
   cid=$(docker run -d \
-    --net=bridge --net=hcf --privileged=true \
+    --net=bridge --net=hcf \
     -p 8401:8401 -p 8501:8501 -p 8601:8601 -p 8310:8310 -p 8311:8311 -p 8312:8312 \
     --name $container_name \
     -v $store_dir/$container_name:/opt/hcf/share/consul \


### PR DESCRIPTION
First step, containers still need net admin for iptables (used to workaround CF local IP address detection mechanism)
