### PR TITLE
HCF-727 Bump docker version for dns fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb, override|
     # Need to shorten the URL for Windows' sake
-    override.vm.box = "https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-virtualbox-v1.0.9.box"
+    override.vm.box = "https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-virtualbox-v1.0.10.box"
 
     # Customize the amount of memory on the VM:
     vb.memory = "8192"
@@ -40,7 +40,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider "vmware_fusion" do |vb, override|
-    override.vm.box="https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-vmware-v1.0.9.box"
+    override.vm.box="https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-vmware-v1.0.10.box"
 
     # Customize the amount of memory on the VM:
     vb.memory = "8192"
@@ -65,7 +65,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider "vmware_workstation" do |vb, override|
-    override.vm.box="https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-vmware-v1.0.9.box"
+    override.vm.box="https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-vmware-v1.0.10.box"
 
     # Customize the amount of memory on the VM:
     vb.memory = "8192"
@@ -87,7 +87,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider "libvirt" do |libvirt, override|
-    override.vm.box = "https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-libvirt-v1.0.9.box"
+    override.vm.box = "https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-libvirt-v1.0.10.box"
     libvirt.driver = "kvm"
     # Allow downloading boxes from sites with self-signed certs
     override.vm.box_download_insecure = true

--- a/container-host-files/opt/hcf/bin/docker/install_docker.sh
+++ b/container-host-files/opt/hcf/bin/docker/install_docker.sh
@@ -11,12 +11,14 @@ if test $(id -u) -ne '0' ; then
     exit $?
 fi
 
-apt-get update && \
-apt-get install apt-transport-https ca-certificates -y && \
-apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
-echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
-apt-get update && \
-apt-get install docker-engine=1.12.0-0~trusty lvm2 -y && \
+apt-get update
+apt-get install apt-transport-https ca-certificates -y
+apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+
+echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list
+
+apt-get update
+apt-get install docker-engine=1.12.0-0~trusty lvm2 -y
 usermod -aG docker $user
 
 # Note: lvm2 is needed by configure_docker.sh (pvcreate, etc.)

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "1.0.9",
+        "version": "1.0.10",
         "vm_name": "hcf-vagrant-{{isotime \"20060102-1504\"}}",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",


### PR DESCRIPTION
Move to Docker 1.12.0. New Vagrant boxes have been built and uploaded.
