### PR TITLE
Update consul binary release url

### DIFF
--- a/docker-images/hcf-consul-base/Dockerfile
+++ b/docker-images/hcf-consul-base/Dockerfile
@@ -2,5 +2,5 @@ FROM ubuntu:trusty
 MAINTAINER hcf-dev@hpe.com
 LABEL version="1.0"
 RUN apt-get update && apt-get install -y curl wget unzip jq xmlstarlet && \
-	wget -O /tmp/consul.zip https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip && \
+	wget -O /tmp/consul.zip https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip && \
 	mkdir /opt/consul && unzip -d /opt/consul /tmp/consul.zip && rm /tmp/consul.zip


### PR DESCRIPTION
Will fix this:

```
Setting up xmlstarlet (1.5.0-1) ...
Processing triggers for libc-bin (2.19-0ubuntu6.6) ...
Processing triggers for ca-certificates (20141019ubuntu0.14.04.1) ...
Updating certificates in /etc/ssl/certs... 173 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d....done.
Processing triggers for sgml-base (1.26+nmu4ubuntu1) ...
--2016-02-09 15:04:02--  https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip
Resolving dl.bintray.com (dl.bintray.com)... 5.153.35.248, 159.122.18.156, 159.122.18.156
Connecting to dl.bintray.com (dl.bintray.com)|5.153.35.248|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2016-02-09 15:04:02 ERROR 404: Not Found.
```
