### PR TITLE
packer: libvirt: install nfs packages

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,7 +69,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider "libvirt" do |libvirt, override|
-    override.vm.box = "https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-libvirt-v1.0.7.box"
+    override.vm.box = "https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-libvirt-v1.0.8.box"
     libvirt.driver = "kvm"
     # Allow downloading boxes from sites with self-signed certs
     override.vm.box_download_insecure = true

--- a/packer/scripts/qemu_tools.sh
+++ b/packer/scripts/qemu_tools.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+# Install files needed for NFS shares
+apt-get -qy install nfs-common portmap

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "1.0.7",
+        "version": "1.0.8",
         "vm_name": "hcf-vagrant-{{isotime \"20060102-1504\"}}",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",
@@ -81,6 +81,7 @@
             "vm_name": "{{user `vm_name`}}",
             "disk_size": 100000,
             "disk_interface": "scsi",
+            "disk_compression": true,
             "ssh_username": "{{user `ssh_username`}}",
             "ssh_password": "{{user `ssh_password`}}",
             "iso_url": "{{user `iso_url`}}",
@@ -130,6 +131,15 @@
             "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
             "scripts": [
                 "scripts/virtualbox_tools.sh"
+            ],
+            "start_retry_timeout": "7m"
+        },
+        {
+            "type": "shell",
+            "only": ["qemu"],
+            "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
+            "scripts": [
+                "scripts/qemu_tools.sh"
             ],
             "start_retry_timeout": "7m"
         },


### PR DESCRIPTION
These are required for NFS to work out of the box (without downloading packages off the internet); it helps getting the box running on networks without direct internet access.

Also compress the disk images by default.  New option in newer versions of packer.
