### PR TITLE
Add open-Autoscaler to make/include/fissile

### DIFF
--- a/make/include/fissile
+++ b/make/include/fissile
@@ -17,6 +17,7 @@ if test -z ${FISSILE_RELEASE:-''}; then
       hcf-release
       hcf-sso/hcf-sso-release
       windows-runtime-release
+      open-Autoscaler/bosh-release
     '); do
         FISSILE_RELEASE=${FISSILE_RELEASE},${GIT_ROOT}/src/${RELEASE};
     done


### PR DESCRIPTION
Bug reference: https://jira.hpcloud.net/browse/COPS-43

open-Autoscaler is missing make/include/fissile which result in `make -C src compile` to fail.

```
.+ export FISSILE_DEV_CACHE_DIR=/tmp/build/4a67f4d7/bosh-cache
+ FISSILE_DEV_CACHE_DIR=/tmp/build/4a67f4d7/bosh-cache
+ export FISSILE_WORK_DIR=/tmp/build/4a67f4d7/work-dir
+ FISSILE_WORK_DIR=/tmp/build/4a67f4d7/work-dir
+ make -C src compile
make: Entering directory `/tmp/build/4a67f4d7/src'
/tmp/build/4a67f4d7/src/make/compile
Please allow a long time for mariadb to compile
Error loading roles manifest: Error - release cf-open-autoscaler has not been loaded and is referenced by job autoscaler_api in role autoscaler-api.
make: *** [compile] Error 1
make: Leaving directory `/tmp/build/4a67f4d7/src'
+ stop_docker
```
