### PR TITLE
Change HCP generation to use version tags

### DIFF
--- a/make/generate
+++ b/make/generate
@@ -16,7 +16,7 @@ OPTIONS=$(echo \
     --dtr \"${IMAGE_REGISTRY}\" \
     --dtr-org \"${IMAGE_ORG}\" \
     --hcf-prefix \"${IMAGE_PREFIX}\" \
-    --hcf-tag \"${GIT_BRANCH}\" \
+    --hcf-tag \"${DOCKER_ARTIFACT_VERSION}\" \
     --hcf-version \"${ARTIFACT_VERSION}\" \
     --env-dir \"${ENV_DIR}\"
 )

--- a/make/images
+++ b/make/images
@@ -7,8 +7,6 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 . ${GIT_ROOT}/make/include/registry
 . ${GIT_ROOT}/make/include/versioning
 
-APP_VERSION=$(echo ${APP_VERSION} | tr + _)
-
 TARGET=${1}
 ACTION=${2}
 
@@ -38,11 +36,11 @@ for ROLE in ${ROLES}; do
                     TAG=latest
                 ;;
             esac
-            docker tag ${PREFIX}${ROLE}:${TAG} ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${APP_VERSION}
+            docker tag ${PREFIX}${ROLE}:${TAG} ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${DOCKER_ARTIFACT_VERSION}
             docker tag ${PREFIX}${ROLE}:${TAG} ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}
             ;;
         publish)
-            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${APP_VERSION}
+            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${DOCKER_ARTIFACT_VERSION}
             docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}
             ;;
         clean)
@@ -62,7 +60,7 @@ for ROLE in ${ROLES}; do
             esac
             # For all images, there may be things tagged for the registry for the wrong branch
             docker images ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE} | tail -n +2 | while read REPOSITORY TAG _; do
-                if test "${TAG}" != "${APP_VERSION}" -a "${TAG}" != "${GIT_BRANCH}" ; then
+                if test "${TAG}" != "${DOCKER_ARTIFACT_VERSION}" -a "${TAG}" != "${GIT_BRANCH}" ; then
                     docker rmi "${REPOSITORY}:${TAG}"
                 fi
             done

--- a/make/include/versioning
+++ b/make/include/versioning
@@ -16,5 +16,6 @@ GIT_SHA=${GIT_SHA:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $3 }' )}
 
 ARTIFACT_NAME=${ARTIFACT_NAME:-$(basename $(git config --get remote.origin.url) .git | sed s/^hcf-//)}
 ARTIFACT_VERSION=${GIT_TAG}+${GIT_COMMITS}.${GIT_SHA}.${GIT_BRANCH}
+DOCKER_ARTIFACT_VERSION=$(echo ${ARTIFACT_VERSION} | tr + _)
 
 APP_VERSION=${ARTIFACT_NAME}-${ARTIFACT_VERSION}

--- a/make/print-version
+++ b/make/print-version
@@ -12,6 +12,6 @@ case ${DOCKER_FRIENDLY_TAGS} in
         echo ${APP_VERSION}
         ;;
     *)
-        echo ${APP_VERSION} | tr + _
+        echo ${DOCKER_ARTIFACT_VERSION}
         ;;
 esac


### PR DESCRIPTION
- Don't use develop/master in things we ship to people because they can
  change, remove them from the hcp generation in favor of the full
  version tag.
