### PR TITLE
HCF-641 Only copy the fissile compilation cache we will actually need

### DIFF
--- a/make/compile
+++ b/make/compile
@@ -62,7 +62,7 @@ clean() {
     existing_packages=""
     for directory in "${FISSILE_WORK_DIR}/compilation/"*/* ; do
         test -d "${directory}" || continue  # in case expansion failed
-        hash=$(basename ${directory})
+        hash=$(basename "${directory}")
         package=$(basename "$(dirname "${directory}")")
         existing_packages="${existing_packages} ${package}/${hash}"
     done


### PR DESCRIPTION
Also be smarter, and create the tar archive directly where we want it, instead of using the local disk as an intermediary and rsync it after. That is unnecessary and increases the chances we will run out of disk.

If desired, we can also start compressing those archives (`*.tgz`) and try both options when restoring.
