### PR TITLE
[hcf-556] Do not generate TF for variables which are optional and wit…

### DIFF
--- a/bin/rm-transformer/tf.rb
+++ b/bin/rm-transformer/tf.rb
@@ -75,6 +75,8 @@ class ToTerraform < Common
       name = config['name']
       next if special?(name)
       value = config['default']
+      # Ignore optional values without a default.
+      next if value.nil? && !config['required']
       emit_variable(name, value: value)
     end
     puts 'PUBLIC_IP is missing from input role-manifest' unless @have_public_ip
@@ -142,6 +144,8 @@ class ToTerraform < Common
   def emit_settings(manifest)
     rm_configuration = ''
     manifest['configuration']['variables'].each do |config|
+      # Ignore optional values without a default.
+      next if config['default'].nil? && !config['required']
       rm_configuration += make_assignment_for(config['name'])
     end
 


### PR DESCRIPTION
…hout a value.

(Example: TRUSTED_CERTS, since commit 92469fb1f2d616cee48ceb514b62fee8fff7152e, for HCF-556)
