### PR TITLE
Hcf 627 index mysql proxy  diego access

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1187,8 +1187,6 @@ configuration:
     secret: true
   - name: DNS_SUFFIX
     default: ""
-  - name: GARDEN_LINUX_DNS_SERVER
-    default: ""
     required: false
   - name: DOMAIN
     example: "192.168.77.77.nip.io"


### PR DESCRIPTION
Remove indexing for diego.ssh_proxy.servers, constrain indexing for mysql-proxy.run.scaling
