### PR TITLE
Bump the version of BOSH CLI we're using

### DIFF
--- a/docker-images/hcf-pipeline-ruby-bosh/Dockerfile
+++ b/docker-images/hcf-pipeline-ruby-bosh/Dockerfile
@@ -22,4 +22,4 @@ RUN xargs -L 1 rbenv install < /root/versions.txt
 RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 RUN bash -l -c 'for v in $(cat /root/versions.txt); do rbenv global $v; gem install bundler; done'
 
-RUN bash -l -c 'rbenv global 2.2.3 && gem install bosh_cli -v 1.3184.1.0 --no-ri --no-rdoc'
+RUN bash -l -c 'rbenv global 2.2.3 && gem install bosh_cli -v 1.3202.0 --no-ri --no-rdoc'


### PR DESCRIPTION
This resolves a bug that caused release manifests to be incorrectly serialized
