### PR TITLE
HCFRO-118 Change mysql docker image

### DIFF
--- a/docker-images/mysql-manager/Dockerfile
+++ b/docker-images/mysql-manager/Dockerfile
@@ -1,3 +1,3 @@
-FROM mysql:5.6
+FROM centurylink/mysql:5.5
 LABEL role=mysql-manager
 ENV MYSQL_ROOT_PASSWORD password


### PR DESCRIPTION
The official mysql image is having issues when being initialized for the first time by hcf. It seems that this only happens when starting multiple docker containers at the same time.
