### PR TITLE
HCF-514: rysnc compiled artifacts out of vagrant box in the background

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,13 +123,16 @@ compile:
 	@echo Please allow a long time for mariadb to compile
 	fissile dev compile
 ifneq (,${HCF_PACKAGE_COMPILATION_CACHE})
-	for i in ${FISSILE_WORK_DIR}/compilation/*/*/compiled ; do \
-		i=$$(dirname $${i}) ; \
-		echo pack $${i} ; \
-		tar cf $${i}/compiled.tar -C "$${i}" compiled ; \
-	done
 	# rsync takes the first match; need to explicitly include parent directories in order to include the children.
-	rsync -rl --include="/*/" --include="/*/*/" --include="/*/*/compiled.tar" --exclude="*" --info=progress2 "${FISSILE_WORK_DIR}/compilation/" "${HCF_PACKAGE_COMPILATION_CACHE}/"
+	{ \
+		set -e ; \
+		for i in ${FISSILE_WORK_DIR}/compilation/*/*/compiled ; do \
+			i=$$(dirname $${i}) ; \
+			echo pack $${i} ; \
+			tar cf $${i}/compiled.tar -C "$${i}" compiled ; \
+		done ; \
+		rsync -rl --include="/*/" --include="/*/*/" --include="/*/*/compiled.tar" --exclude="*" --info=progress2 "${FISSILE_WORK_DIR}/compilation/" "${HCF_PACKAGE_COMPILATION_CACHE}/" ; \
+	} >"${FISSILE_WORK_DIR}/rsync.log" 2>&1 &
 endif
 
 images: bosh-images


### PR DESCRIPTION
We don't need to wait for things to happen at this point; this is just an optimization for the next vagrant box.

Picked this out of the backlog because it was saving me time when working on HCF-532.
