### PR TITLE
HCF-663 Revert "HCF-663 NET_ADMIN not needed"

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1092,7 +1092,7 @@ roles:
       indexed: 1
       min: 1
       max: 1
-    capabilities: []
+    capabilities: ['NET_ADMIN']
     persistent-volumes: []
     shared-volumes: []
     memory: 1024


### PR DESCRIPTION
Looks like dnsmasq still needs NET_ADMIN even when using a non-admin port:

```
/ # dnsmasq -k -p 8600 --log-facility=-
dnsmasq[21]: setting capabilities failed: Operation not permitted
dnsmasq[21]: FAILED to start up
```

This reverts commit 6791372a6e0e173ae6e7582c8cf745000cfb1d37.
