### PR TITLE
HCF-824 Reduce port count for hcp transformer

### DIFF
--- a/bin/rm-transformer/hcp.rb
+++ b/bin/rm-transformer/hcp.rb
@@ -314,7 +314,7 @@ class ToHCP < Common
     }
   end
 
-  MAX_EXTERNAL_PORT_COUNT = 100
+  MAX_EXTERNAL_PORT_COUNT = 10
   EXTERNAL_PORT_UPPER_BOUND = 29999
   def add_ports(component, ports)
     cname = component['name']

--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -458,7 +458,7 @@ properties:
     router_groups:
     - name: default-tcp
       type: tcp
-      reservable_ports: 20000-25535
+      reservable_ports: 20000-20008
     uri: http://routing-api
   smoke_tests:
     suite_name: CF_SMOKE_TESTS

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -392,8 +392,8 @@ roles:
       public: true
     - name: 'tcp-routing'
       protocol: TCP
-      external: "20000-20098"
-      internal: "20000-20098"
+      external: "20000-20008"
+      internal: "20000-20008"
       public: true
   configuration:
     templates:


### PR DESCRIPTION
HCP has a low timeout wich causes ELBs that have a large number of ports to fail on creation.
