### PR TITLE
[APAAS-2965] Start dns servert for external hosts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,6 +79,7 @@ Vagrant.configure(2) do |config|
     # Configure Docker things
     sudo /home/vagrant/hcf/container-host-files/opt/hcf/bin/docker/configure_docker.sh /dev/sdb 64 4
     /home/vagrant/hcf/container-host-files/opt/hcf/bin/docker/setup_network.sh "172.20.10.0/24" "172.20.10.1"
+    /home/vagrant/hcf/container-host-files/opt/hcf/bin/docker/create_docker_dns_server.sh
 
     # Install development tools
     /home/vagrant/hcf/bin/dev/install_tools.sh

--- a/container-host-files/opt/hcf/bin/docker/create_docker_dns_server.sh
+++ b/container-host-files/opt/hcf/bin/docker/create_docker_dns_server.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Create a DNS server in docker hcf network that is exposed on the host
+# to allow external hosts to use the internal DNS server from docker.
+# I.e. a Windows box could resolve the 'diego-database.hcf' hostname if
+# the DNS client is pointing to 192.168.77.77
+docker run  -p 192.168.77.77:53:8600/udp --net=hcf -d --restart=always \
+  --name dnsb voxxit/consul agent -data-dir /data -server -bootstrap \
+  -client=0.0.0.0 -recursor=127.0.0.11


### PR DESCRIPTION
This is a requirement for Windows to be able to resolve .hcf hostnames and connect to diego components. It is currently documented as a manual step when installing windows. 

This patch will make it run automatically as a docker service. It does also persists if the vagrant box restarts.
