### PR TITLE
[HCFRO-314] - HCP Logging: rsyslog configuration 

### DIFF
--- a/container-host-files/etc/hcf/config/forward_logfiles.sh
+++ b/container-host-files/etc/hcf/config/forward_logfiles.sh
@@ -1,0 +1,161 @@
+#used for initial config
+MAIN_CONFIG="90-vcap.conf"
+RSYSLOG_CONF_DIR="/etc/rsyslog.d"
+
+#used for adding individual logs
+BACKUP_WATCH_DIR=/var/vcap/sys/log #in case no ENV variable is set for RSYSLOG_FORWARDER_WATCH_DIR
+RSYSLOG_CONF_PREFIX=91-vcap
+RSYSLOG_CONF_DIR=/etc/rsyslog.d
+IGNORE_DIR="gocode"
+TARGET_NAME=
+TARGET_BASENAME=
+
+SCRIPT_FILE=/usr/sbin/forward_logfiles.sh
+PB_OUT=/usr/sbin/pb.out
+
+if [ ! -f $SCRIPT_FILE ]; then
+	echo "#log forwarding script" > $PB_OUT
+fi
+
+if [ -z "$RSYSLOG_FORWARDER_WATCH_DIR" ]; then
+        RSYSLOG_FORWARDER_WATCH_DIR=$BACKUP_WATCH_DIR
+        echo "RSYSLOG_FORWARDER_WATCH_DIR not set. Using default $BACKUP_WATCH_DIR" >> $PB_OUT
+fi
+
+if [ ! -d "$RSYSLOG_FORWARDER_WATCH_DIR" ]; then
+        echo "$RSYSLOG_FORWARDER_WATCH_DIR is not a valid directory" >> $PB_OUT
+fi
+
+function appendToCron {
+	echo appending to cron
+	if [ ! -z "$HCP_FLIGHTRECORDER_HOST" ]; then
+                if [ -z "$HCP_FLIGHTRECORDER_PORT" ]; then
+                        HCP_FLIGHTRECORDER_PORT=514
+                fi
+                crontab -l > tempcrontab
+                echo "export _HCP_FLIGHT_RECORDER=$HCP_FLIGHTRECORDER_HOST:$HCP_FLIGHTRECORDER_PORT" >> $SCRIPT_FILE
+                echo "export RSYSLOG_FORWARDER_WATCH_DIR=$RSYSLOG_FORWARDER_WATCH_DIR" >> $SCRIPT_FILE
+                cat $0 >> $SCRIPT_FILE
+                echo "*/1 * * * * bash $SCRIPT_FILE >> /dev/null 2>&1" >> tempcrontab
+                crontab tempcrontab
+        else
+		
+                echo "HCP_FLIGHTRECORDER_HOST env var missing. Not adding log forwarding to cron." >> $SCRIPT_FILE
+                exit 0
+        fi
+}
+
+#check if cron has something in it
+crontab -l 1>>$PB_OUT 2>>$PB_OUT
+if [ $? -ne 0 ]; then
+	echo "#creating cron conf as it does not exist yet" >> $PB_FILE
+	appendToCron
+else
+	#put the script in cron if it is not there already
+	crontab -l | grep forward_logfiles.sh
+
+	if [ $? -ne 0 ]; then
+        	appendToCron
+	fi	
+fi
+
+
+#create the file that will forward all messages to flight recorder
+function initialConfig {
+
+        echo "module(load=\"imfile\" mode=\"polling\")" > $RSYSLOG_CONF_DIR/$MAIN_CONFIG
+        echo "\$template RFC5424Format,\"<13>%protocol-version% 2016-07-20T09:03:00.329650+00:00 %HOSTNAME% %app-name% - - - %msg%\n\"" >> $RSYSLOG_CONF_DIR/$MAIN_CONFIG
+        echo "\$ActionFileDefaultTemplate RFC5424Format" >> $RSYSLOG_CONF_DIR/$MAIN_CONFIG
+        echo "\$RepeatedMsgReduction on" >> $RSYSLOG_CONF_DIR/$MAIN_CONFIG
+        echo \*.\* @@$HCP_FLIGHTRECORDER_HOST:$HCP_FLIGHTRECORDER_PORT >> $RSYSLOG_CONF_DIR/$MAIN_CONFIG
+        echo ":app-name, contains, \"vcap\"" ~ >> $RSYSLOG_CONF_DIR/$MAIN_CONFIG
+
+        if [ $? -ne 0 ]; then
+                echo "Rsyslog forwarder: Could not create $MAIN_CONFIG in $RSYSLOG_CONF_DIR" >> $PB_OUT
+                exit 0
+        fi
+
+        if [[ ! -f "$RSYSLOG_CONF_DIR/$MAIN_CONFIG" ]]; then
+                echo "Rsyslog forwarder: File $MAIN_CONFIG not found in $RSYSLOG_CONF_DIR" >> $PB_OUT
+                exit 0
+        fi
+}
+
+#search is there are more logs to be monitored by rsyslog
+function searchTargetDir {
+        filesAdded=1
+        for file in $1/*
+        do
+                if [ -d $file ]; then
+                        ignored=false
+                        for ignore in $IGNORE_DIR
+                        do
+                                if [[ $file == $RSYSLOG_FORWARDER_WATCH_DIR/$ignore ]]; then
+                                        echo "Ignoring $file directory"
+                                        ignored=true
+                                fi
+                        done;
+                        if [ $ignored == false ]; then
+                                if searchTargetDir $file; then
+                                        filesAdded=0
+                                fi
+                        fi
+                else
+                        if [ "${file: -4}" == ".log" ]; then
+                                targetName $file
+                                if checkConfigExists $file; then
+                                        echo $TARGET_NAME exists
+                                else
+                                        echo "Creating $TARGET_NAME"
+                                        createTargetConf $file
+                                        filesAdded=0
+                                fi
+                        fi
+                fi
+        done
+        return $filesAdded
+}
+
+#Create the rsyslog configuration file inside rsysconf.d
+function createTargetConf {
+        echo "\$InputFileName $1" > $TARGET_NAME
+        echo "\$InputFileTag vcap-$TARGET_BASENAME" >> $TARGET_NAME
+        echo "\$InputFileStateFile ${TARGET_BASENAME}_state" >> $TARGET_NAME
+        echo "\$InputFileFacility local7" >> $TARGET_NAME
+        echo "\$InputRunFileMonitor" >> $TARGET_NAME
+}
+
+function targetName {
+        filename=$(basename $1)
+        TARGET_BASENAME="${filename%.*}"
+}
+
+function checkConfigExists {
+        TARGET_NAME=$RSYSLOG_CONF_DIR/$RSYSLOG_CONF_PREFIX-$TARGET_BASENAME.conf
+        if [ -f $TARGET_NAME ]; then
+                return 0
+        else
+                return 1
+        fi
+}
+
+#check if the forwarding conf is set up
+if [ ! -f $RSYSLOG_CONF_DIR/$MAIN_CONFIG ]; then
+      if [ -z $HCP_FLIGHTRECORDER_HOST ]; then
+              echo "HCP_FLIGHTRECORDER_HOST not set" >> $PB_OUT
+              exit 0
+      fi
+      if [ -z $HCP_FLIGHTRECORDER_PORT ]; then
+	      HCP_FLIGHTRECORDER_PORT=514
+      fi
+      _HCP_FLIGHT_RECORDER=$HCF_FLIGHTRECORDER_HOST:$HCF_FLIGHTRECORDER_PORT
+      echo creating initial config for forwarding
+      initialConfig
+else
+      echo initial config for forwarding exists
+fi
+
+#make sure the logs configs are added to rsyslog.d folder
+if searchTargetDir $RSYSLOG_FORWARDER_WATCH_DIR; then
+      service rsyslog restart
+fi

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -4,6 +4,7 @@ roles:
   scripts:
   - fake_spec_index_on_hcp.sh
   - fix-nats-log-dir.sh
+  - forward_logfiles.sh
   jobs:
   - name: nats
     release_name: cf
@@ -42,6 +43,7 @@ roles:
 - name: consul
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: consul_agent
     release_name: cf
@@ -108,6 +110,7 @@ roles:
   scripts:
   - fake_spec_index_on_hcp.sh
   - fix_mysql_advertise_ip.sh
+  - forward_logfiles.sh
   jobs:
   - name: mysql
     release_name: cf-mysql
@@ -165,6 +168,7 @@ roles:
   scripts:
   - fake_spec_index_on_hcp.sh
   - fix_mysql_proxy_host_list.sh
+  - forward_logfiles.sh
   jobs:
   - name: proxy
     release_name: cf-mysql
@@ -218,6 +222,7 @@ roles:
 - name: diego-database
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: bbs
     release_name: diego
@@ -266,6 +271,7 @@ roles:
 - name: ha-proxy
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: haproxy
     release_name: cf
@@ -316,6 +322,7 @@ roles:
   - fake_spec_index_on_hcp.sh
   - router_internal_host_names.sh
   - authorize_internal_ca.sh
+  - forward_logfiles.sh
   jobs:
   - name: gorouter
     release_name: routing
@@ -350,6 +357,7 @@ roles:
   # But this is a _different_ HAProxy from the one in the CF release.
   scripts:
   - router_internal_host_names.sh
+  - forward_logfiles.sh
   jobs:
   - name: haproxy
     release_name: routing
@@ -395,6 +403,7 @@ roles:
   scripts:
   - router_internal_host_names.sh
   - authorize_internal_ca.sh
+  - forward_logfiles.sh
   jobs:
   - name: consul_agent
     release_name: cf
@@ -450,6 +459,7 @@ roles:
   scripts:
   - fake_spec_index_on_hcp.sh
   - fix_uaa_hostnames_in_uaa_yml.sh
+  - forward_logfiles.sh
   jobs:
   - name: uaa
     release_name: cf
@@ -499,6 +509,7 @@ roles:
   - cloud_controller_v2_droplet_count.sh
   - fix_buildpack_install.sh
   - authorize_internal_ca.sh
+  - forward_logfiles.sh
   jobs:
   - name: cloud_controller_ng
     release_name: cf
@@ -571,6 +582,7 @@ roles:
 - name: api-worker
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: cloud_controller_worker
     release_name: cf
@@ -602,6 +614,7 @@ roles:
 - name: blobstore
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: blobstore
     release_name: cf
@@ -646,6 +659,7 @@ roles:
 - name: clock-global
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: cloud_controller_clock
     release_name: cf
@@ -674,6 +688,7 @@ roles:
 - name: cf-usb
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: cf-usb
     release_name: cf-usb
@@ -717,6 +732,7 @@ roles:
 - name: doppler
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: doppler
     release_name: cf
@@ -757,6 +773,7 @@ roles:
 - name: etcd
   scripts:
   - fix_etcd_bootstrap.sh
+  - forward_logfiles.sh
   jobs:
   - name: etcd
     release_name: cf
@@ -813,6 +830,7 @@ roles:
 - name: loggregator
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: loggregator_trafficcontroller
     release_name: cf
@@ -851,6 +869,7 @@ roles:
 - name: diego-brain
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: consul_agent
     release_name: cf
@@ -886,6 +905,7 @@ roles:
 - name: diego-cc-bridge
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: stager
     release_name: cf
@@ -974,6 +994,7 @@ roles:
 - name: diego-route-emitter
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: route_emitter
     release_name: diego
@@ -1001,6 +1022,7 @@ roles:
 - name: diego-access
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: ssh_proxy
     release_name: diego
@@ -1046,6 +1068,7 @@ roles:
   - prevent_apparmor_disable.sh
   - configure-nested-net.sh
   - cleanup-garden-graph.sh
+  - forward_logfiles.sh
   jobs:
   - name: rep
     release_name: diego
@@ -1084,6 +1107,7 @@ roles:
   scripts:
   - configgin-config-properties.sh
   - wait_for_couchdb.sh
+  - forward_logfiles.sh
   jobs:
   - name: autoscaler_api
     release_name: cf-open-autoscaler
@@ -1117,6 +1141,7 @@ roles:
   scripts:
   - configgin-config-properties.sh
   - wait_for_couchdb.sh
+  - forward_logfiles.sh
   jobs:
   - name: autoscaler_server
     release_name: cf-open-autoscaler
@@ -1147,6 +1172,7 @@ roles:
   scripts:
   - configgin-config-properties.sh
   - wait_for_couchdb.sh
+  - forward_logfiles.sh
   jobs:
   - name: autoscaler_servicebroker
     release_name: cf-open-autoscaler
@@ -1324,6 +1350,7 @@ roles:
 - name: hcf-sso
   scripts:
   - fake_spec_index_on_hcp.sh
+  - forward_logfiles.sh
   jobs:
   - name: hcf-sso
     release_name: hcf-sso


### PR DESCRIPTION
Add forwarding for logfiles towards Flightrecorder

The script will put itself in cron and will be run periodically to check if there are new logs in the configured scanned directory to forward. If new logs are found the will also be forwarded towards the configured flightrecorder server.
The script adds new configuration files to rsyslog.d directory and restarts the service if new logs are found.
Rsyslog does the forwarding.
