### PR TITLE
HCF-892 rm-transformer: Add some variables only for AWS

### DIFF
--- a/bin/rm-transformer/hcp-instance.rb
+++ b/bin/rm-transformer/hcp-instance.rb
@@ -23,11 +23,11 @@ class ToHCPInstance < Common
   def to_hcp_instance(manifest)
     definition = load_template
 
-    dev_env = Common.collect_dev_env(dirs_for_flavor[@options[:instance_definition_template]])
+    dev_env = Common.collect_dev_env(env_dirs)
 
     vars = manifest['configuration']['variables']
 
-    dev_env.each_pair do |name, (env_file, value)|
+    dev_env.each_pair do |name, (_, value)|
       i = vars.find_index{|x| x['name'] == name }
       vars[i]['default'] = value unless i.nil?
     end
@@ -47,11 +47,8 @@ class ToHCPInstance < Common
     end
   end
 
-  def dirs_for_flavor
-    {
-      'hcp/instance-basic-dev.template.json' => ['bin/settings', 'bin/settings/hcp'],
-      'hcp/instance-ha-dev.template.json' => ['bin/settings', 'bin/settings/hcp']
-    }
+  def env_dirs
+    ['bin/settings', 'bin/settings/hcp']
   end
 
   def collect_parameters(variables)

--- a/bin/rm-transformer/tf.rb
+++ b/bin/rm-transformer/tf.rb
@@ -62,18 +62,14 @@ class ToTerraform < Common
   # High level emitters, HCF specific structures ...
 
   def emit_configuration(manifest)
-    manifest['configuration']['variables'].each do |config|
-      name = config['name']
+    Common.collect_dev_env(env_dirs).each do |name, (_, value)|
       if special_variables.include?(name)
         @have_specials << name
         next
       end
-      value = config['default']
-      # Ignore optional values without a default.
-      next if value.nil? && !config['required']
       emit_variable(name, value: value)
     end
-    missing = special_variables.sort - @have_specials.sort
+    missing = (special_variables - @have_specials).sort
     missing.each do |var_name|
       STDERR.puts "#{var_name} is missing from input role-manifest"
     end
@@ -215,6 +211,10 @@ class ToTerraform < Common
       'internal'    => 22,
       'public'      => true
     }
+  end
+
+  def env_dirs
+    ['bin/settings']
   end
 
   # # ## ### ##### ########


### PR DESCRIPTION
We have a few variables in our configs to fake out a HCP environment. Those variables were not being used in AWS terraform configurations, which causes things to fail.  Introduce transformer-provider-specific variables so that can be included correctly.
