### PR TITLE
HCF-841 Revert escaping of \n after JSON encoding

### DIFF
--- a/bin/rm-transformer/hcp-instance.rb
+++ b/bin/rm-transformer/hcp-instance.rb
@@ -16,10 +16,7 @@ class ToHCPInstance < Common
 
   # Public API
   def transform(manifest)
-    pretty_manifest = JSON.pretty_generate(to_hcp_instance(manifest))
-    # Certificates coming from certs.env contain `\n` which are converted to `\\n` by the JSON encoding
-    # We want them to keep their `\n`
-    pretty_manifest.gsub!('\\\\n', '\\n')
+    JSON.pretty_generate(to_hcp_instance(manifest))
   end
 
   def to_hcp_instance(manifest)
@@ -50,9 +47,12 @@ class ToHCPInstance < Common
       # secrets currently need to be lowercase and can only use dashes, not underscores
       # This should be handled by HCP instead: https://jira.hpcloud.net/browse/CAPS-184
       name.downcase!.gsub!('_', '-') if var['secret']
+      value = var['default']
+      # Some certificates coming from certs.env contain literal `\n` instead of line breaks
+      value.gsub!('\\n', "\n")
       results << {
         'name' => name,
-        'value' => var['default']
+        'value' => value
       }
     end
     results

--- a/bin/rm-transformer/hcp.rb
+++ b/bin/rm-transformer/hcp.rb
@@ -16,10 +16,7 @@ class ToHCP < Common
 
   # Public API
   def transform(roles)
-    pretty_manifest = JSON.pretty_generate(to_hcp(roles))
-    # Certificates coming from certs.env contain `\n` which are converted to `\\n` by the JSON encoding
-    # We want them to keep their `\n`
-    pretty_manifest.gsub!('\\\\n', '\\n')
+    JSON.pretty_generate(to_hcp(roles))
   end
 
   # Internal definitions


### PR DESCRIPTION
Current pipeline that writes certs in instance.json:
generate_dev_certs.sh -> various cert files -> certs.env -> instance.json (via rm-transform.rb)

generate_dev_certs generates cert files that have line breaks (correct PEM encoding).
These certs line breaks are converted into literal `\n` before being added to certs.env. The reason being that multi-line env vars aren't handled by the `docker run` command which starts roles. (nor by rm-transform)
rm-transform.rb then escapes those again into `\\n` because of the JSON encoding.

There is no way to prevent JSON.pretty_generate() from escaping the backslash character, because that is part of the JSON standard.
See: http://stackoverflow.com/questions/6499200/prevent-json-pretty-generate-from-escaping-unicode

Going from `\n` to `\\n` back to `\n` is a little ugly but the alternative workarounds are even uglier.
