### PR TITLE
[APAAS-2965]  Make use of protocol for docker port forwarding

### DIFF
--- a/container-host-files/opt/hcf/bin/common.sh
+++ b/container-host-files/opt/hcf/bin/common.sh
@@ -92,7 +92,7 @@ function setup_role() {
   # If there are any exposed ports, this creates a string that resembles the
   # line below. It returns an empty string otherwise.
   # -p 80:80 -p 443:443
-  ports=$(echo "${role_info}" | jq --raw-output --compact-output '."exposed-ports"[] | if length > 0 then "-p " + ([(.source | tostring) + ":" + (.target | tostring)] | join(" -p ")) else "" end')
+  ports=$(echo "${role_info}" | jq --raw-output --compact-output '."exposed-ports"[] | if length > 0 then "-p " + ([(.source | tostring) + ":" + (.target | tostring) + "/" + (.protocol | tostring) ] | join(" -p ")) else "" end')
 
   # Add persistent volumes
   # If there are any persistent volume mounts defined, this creates a string that resembles the


### PR DESCRIPTION
Related to this:
https://github.com/hpcloud/hcf-infrastructure/pull/210
and
https://github.com/hpcloud/hcf-infrastructure/commit/cf278a41efda58e07b0db96fe589f50c21023395

With this patch and a revert of this commit https://github.com/hpcloud/hcf-infrastructure/commit/4a9e08567635cf9b7edcb13e68eed671a1ca8061 (i.e. it disables service discovery) I was a able to push a windows app with greenhouse installers.
