### PR TITLE
HCF-501: Only look at nameserver lines checking for resolv.conf override

### DIFF
--- a/container-host-files/etc/hcf/config/fix_linux_garden_dns.sh
+++ b/container-host-files/etc/hcf/config/fix_linux_garden_dns.sh
@@ -10,7 +10,7 @@ read -d '' setup_patch <<PATCH || true
  # In this case, the container must use the network_host_ip address
  # as the nameserver.
 -if [[ "\$(cat /etc/resolv.conf)" == "nameserver 127.0.0.1" ]]
-+if [[ "\$(cat /etc/resolv.conf)" == "nameserver 127.0.0."* ]]
++if [[ "\$(grep '^nameserver ' /etc/resolv.conf)" == "nameserver 127.0.0."* ]]
  then
    cat > \$rootfs_path/etc/resolv.conf <<-EOS
 -nameserver \$network_host_ip


### PR DESCRIPTION
There can be other things in /etc/resolv.conf (default suffix, etc.); ignore those when checking to see if we need to override it.

I need this to be able to download the go buildpack.  However, deploy still fails:

```
2016-02-23T11:33:16.30-0800 [API/0]      OUT Created app with guid 2a89fe1b-f6a2-4a44-81a8-a26d239b1362
2016-02-23T11:33:16.42-0800 [API/0]      OUT Updated app with guid 2a89fe1b-f6a2-4a44-81a8-a26d239b1362 ({"route"=>"ecf438e8-6c7b-4a5f-8c2d-7c5aeec94b10"})
2016-02-23T11:33:21.78-0800 [API/0]      OUT Updated app with guid 2a89fe1b-f6a2-4a44-81a8-a26d239b1362 ({"state"=>"STARTED"})
2016-02-23T11:33:21.81-0800 [STG/0]      OUT Creating container
2016-02-23T11:33:33.45-0800 [STG/0]      OUT Successfully created container
2016-02-23T11:33:33.46-0800 [STG/0]      OUT Downloading app package...
2016-02-23T11:33:33.50-0800 [STG/0]      OUT Downloaded app package (1.3K)
2016-02-23T11:33:33.50-0800 [STG/0]      OUT Downloading buildpacks (https://github.com/cloudfoundry/go-buildpack#v1.3.1)...
2016-02-23T11:33:33.98-0800 [STG/0]      OUT Downloaded buildpacks
2016-02-23T11:33:33.98-0800 [STG/0]      OUT Staging...
2016-02-23T11:33:54.54-0800 [STG/0]      OUT -------> Buildpack version 1.3.1
2016-02-23T11:34:01.37-0800 [STG/0]      OUT -----> Installing go1.4.2... done
2016-02-23T11:34:01.38-0800 [STG/0]      OUT        Tired of waiting for bzr and hg?
2016-02-23T11:34:01.38-0800 [STG/0]      OUT        Try github.com/kr/godep for faster deploys.
2016-02-23T11:34:01.78-0800 [STG/0]      OUT        Installing Virtualenv... done
2016-02-23T11:34:01.78-0800 [STG/0]      OUT        Installing Mercurial... done
2016-02-23T11:34:01.78-0800 [STG/0]      OUT        Installing Bazaar... done
2016-02-23T11:34:01.78-0800 [STG/0]      OUT -----> Running: go get -tags cloudfoundry ./...
2016-02-23T11:34:09.40-0800 [STG/0]      OUT Exit status 0
2016-02-23T11:34:09.40-0800 [STG/0]      OUT Staging complete
2016-02-23T11:34:09.40-0800 [STG/0]      OUT Uploading droplet, build artifacts cache...
2016-02-23T11:34:09.40-0800 [STG/0]      OUT Uploading droplet...
2016-02-23T11:34:09.40-0800 [STG/0]      OUT Uploading build artifacts cache...
2016-02-23T11:34:09.96-0800 [STG/0]      OUT Uploaded build artifacts cache (62M)
2016-02-23T11:34:10.47-0800 [STG/0]      OUT Uploaded droplet (1.6M)
2016-02-23T11:34:10.47-0800 [STG/0]      OUT Uploading complete
2016-02-23T11:34:11.28-0800 [CELL/0]     OUT Creating container
2016-02-23T11:34:11.81-0800 [CELL/0]     OUT Successfully created container
2016-02-23T11:34:11.92-0800 [API/0]      OUT App instance exited with guid 2a89fe1b-f6a2-4a44-81a8-a26d239b1362 payload: {"instance"=>"c7564d98-4865-401a-54df-ff61790a6c83", "index"=>0, "reason"=>"CRASHED", "exit_description"=>"Copying into the container failed", "crash_count"=>1, "crash_timestamp"=>1456256051912274930, "version"=>"2d53a5e7-0d4f-4b1d-8ed6-c13f5a4721e9"}
2016-02-23T11:34:11.93-0800 [CELL/0]     OUT Creating container
2016-02-23T11:34:12.29-0800 [CELL/0]     OUT Successfully created container
2016-02-23T11:34:12.38-0800 [API/0]      OUT App instance exited with guid 2a89fe1b-f6a2-4a44-81a8-a26d239b1362 payload: {"instance"=>"d2f443fa-825a-41a4-4638-095eb0b76333", "index"=>0, "reason"=>"CRASHED", "exit_description"=>"Copying into the container failed", "crash_count"=>2, "crash_timestamp"=>1456256052381156028, "version"=>"2d53a5e7-0d4f-4b1d-8ed6-c13f5a4721e9"}
2016-02-23T11:34:12.40-0800 [CELL/0]     OUT Creating container
2016-02-23T11:34:13.05-0800 [CELL/0]     OUT Successfully created container
2016-02-23T11:34:13.28-0800 [API/0]      OUT App instance exited with guid 2a89fe1b-f6a2-4a44-81a8-a26d239b1362 payload: {"instance"=>"d22fcb5d-2b92-40d4-5e6c-44907bdd4e2f", "index"=>0, "reason"=>"CRASHED", "exit_description"=>"Copying into the container failed", "crash_count"=>3, "crash_timestamp"=>1456256053278712642, "version"=>"2d53a5e7-0d4f-4b1d-8ed6-c13f5a4721e9"}
2016-02-23T11:34:51.70-0800 [CELL/0]     OUT Creating container
2016-02-23T11:34:51.93-0800 [CELL/0]     OUT Successfully created container
2016-02-23T11:34:52.07-0800 [API/0]      OUT App instance exited with guid 2a89fe1b-f6a2-4a44-81a8-a26d239b1362 payload: {"instance"=>"db4b5f31-1a57-4564-4176-f78489aa4437", "index"=>0, "reason"=>"CRASHED", "exit_description"=>"Copying into the container failed", "crash_count"=>4, "crash_timestamp"=>1456256092067534393, "version"=>"2d53a5e7-0d4f-4b1d-8ed6-c13f5a4721e9"}
```
