### PR TITLE
HCF-618 Fix typo in make/clean

### DIFF
--- a/make/clean
+++ b/make/clean
@@ -6,4 +6,4 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
 . ${GIT_ROOT}/make/include/fissile
 
-rm -rf ${FISSILE_WORKDIR}
+rm -rf ${FISSILE_WORK_DIR}


### PR DESCRIPTION
```
vagrant@hcf-vagrant:~/hcf$ make clean
/home/vagrant/hcf/make/clean
/home/vagrant/hcf/make/clean: 9: /home/vagrant/hcf/make/clean: FISSILE_WORKDIR: parameter not set
make: *** [clean] Error 2
```
