### PR TITLE
Make it possible to tag + publish in parallel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,19 +128,39 @@ build: compile images
 
 tag: bosh-tag docker-tag
 
+# This rule iterates over all bosh images, and tags them via the wildcard rule
 bosh-tag:
-	${GIT_ROOT}/make/images bosh tag
+	${MAKE} $(foreach role,$(shell ${GIT_ROOT}/make/images bosh print),bosh-tag-${role})
 
+# This rule iterates over all docker images, and tags them via the wildcard rule
 docker-tag:
-	${GIT_ROOT}/make/images docker tag
+	${MAKE} $(foreach role,$(shell ${GIT_ROOT}/make/images docker print),docker-tag-${role})
 
 publish: bosh-publish docker-publish
 
+# This rule iterates over all bosh images, and publishes them via the wildcard rule
 bosh-publish:
-	${GIT_ROOT}/make/images bosh publish
+	${MAKE} $(foreach role,$(shell ${GIT_ROOT}/make/images bosh print),bosh-publish-${role})
 
+# This rule iterates over all docker images, and publishes them via the wildcard rule
 docker-publish:
-	${GIT_ROOT}/make/images docker publish
+	${MAKE} $(foreach role,$(shell ${GIT_ROOT}/make/images docker print),docker-publish-${role})
+
+# This wildcard rule tags one single bosh image
+bosh-tag-%:
+	make/images bosh tag $(@:bosh-tag-%=%)
+
+# This wildcard rule tags one single docker image
+docker-tag-%:
+	make/images docker tag $(@:docker-tag-%=%)
+
+# This wildcard rule publishes one single bosh image
+bosh-publish-%:
+	make/images bosh publish $(@:bosh-publish-%=%)
+
+# This wildcard rule publishes one single docker image
+docker-publish-%:
+	make/images docker publish $(@:docker-publish-%=%)
 
 show-docker-setup:
 	${GIT_ROOT}/make/show-docker-setup

--- a/make/images
+++ b/make/images
@@ -9,14 +9,19 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
 TARGET=${1}
 ACTION=${2}
+ROLES=${3:-}
 
 case ${TARGET} in
     docker)
-        ROLES=$(${GIT_ROOT}/container-host-files/opt/hcf/bin/list-docker-roles.sh)
+        if test -z "${ROLES}" ; then
+            ROLES=$(${GIT_ROOT}/container-host-files/opt/hcf/bin/list-docker-roles.sh)
+        fi
         PREFIX=''
         ;;
     bosh)
-        ROLES=$(fissile show image| awk -F : '{ print $1 }' | sed 's/^fissile-//')
+        if test -z "${ROLES}" ; then
+            ROLES=$(fissile show image| awk -F : '{ print $1 }' | sed 's/^fissile-//')
+        fi
         PREFIX='fissile-'
         ;;
 esac
@@ -64,6 +69,9 @@ for ROLE in ${ROLES}; do
                     docker rmi "${REPOSITORY}:${TAG}"
                 fi
             done
+            ;;
+        print)
+            echo ${ROLE}
             ;;
     esac
 done


### PR DESCRIPTION
Usage:

```
    make -j4 tag
    make -j4 publish
```

Note that it's possible (but unlikely) that `make -j tag publish` would fail, as make doesn't understand the dependency and could try to publish images before they are tagged.
