### PR TITLE
HCF-652 Don't chown the generated autoscaler files

### DIFF
--- a/make/generate-autoscaler-blobs
+++ b/make/generate-autoscaler-blobs
@@ -24,7 +24,6 @@ for x in api server servicebroker ; do
        --workdir ${GIT_ROOT}/src/open-Autoscaler/$x \
        --entrypoint bash \
        ${DOCKER_RUNTIME} -l -c "rm -rf ./$x/target/ && mvn clean package -P${AUTOSCALER_PROFILE} -DskipTests"
-    sudo chown -R $USER:$USER $x/target
   fi
 done
 


### PR DESCRIPTION
Not sure why this was done in the first place; at least on VMware Fusion
the generated files are already owned by the vagrant user.  And `chown`ing
any files that are actually mounted from the host doesn't work, even with
`sudo`.
