### PR TITLE
[Windows HCF] Use -Raw argument when reading IDL

### DIFF
--- a/windows/hcp/deploy/install-windows-hcf.ps1
+++ b/windows/hcp/deploy/install-windows-hcf.ps1
@@ -10,7 +10,7 @@ mkdir -f $wd | Out-Null
 
 # Prepare network
 
-$hcfIdl = (cat $hcfIdlPath) | ConvertFrom-Json
+$hcfIdl = Get-Content -Raw $hcfIdlPath | ConvertFrom-Json
 
 $instanceId = $hcfIdl.'instance_id'
 $clusterDnsAffix = "svc.cluster.hcp"


### PR DESCRIPTION
Fixes the following error when IDL is a multi-lin JSON:

```
ConvertFrom-Json : Invalid object passed in, ':' or '}' expected. (1): {
```
