### PR TITLE
Vagrant: make docker allow insecure registries on 192.168.* by default

### DIFF
--- a/container-host-files/opt/hcf/bin/docker/configure_docker.sh
+++ b/container-host-files/opt/hcf/bin/docker/configure_docker.sh
@@ -43,6 +43,9 @@ dopts="$dopts --storage-opt dm.datadev=/dev/vg-docker/data"
 dopts="$dopts --storage-opt dm.metadatadev=/dev/vg-docker/metadata"
 dopts="$dopts --storage-opt dm.basesize=100G"
 
+# By default, whitelist local network as insecure registry (to work on UCP)
+dopts="$dopts --insecure-registry=192.168.0.0/16"
+
 for var in http_proxy https_proxy no_proxy HTTP_PROXY HTTPS_PROXY NO_PROXY ; do
   if test -n "${!var}" ; then
     echo "export ${var}=${!var}" >> /etc/default/docker


### PR DESCRIPTION
This makes it easier to do test builds for UCP.
