### PR TITLE
Fix versioning for git 2.9

### DIFF
--- a/make/include/versioning
+++ b/make/include/versioning
@@ -8,7 +8,7 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 GIT_DESCRIBE=${GIT_DESCRIBE:-$(git describe --tags --long)}
-GIT_BRANCH=${GIT_BRANCH:-$(git name-rev --name-only HEAD | sed -e 's/[^-a-zA-Z0-9_.]/_/g')}
+GIT_BRANCH=${GIT_BRANCH:-$(git name-rev --refs="refs/heads/*" --name-only HEAD | sed -e 's/[^-a-zA-Z0-9_.]/_/g')}
 
 GIT_TAG=${GIT_TAG:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $1 }' )}
 GIT_COMMITS=${GIT_COMMITS:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $2 }' )}


### PR DESCRIPTION
- It was using tags instead of branch names, force it to use branch
  names by specifying the heads refs
