### PR TITLE
Add APP_VERSION variable for aws-dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 #!/usr/bin/env make
 
 GIT_ROOT:=$(shell git rev-parse --show-toplevel)
+APP_VERSION:=$(shell ${GIT_ROOT}/make/print-version)
 
 # Default target specification
 run:
@@ -148,18 +149,18 @@ aws-proxy-dist: aws-proxy
 	mkdir -p $$base/aws-proxy/terraform && \
 	cp -rf container-host-files terraform/aws.tfvars.example terraform/aws-proxy.tf terraform/README-aws.md hcf-aws-proxy.tf.json $$base/aws-proxy/ && \
 	cp terraform/proxy.conf terraform/proxy-setup.sh $$base/aws-proxy/terraform/ && \
-	( cd $$base && zip -r9 ${CURDIR}/aws-proxy-$(APP_VERSION).zip aws-proxy ) && \
+	( cd $$base && zip -r9 ${CURDIR}/aws-proxy-${APP_VERSION}.zip aws-proxy ) && \
 	rm -rf $$base && \
-	echo Generated aws-proxy-$(APP_VERSION).zip
+	echo Generated aws-proxy-${APP_VERSION}.zip
 
 aws-spot-dist: aws
 	$(call print_status, Package AWS spot instance terraform configuration for distribution)
 	@base=$$(mktemp -d aws_XXXXXXXXXX) && \
 	mkdir $$base/aws-spot && \
 	cp -rf container-host-files terraform/aws.tfvars.example terraform/aws-spot.tf terraform/README-aws.md hcf-aws.tf.json $$base/aws-spot/ && \
-	( cd $$base && zip -r9 ${CURDIR}/aws-spot-$(APP_VERSION).zip aws-spot ) && \
+	( cd $$base && zip -r9 ${CURDIR}/aws-spot-${APP_VERSION}.zip aws-spot ) && \
 	rm -rf $$base && \
-	echo Generated aws-spot-$(APP_VERSION).zip
+	echo Generated aws-spot-${APP_VERSION}.zip
 
 aws-spot-proxy-dist: aws-proxy
 	$(call print_status, Package AWS spot instance with proxy terraform configuration for distribution)
@@ -167,9 +168,9 @@ aws-spot-proxy-dist: aws-proxy
 	mkdir -p $$base/aws-spot-proxy/terraform && \
 	cp -rf container-host-files terraform/aws.tfvars.example terraform/aws-spot-proxy.tf terraform/README-aws.md hcf-aws-proxy.tf.json $$base/aws-spot-proxy/ && \
 	cp terraform/proxy.conf terraform/proxy-setup.sh $$base/aws-spot-proxy/terraform/ && \
-	( cd $$base && zip -r9 ${CURDIR}/aws-spot-proxy-$(APP_VERSION).zip aws-spot-proxy ) && \
+	( cd $$base && zip -r9 ${CURDIR}/aws-spot-proxy-${APP_VERSION}.zip aws-spot-proxy ) && \
 	rm -rf $$base && \
-	echo Generated aws-spot-proxy-$(APP_VERSION).zip
+	echo Generated aws-spot-proxy-${APP_VERSION}.zip
 
 mpc-terraform-tests:
 	${GIT_ROOT}/make/terraform-tests mpc ${OS_SSH_KEY_PATH}


### PR DESCRIPTION
It looks like this went missing in the recent Makefile changes.

Also changed `(APP_VERSION)` to `{APP_VERSION}` for a consistent style.
