### PR TITLE
HCF-827 Remove interactive + tty options for run-role.sh

### DIFF
--- a/container-host-files/opt/hcf/bin/common.sh
+++ b/container-host-files/opt/hcf/bin/common.sh
@@ -75,7 +75,7 @@ function start_role {
   mkdir -p ${log_dir}/${role}
 
   function _do_start_role() {
-    docker run -it --name ${name} \
+    docker run --name ${name} \
         ${detach} \
         --net=hcf \
         --dns-search=hcf \


### PR DESCRIPTION
The user can still supply them on the command line.
