### PR TITLE
HCF-754-755 Add error message on bad config folder

### DIFF
--- a/container-host-files/opt/hcf/bin/run-role.sh
+++ b/container-host-files/opt/hcf/bin/run-role.sh
@@ -12,6 +12,11 @@ setup_dir="$1"
 role_name="$2"
 shift 2
 
+if [ ! -d "$setup_dir" ]; then
+    echo 1>&2 "Config directory does not exist"
+    exit 1
+fi
+
 # Terraform, in HOS/MPC VM, hcf-infra container support as copied
 # SELF    = /opt/hcf/bin/list-roles.sh
 # SELFDIR = /opt/hcf/bin


### PR DESCRIPTION
I thought I'd add a check [in start_role](https://github.com/hpcloud/hcf/blob/c8720d648322950c633e338b77011fc8359265b7/container-host-files/opt/hcf/bin/common.sh#L52), which would also check for empty env files.
But I didn't know if there was a chance a role could intentionally start without settings, so I figured I'd add the directory check at the source, run-role.sh, instead.

This probably isn't enough to close HCF-754 and HCF-755 yet, as there are some doubts in the AWS build itself. Not sure if I should put it in code review yet.
