### PR TITLE
[HCF-451] Added check to core that proxy is properly initialized.

### DIFF
--- a/terraform/aws-spot-proxy.tf
+++ b/terraform/aws-spot-proxy.tf
@@ -435,6 +435,7 @@ resource "aws_spot_instance_request" "core" {
 
     provisioner "remote-exec" {
         inline = [
+            "set -e",
             # Set up proxies
             "echo 'http_proxy=${null_resource.HTTP_PROXY.triggers.HTTP_PROXY}' | sudo tee -a /etc/environment",
             "echo 'HTTP_PROXY=${null_resource.HTTP_PROXY.triggers.HTTP_PROXY}' | sudo tee -a /etc/environment",
@@ -444,6 +445,12 @@ resource "aws_spot_instance_request" "core" {
             "echo 'Acquire::https::Proxy \"${null_resource.HTTPS_PROXY.triggers.HTTPS_PROXY}\";' | sudo tee -a /etc/apt/apt.conf.d/60-proxy",
             "echo 'NO_PROXY=${var.NO_PROXY}' | sudo tee -a /etc/environment",
             "echo 'no_proxy=${var.NO_PROXY}' | sudo tee -a /etc/environment",
+
+            # Wait for the proxy to come up without spamming the terminal with connection attempts
+            "echo Waiting for proxy to be live at ${null_resource.HTTP_PROXY.triggers.HTTP_PROXY}",
+            "for i in `seq 10`; do curl --silent ${null_resource.HTTP_PROXY.triggers.HTTP_PROXY} >/dev/null 2>&1 && echo Proxy reached on $i && exit 0; sleep 10; done",
+            "echo Proxy not available",
+            "exit 1"
         ]
     }
 


### PR DESCRIPTION
We have seen tf initializing proxy where it claims the instance as
created yet the proxy_setup.sh script was not properly run (no
output from it). In such a case the new code will abort core
provisioning early and with a proper message. Without it core creation
would abort in install_kernel.sh, unable to reach package servers
through the missing proxy, with confusing messages.
