### PR TITLE
HCF-569 Support AWS for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,4 +172,7 @@ aws-spot-proxy-dist: aws-proxy
 	echo Generated aws-spot-proxy-$(APP_VERSION).zip
 
 mpc-terraform-tests:
-	${GIT_ROOT}/make/mpc-terraform-tests
+	${GIT_ROOT}/make/terraform-tests mpc ${OS_SSH_KEY_PATH}
+
+aws-terraform-tests:
+	${GIT_ROOT}/make/terraform-tests aws ${AWS_PUBLIC_KEY_PATH} ${AWS_PRIVATE_KEY_PATH}

--- a/docker-images/terraform-tests/Dockerfile
+++ b/docker-images/terraform-tests/Dockerfile
@@ -1,4 +1,4 @@
 FROM ruby:2-alpine
-ADD https://releases.hashicorp.com/terraform/0.6.8/terraform_0.6.8_linux_amd64.zip /usr/local/bin/
-RUN unzip -d /usr/local/bin/ /usr/local/bin/terraform_0.6.8_linux_amd64.zip
+ADD https://releases.hashicorp.com/terraform/0.6.14/terraform_0.6.14_linux_amd64.zip /usr/local/bin/
+RUN unzip -d /usr/local/bin/ /usr/local/bin/terraform_0.6.14_linux_amd64.zip
 RUN apk add --update openssh-client

--- a/make/terraform-tests
+++ b/make/terraform-tests
@@ -11,10 +11,21 @@ trap "rm -rf ${ENV_FILE}" HUP INT TERM EXIT
 
 cat /proc/self/environ > ${ENV_FILE}
 
+PROVIDER="$1"
+shift
+
+EXTRA_MOUNTS=""
+
+while test -n ${1-''} ; do
+  EXTRA_MOUNTS="${EXTRA_MOUNTS} --volume ${1}:${1}:ro"
+  shift
+done
+
 docker run \
        --rm \
        --volume ${GIT_ROOT}:${GIT_ROOT} \
-       --volume ${OS_SSH_KEY_PATH}:${OS_SSH_KEY_PATH}:ro \
+       ${EXTRA_MOUNTS} \
        --volume ${ENV_FILE}:/environ:ro \
        ${DOCKER_RUNTIME} \
-       ruby ${GIT_ROOT}/bin/run-terraform-tests.rb
+       ruby ${GIT_ROOT}/bin/run-terraform-tests.rb \
+       --provider=${PROVIDER}


### PR DESCRIPTION
Usage:
1. Export relevant environment variables as appropriate:
   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
   - `AWS_PUBLIC_KEY_PATH`, `AWS_PRIVATE_KEY_PATH`
   - `CLUSTER_PREFIX`
   - `DOCKER_USERNAME`, `DOCKER_PASSWORD`, `DOCKER_EMAIL`
   - `HCF_VERSION`
2. `make aws-spot aws-terraform-tests`

Note that there seems to be an issue with Terraform tearing down the VPC; that's independent of this.  We'll need to solve it before deploying this on CI, though.
