### PR TITLE
[HCF-578] Increase mysql proxy timeout

### DIFF
--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -575,3 +575,6 @@ properties:
     - name: uaaadmin
       password: admin_password
       tag: admin
+  cf_mysql:
+    proxy:
+      healthcheck_timeout_millis: 30000


### PR DESCRIPTION
The switchboard checks the health of mysql backends using an HTTP endpoint.
By default, the timeout for the GET for those endpoints is 5000 ms. If the timeout is reached, the switchboard considers the backend to be dead, and severs connections.
With the new timeout, there were no dropped connections across 100,000 "cf apps" requests, in ~8 hrs.
