### PR TITLE
[HCF-581] Redirect the output of 'docker pull' through a pipe, disabl…

### DIFF
--- a/bin/rm-transformer/tf.rb
+++ b/bin/rm-transformer/tf.rb
@@ -193,7 +193,7 @@ class ToTerraform < Common
     cmd = 'docker pull ${var.docker_trusted_registry}/${var.docker_org}/'
     cmd += '${var.hcf_image_prefix}' + name
     cmd += ':${var.hcf_version}'
-    cmd += ' | tee $$ ; rm $$'
+    cmd += ' | cat'
     cmd += "\n"
     cmd
   end


### PR DESCRIPTION
…ing the animated progress-bars in the output which upset terraforms log handling.

The redirection prevents docker from seeing a tty to play with, causing it to switch to a log method without any animation which can be logged properly.

Tested with AWS/TF.
