### PR TITLE
HCF-622 Change the cf compatibility spreadsheet URL

### DIFF
--- a/bin/get-cf-versions.sh
+++ b/bin/get-cf-versions.sh
@@ -14,7 +14,7 @@ RELEASE=$1
 CF_RELEASE=https://raw.githubusercontent.com/cloudfoundry/cf-release/master/releases/cf-$RELEASE.yml
 COMMIT_HASH=$(curl $CF_RELEASE 2>/dev/null | yaml2json | jq '"X"+.commit_hash')
 
-COMPAT=https://raw.githubusercontent.com/cloudfoundry-incubator/diego-cf-compatibility/master/compatibility-v3.csv
+COMPAT=https://raw.githubusercontent.com/cloudfoundry-incubator/diego-cf-compatibility/master/compatibility-v4.csv
 RELEASE_INFO=$(curl $COMPAT 2>/dev/null | perl -pe '$. == 1 or s/,/,X/g' | csv2json | jq -c "map( select(.[\"cf-release-commit-sha\"] | contains($COMMIT_HASH)))|.[0]")
 
 echo $RELEASE_INFO | jq . | perl -pe 's/"X/"/'


### PR DESCRIPTION
They are now on v4

Sample output:

```
$ ./bin/get-cf-versions.sh 236
{
  "date": "2016-04-23T03:21:54Z",
  "cf-release-commit-sha": "fb04a6dfefe529bb8e47990a8e36ae53d5ee6fe5",
  "diego-release-commit-sha": "a54eeaf40af79dda330f073fd8a1e6ef3679d048",
  "diego-release-version": "0.1468.0",
  "garden-linux-release-version": "0.337.0",
  "etcd-release-version": "45",
  "cflinuxfs2-rootfs-release-version": "0.2.0",
  "stemcell": "bosh-aws-xen-hvm-ubuntu-trusty-go_agent/3215.4",
  "director-version": "1.3215.1.0"
}
```
