### PR TITLE
COPS-43: Add routing-release to things to build

### DIFF
--- a/make/include/fissile
+++ b/make/include/fissile
@@ -14,6 +14,7 @@ if test -z ${FISSILE_RELEASE:-''}; then
       garden-linux-release
       cf-mysql-release
       cflinuxfs2-rootfs-release
+      routing-release
       hcf-release
       hcf-sso/hcf-sso-release
       windows-runtime-release


### PR DESCRIPTION
This wasn't broken for vagrant because that uses .fissilerc
