### PR TITLE
Transformer: HCP: Limit service port names to 15 characters

### DIFF
--- a/bin/rm-transformer/hcp.rb
+++ b/bin/rm-transformer/hcp.rb
@@ -337,8 +337,14 @@ class ToHCP < Common
   end
 
   def convert_port(port)
+    name = port['name']
+    if name.length > 15
+      # Service ports must have a length no more than 15 characters
+      # (to be a valid host name)
+      name = "#{name[0...8]}#{name.hash.to_s(16)[-8...-1]}"
+    end
     {
-      'name'        => port['name'],
+      'name'        => name,
       'protocol'    => port['protocol'],
       'source_port' => port['source'],
       'target_port' => port['target'],


### PR DESCRIPTION
This is a HCP limitation as they use it as a host name, and that has limits on the length and character set.

HCP output:

```
{"code":400,"message":"Component 'routing-ha-proxy', service_port 'tcp-routing-60000' has a name exceeding 15 characters (not a valid IANA_SVC_NAME)\nComponent 'routing-ha-proxy', service_port 'tcp-routing-60001' has a name exceeding 15 characters (not a valid IANA_SVC_NAME)"}
```
