### PR TITLE
HCF-612 - Remove "our" containers only.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,11 @@ clean-harder: clean
 	$(call print_status, Cleaning docker containers)
 	-docker rm --force $(shell docker ps --all --quiet --filter=name=fissile-)
 
+clean-running-roles:
+	@docker ps --all --format '{{.ID}} {{.Image}}' | \
+	  awk 'index($$2, "docker.helion.lol/helioncf/hcf-") == 0 || index($$2, "dev-service-") == 0 { print $$1 }' | \
+	  xargs --no-run-if-empty docker rm --force
+
 all: images tag terraform
 
 fetch-submodules:


### PR DESCRIPTION
Assume HCF containers are based on images whose names start with
"docker.helion.lol/helioncf". Note that in awk string indices start at 1,
and 0 indicates failure.

If this program is run midway during a task like 'make run' it won't
delete containers based on images like wildducktheories/y2j or
<DB>-manager. But we can assume if someone's going to run this
on an incomplete system they know what they're doing.
