### PR TITLE
make/images: fix docker push output for make -j

### DIFF
--- a/make/images
+++ b/make/images
@@ -45,8 +45,8 @@ for ROLE in ${ROLES}; do
             docker tag ${PREFIX}${ROLE}:${TAG} ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}
             ;;
         publish)
-            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION}
-            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}
+            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION} | cat
+            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH} | cat
             ;;
         clean)
             case ${TARGET} in


### PR DESCRIPTION
Force `docker push` to be piped to `cat` (instead of to a tty) so that it doesn't attempt to draw fancy progress bars.  This fixes the display when we run it under `make -j`.
