### PR TITLE
HCF-809 Implement exponential backoff for all 3 post-deployment scripts

### DIFF
--- a/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
+++ b/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
@@ -47,8 +47,26 @@ if_p("hcf_set_proxy.api_proxy") do |val|
 end
 %>
 
+# helper function to retry a command several times, with a delay between trials
+# usage: retry <max-tries> <delay> <command>...
+function retry () {
+    max=${1}
+    delay=${2}
+    i=0
+    shift 2
+
+    while test ${i} -lt ${max} ; do
+        if "$@" ; then
+            break
+        fi
+        sleep "${delay}"
+        i="$(expr ${i} + 1)"
+    done
+}
+
+
 <% skip_ssl_validation = properties.ssl.skip_cert_verify ? '--skip-ssl-validation' : '' %>
-cf api <%= skip_ssl_validation %> api.<%= properties.system_domain %>
+retry 240 30s    cf api <%= skip_ssl_validation %> api.<%= properties.system_domain %>
 <% 
 username, password = properties.uaa.scim.users.detect{|u|u.include? 'cloud_controller.admin'}.split('|')[0..1]
 %>

--- a/src/hcf-release/jobs/hcf-sso-routing/templates/run.erb
+++ b/src/hcf-release/jobs/hcf-sso-routing/templates/run.erb
@@ -10,11 +10,15 @@ export PATH=/var/vcap/packages/cli/bin:${PATH}
 function retry () {
     max=${1}
     delay=${2}
+    i=0
     shift 2
 
-    for i in $(seq "${max}")
-    do
-        "$@" && break || sleep "${delay}"
+    while test ${i} -lt ${max} ; do
+        if "$@" ; then
+            break
+        fi
+        sleep "${delay}"
+        i="$(expr ${i} + 1)"
     done
 }
 
@@ -24,13 +28,11 @@ function retry () {
 skip_ssl_validation = properties.ssl.skip_cert_verify ? '--skip-ssl-validation' : ''
 username, password = properties.uaa.scim.users.detect{|u|u.include? 'cloud_controller.admin'}.split('|')[0..1]
 %>
-retry 10 30s    cf api <%= skip_ssl_validation %> api.<%= properties.system_domain %>
+retry 240 30s    cf api <%= skip_ssl_validation %> api.<%= properties.system_domain %>
 cf auth <%= username.shellescape %> <%= password.shellescape %>
 
 echo "Waiting for SSO Routing service broker..."
-while ! curl --fail --silent --insecure https://<%= p("hcf_sso.host") %>:<%= p("hcf_sso.port") %>/ping >/dev/null 2>&1; do
-    sleep 10
-done
+retry 240 30s    curl --fail --silent --insecure https://<%= p("hcf_sso.host") %>:<%= p("hcf_sso.port") %>/ping >/dev/null 2>&1
 
 echo "Registering SSO Routing service broker..."
 

--- a/src/hcf-release/jobs/usb-create-services/templates/run.erb
+++ b/src/hcf-release/jobs/usb-create-services/templates/run.erb
@@ -8,10 +8,26 @@ cf plugins | grep -q cf-plugin-usb || {
   cf install-plugin /var/vcap/packages/cf-plugin-usb/bin/cf-plugin-usb
 }
 
-#TODO: check for ssl validation property
+# helper function to retry a command several times, with a delay between trials
+# usage: retry <max-tries> <delay> <command>...
+function retry () {
+    max=${1}
+    delay=${2}
+    i=0
+    shift 2
+
+    while test ${i} -lt ${max} ; do
+        if "$@" ; then
+            break
+        fi
+        sleep "${delay}"
+        i="$(expr ${i} + 1)"
+    done
+}
+
 
 <% skip_ssl_validation = properties.ssl.skip_cert_verify ? '--skip-ssl-validation' : '' %>
-for i in {1..10}; do cf api <%= skip_ssl_validation %> api.<%= properties.system_domain %> && break || sleep 30; done
+retry 240 30s    cf api <%= skip_ssl_validation %> api.<%= properties.system_domain %>
 <% 
 username, password = properties.uaa.scim.users.detect{|u|u.include? 'cloud_controller.admin'}.split('|')[0..1]
 %>


### PR DESCRIPTION
Previously, some of our post deployment scripts implemented retries by simply failing and letting the runner (docker, HCP) retry on our behalf.

Unfortunately, in HCP this ended up retrying too often and leaving around many dead containers, which put pressure on the system and caused failures due to stress.  Instead, implement exponential retries in all three scripts such that the system get a chance to recover without creating these dead containers.  The current configurations will retry for up to around two hours (with the initial wait being around 30 seconds).
