### PR TITLE
Workaround bug in versioning server

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1409,6 +1409,9 @@ roles:
       public: false
   configuration:
     templates:
+      # Workaround until we fix how the versioning server constructs the
+      # location of the cloud controller
+      properties.cc.internal_service_hostname: 'api'
       properties.route_registrar.routes: '[{"name":"hcf-versions-api", "port":3000, "uris":["hcf-versions-api.((DOMAIN))"], "registration_interval":"10s"}]'
 - name: status-route
   tags:


### PR DESCRIPTION
https://github.com/hpcloud/hcf-versions/blob/28a0442493f7a51c3e820003d56748fd5b007459/lib/restapi/configure_versions.go#L36

Location of API should always be internal.
