### PR TITLE
Make: Fix name of windows-runtime-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ hcf-deployment-hooks:
 	${GIT_ROOT}/make/bosh-release src/hcf-deployment-hooks
 
 windows-runtime-release:
-	${GIT_ROOT}/make/bosh-release src/windows-runtime-release
+	${GIT_ROOT}/make/bosh-release src/windows-runtime-release windows-runtime-release
 
 releases: cf-release usb-release diego-release etcd-release garden-release mysql-release hcf-deployment-hooks windows-runtime-release
 

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -354,7 +354,7 @@ roles:
   - name: staticfile-buildpack
     release_name: cf
   - name: cf_iis_buildpack
-    release_name: windows-runtime
+    release_name: windows-runtime-release
   processes:
   - name: cloud_controller_ng
   - name: cloud_controller_worker_local_1
@@ -764,7 +764,7 @@ roles:
   - name: file_server
     release_name: diego
   - name: windows_buildpack_app_lifecycle
-    release_name: windows-runtime
+    release_name: windows-runtime-release
   processes:
   - name: file_server
   - name: metron_agent


### PR DESCRIPTION
Because it insists on calling itself a release. Otherwise fissile can't find it when looking at config/final.yml and everything falls apart.
