### PR TITLE
HCF-542: Update libvirt vagrant box configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,11 +51,12 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider "libvirt" do |libvirt, override|
-    override.vm.box = "https://15.184.137.5:8080/v1/AUTH_7b52c1fb73ad4568bbf5e90bead84e21/hcf-vagrant-box-images/hcf-libvirt-v0.box"
+    override.vm.box = "https://api.mpce.hpelabs.net:8080/v1/AUTH_7b52c1fb73ad4568bbf5e90bead84e21/hcf-vagrant-box-images/hcf-libvirt-v1.0.1.box"
     libvirt.driver = "kvm"
     # Allow downloading boxes from sites with self-signed certs
     override.vm.box_download_insecure = true
     libvirt.memory = 8192
+    libvirt.cpus = 4
     override.vm.synced_folder ".fissile/.bosh", "/home/vagrant/.bosh", type: "nfs"
     override.vm.synced_folder ".", "/home/vagrant/hcf", type: "nfs"
   end

--- a/packer/.gitignore
+++ b/packer/.gitignore
@@ -1,1 +1,2 @@
 /packer_cache/
+/output-*/

--- a/packer/Vagrantfile-qemu.template
+++ b/packer/Vagrantfile-qemu.template
@@ -1,0 +1,8 @@
+Vagrant.configure('2') do |config|
+  config.vm.provider :libvirt do |libvirt|
+    # We require a secondary disk at /dev/sdb for the docker graph storage
+    # This means the primary must be /dev/sda (to bump the available names)
+    libvirt.disk_bus = 'scsi'
+    libvirt.storage :file, :size => '70G', bus: 'scsi', device: 'sdb'
+  end
+end

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -80,6 +80,7 @@
             "headless": true,
             "vm_name": "{{user `vm_name`}}",
             "disk_size": 50000,
+            "disk_interface": "scsi",
             "ssh_username": "{{user `ssh_username`}}",
             "ssh_password": "{{user `ssh_password`}}",
             "iso_url": "{{user `iso_url`}}",
@@ -144,7 +145,12 @@
     "post-processors": [
         {
             "type": "vagrant",
-            "output": "hcf-{{.Provider}}-v{{user `version`}}.box"
+            "output": "hcf-{{.Provider}}-v{{user `version`}}.box",
+            "override": {
+                "libvirt": {
+                    "vagrantfile_template": "Vagrantfile-qemu.template"
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
We now need a secondary disk to hold the docker stuff.

This means customizing the output `Vagrantfile` to add it, though.  Luckily we don't actually need that disk during `packer build`, so we can get away with it.  Packer does not natively support having more than one disk.
