### PR TITLE
Cert updates for SDL and internal_ca bash script

### DIFF
--- a/container-host-files/etc/hcf/config/authorize_internal_ca.sh
+++ b/container-host-files/etc/hcf/config/authorize_internal_ca.sh
@@ -6,5 +6,5 @@ if [ -r /etc/secrets/internal-ca-cert ]; then
   INTERNAL_CA_CERT=`cat /etc/secrets/internal-ca-cert`;
 fi
 
-echo -e ${INTERNAL_CA_CERT} > /usr/local/share/ca-certificates/internalCA.crt
+echo -e "${INTERNAL_CA_CERT}" > /usr/local/share/ca-certificates/internalCA.crt
 update-ca-certificates

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1922,6 +1922,9 @@ configuration:
       type: Certificate
       value_type: certificate
       key_length: 4096
+      subject_alt_names:
+        - static: server.dc1.hcf
+          wildcard: false
   - name: CONSUL_SERVER_KEY
     secret: true
     generator:


### PR DESCRIPTION
1. CONSUL_SERVER_CERT missing server.dc1.hcf hostname in SANs
2. echo of internal ca cert without quotes does not preserve newlines '\n'
