### PR TITLE
HCF-627 mysql-proxy: properties.cf_mysql.proxy.proxy_ips contains hostnames

### DIFF
--- a/container-host-files/etc/hcf/config/fix_mysql_proxy_host_list.sh
+++ b/container-host-files/etc/hcf/config/fix_mysql_proxy_host_list.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# This patch is from HCF-627
+# We don't really deal with IP addresses; instead, we deal in host names.
+# This makes it more possible to find the instance in the list so it can give
+# a correct index.
+
+set -o errexit -o nounset
+
+PATCH_DIR="/var/vcap/jobs-src/proxy/templates"
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+cd "${PATCH_DIR}"
+
+patch -p0 --force <<"EOF"
+diff --git a/jobs/proxy/templates/route-registrar.yml.erb b/jobs/proxy/templates/route-registrar.yml.erb
+index 8aa3fdf..9e26fec 100644
+--- route-registrar.yml.erb
++++ route-registrar.yml.erb
+@@ -4,9 +4,9 @@ message_bus_servers:
+   user: <%= p('nats.user') %>
+   password: <%= p('nats.password') %>
+ <% end %>
+-<% my_ip = spec.networks.send(p('network_name')).ip %>
+-<% proxy_index = p('cf_mysql.proxy.proxy_ips').index(my_ip) %>
+-host: <%= my_ip %>
++<% my_host = spec.networks.send(p('network_name')).dns_record_name %>
++<% proxy_index = p('cf_mysql.proxy.proxy_ips').index(my_host) %>
++host: <%= my_host %>
+ routes:
+ - name: "proxy_<%= index %>"
+   port: <%= p('cf_mysql.proxy.api_port') %>
+EOF
+
+touch "${SENTINEL}"
+exit 0

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -159,6 +159,7 @@ roles:
 - name: mysql-proxy
   scripts:
   - fake_spec_index_on_ucp.sh
+  - fix_mysql_proxy_host_list.sh
   jobs:
   - name: proxy
     release_name: cf-mysql


### PR DESCRIPTION
We don't really deal with IP addresses; instead, we deal in host names. This makes it more possible to find the instance in the list so it can give a correct index.

Once CAPS-317 is fixed, the role manifest will need to use the new environment variables to build the list.

Unlike #348 we don't do anything about adding a LB role (that's UCP's job). We also don't do anything about the manual indexed roles because that wouldn't produce the correct result; all the instances need a shared name (which UCP should supply) instead.

After applying this PR, in a `mysql-proxy` instance, `/var/vcap/jobs/proxy/config/route-registrar.yml` should have the correct index in the `host:` field.
