### PR TITLE
HCF-802: Move the healthcheck port for routing-ha-proxy

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -398,7 +398,7 @@ roles:
     - name: 'healthcheck'
       protocol: TCP
       source: 80
-      target: 80
+      target: 2341
       public: true
     - name: 'tcp-routing'
       protocol: TCP


### PR DESCRIPTION
It must not overlap with the port we expose for the non-routing ha-proxy, at least on vagrant.
