### PR TITLE
HCF-890 Correctly add variables to HCP HA configuration

### DIFF
--- a/bin/rm-transformer/hcp-instance.rb
+++ b/bin/rm-transformer/hcp-instance.rb
@@ -38,9 +38,6 @@ class ToHCPInstance < Common
   def collect_parameters(variables)
     results = []
     variables.each do |var|
-      unless var['secret']
-        next unless ['DOMAIN'].include? var['name']
-      end
       # HCP currently freaks out if it gets empty values
       next if var['default'].nil? || var['default'].empty?
       name = var['name']

--- a/make/generate
+++ b/make/generate
@@ -41,7 +41,10 @@ case ${TARGET} in
     hcp-instance|hcp-instance-ha)
         OUTFILE=${OUTFILE:-"hcf-${TARGET}.json"}
         TEMPLATE="hcp/hcf-${TARGET}.template.json"
-        OPTIONS="${OPTIONS} --env-dir bin/settings/hcp/ --env-dir bin/settings/hcp/ha/ --provider hcp-instance --instance-definition-template ${TEMPLATE}"
+        OPTIONS="${OPTIONS} --env-dir bin/settings/hcp/ --provider hcp-instance --instance-definition-template ${TEMPLATE}"
+        if test ${TARGET} = hcp-instance-ha ; then
+            OPTIONS="${OPTIONS} --env-dir bin/settings/hcp/ha/"
+        fi
         ;;
     *)
         OUTFILE=${OUTFILE:-"hcf-${TARGET}.tf.json"}


### PR DESCRIPTION
Previously (before HCF-825) we relied on HA-specific variables having different defaults in the HA service definition file.  It makes no sense to have separate service definition files, so we need to put them in the
HA-specific instance definition file instead.

Also, we shouldn't be loading the HA configuration for the non-HA instance definition generation.
