### PR TITLE
HCF-604 Add missing processes to role manifest

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -132,6 +132,7 @@ roles:
   - name: proxy
     release_name: cf-mysql
   processes:
+  - name: route-registrar
   - name: switchboard
   run:
     capabilities: []
@@ -357,10 +358,13 @@ roles:
   processes:
   - name: cloud_controller_ng
   - name: cloud_controller_worker_local_1
+  - name: cloud_controller_worker_local_2
   - name: cloud_controller_migration
   - name: route_registrar
   - name: metron_agent
   - name: consul_agent
+  - name: nginx_cc
+  - name: statsd-injector
   run:
     capabilities: []
     persistent-volumes: []
@@ -511,6 +515,7 @@ roles:
     release_name: cf
   processes:
   - name: doppler
+  - name: metron_agent
   - name: route_registrar
   - name: syslog_drain_binder
   configuration:
@@ -596,6 +601,7 @@ roles:
     release_name: cf
   processes:
   - name: loggregator_trafficcontroller
+  - name: metron_agent
   - name: route_registrar
   configuration:
     templates:
@@ -661,7 +667,9 @@ roles:
   - name: metron_agent
     release_name: cf
   processes:
+  - name: cc_uploader
   - name: stager
+  - name: tps_listener
   - name: tps_watcher
   - name: nsync_listener
   - name: nsync_bulker

--- a/container-host-files/opt/hcf/bin/monit-vs-manifest.sh
+++ b/container-host-files/opt/hcf/bin/monit-vs-manifest.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+SELFDIR="$(readlink -f "$(cd "$(dirname "$0")" && pwd)")"
+source "${SELFDIR}/common.sh"
+
+load_all_roles
+
+function ip_address {
+    docker inspect --format '{{ .NetworkSettings.Networks.hcf.IPAddress }}' $1
+}
+
+function monit_status {
+    curl -s -u monit_user:monit_password http://$(ip_address $1):2822/_status
+}
+
+function actual_processes_in_role {
+    monit_status $1 | perl -ne "s/'//g; print if s/Process //"
+}
+
+for role in $(list_all_bosh_roles); do
+    for actual in $(actual_processes_in_role $role); do
+        for process in $(list_processes_for_role $role); do
+            if [[ $actual == $process ]]; then continue 2; fi
+        done
+        echo "$role is missing: $actual"
+    done
+done
+


### PR DESCRIPTION
Also adds monit-vs-manifest.sh to check a running system against
the manifest to find any missing processes.  Doesn't check for
manifest processes not actually running; that is already covered
by hcf-status.

``` bash
vagrant@hcf-vagrant:~$ monit-vs-manifest.sh
mysql-proxy is missing: route-registrar
api is missing: statsd-injector
api is missing: cloud_controller_worker_local_2
api is missing: nginx_cc
doppler is missing: metron_agent
loggregator is missing: metron_agent
diego-cc-bridge is missing: tps_listener
diego-cc-bridge is missing: cc_uploader
```
