### PR TITLE
HCF-833 Tag status-route container as dev-only

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1345,6 +1345,8 @@ roles:
       target: 3000
       public: false
 - name: status-route
+  tags:
+  - dev-only
   post_config_scripts:
   - status-route-start.sh
   jobs:


### PR DESCRIPTION
It doesn't work on HCP (requires `docker.sock`).
