### PR TITLE
make/compile cache: Don't create empty tar files for missing directories

### DIFF
--- a/make/compile
+++ b/make/compile
@@ -26,6 +26,10 @@ cache() {
             echo "Found:   ${archive}"
             continue
         }
+        test -d "${FISSILE_WORK_DIR}/compilation/${package_version}/compiled" || {
+            echo "Missing: ${package_version}/compiled"
+            continue
+        }
         mkdir -p "$(dirname "${archive}")"
         echo "Creating ${archive}"
         tar cf "${archive}" -C "${FISSILE_WORK_DIR}/compilation/${package_version}/" compiled


### PR DESCRIPTION
If the thing to archive is missing, tar bails out _after_ creating the (empty) archive.  This makes extraction attempts fail.  Don't create the silly empty archive in the first place.  Should also mean we don't bail out and manage to cache more things.
