### PR TITLE
HCF-648 Use temporary fissile to workaround rsyslog ppa being broken

### DIFF
--- a/bin/dev/install_tools.sh
+++ b/bin/dev/install_tools.sh
@@ -6,7 +6,7 @@ bin_dir="${bin_dir:-/home/vagrant/bin}"
 tools_dir="${tools_dir:-/home/vagrant/tools}"
 ubuntu_image="${ubuntu_image:-ubuntu:14.04}"
 configgin_url="${configgin_url:-https://helion-developers.s3.amazonaws.com/viovanov/hcf/configgin-0.13.1%2B13.gd759c2a.develop-linux-amd64.tgz}"
-fissile_url="${fissile_url:-https://s3.amazonaws.com/helion-developers/marky/hcf/fissile-0.13.1%2B18.g5dde06a.develop-linux.amd64.tgz}"
+fissile_url="${fissile_url:-https://s3.amazonaws.com/helion-developers/marky/hcf/fissile-0.13.1%2B33.g1807e5b.HCF-648-rsyslog-broken-ppa-linux.amd64.tgz}"
 cf_url="${cf_url:-https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.14.0&source=github-rel}"
 
 mkdir -p $bin_dir


### PR DESCRIPTION
This switches to ppa:adiscon/v8-devel until they fix it upstream
See also https://github.com/rsyslog/rsyslog-pkg-ubuntu/issues/44
## NOTE

Do not close the bug; we need to revert this once upstream is fixed
