### PR TITLE
make/compile: Do not extract from empty archives

### DIFF
--- a/make/compile
+++ b/make/compile
@@ -43,7 +43,7 @@ restore() {
 
     for package_version in $(get_package_version_list) ; do
         archive="${HCF_PACKAGE_COMPILATION_CACHE}/${package_version}/compiled.tar"
-        test -r "${archive}" || {
+        test -r "${archive}" -a -s "${archive}" || {
             echo "Missing:   ${archive}"
             continue
         }


### PR DESCRIPTION
Sometimes we end up with empty (zero-byte long) compilation cache archives. In that case, do not attempt to extract anything, since that will fail.
