### PR TITLE
HCF-635 Enable some previously skipped test suites

### DIFF
--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -2,6 +2,17 @@
 properties:
   acceptance_tests:
     skip_ssl_validation: true
+    backend: diego
+    include_diego_ssh: true
+    include_diego_docker: true
+    include_backend_compatibility: false
+    include_v3: false
+    include_security_groups: true
+    include_logging: true
+    include_operator: true
+    include_internet_dependent: true
+    include_services: true
+    include_route_services: false
   app_domains:
   - example.com
   app_ssh: null

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1527,17 +1527,6 @@ configuration:
     properties.acceptance_tests.apps_domain: '"((DOMAIN))"'
     properties.acceptance_tests.admin_user: '"((CLUSTER_ADMIN_USERNAME))"'
     properties.acceptance_tests.admin_password: '"((CLUSTER_ADMIN_PASSWORD))"'
-    properties.acceptance_tests.backend: diego
-    properties.acceptance_tests.include_diego_ssh: true
-    properties.acceptance_tests.include_diego_docker: true
-    properties.acceptance_tests.include_backend_compatibility: false
-    properties.acceptance_tests.include_v3: false
-    properties.acceptance_tests.include_security_groups: true
-    properties.acceptance_tests.include_logging: true
-    properties.acceptance_tests.include_operator: true
-    properties.acceptance_tests.include_internet_dependent: true
-    properties.acceptance_tests.include_services: true
-    properties.acceptance_tests.include_route_services: false
     properties.app_domains: '["((DOMAIN))"]'
     properties.app_ssh.host_key_fingerprint: '"((APP_SSH_HOST_KEY_FINGERPRINT))"'
     properties.cc.bulk_api_password: '"((BULK_API_PASSWORD))"'


### PR DESCRIPTION
See the bug's comments for the logic behind which suite is enabled or skipped.

The `properties.acceptance_tests.backend: diego` is to skip every test that is not supported on Diego (`{NO_DIEGO_SUPPORT}` tag)
