### PR TITLE
HCF-909 Add instance-*-simple.json files to hcp-dist.zip

### DIFF
--- a/bin/rm-transformer/hcp-instance.rb
+++ b/bin/rm-transformer/hcp-instance.rb
@@ -42,9 +42,16 @@ class ToHCPInstance < Common
 
   # Load the instance definition template
   def load_template
-    open(@options[:instance_definition_template], 'r') do |f|
-      JSON.load f
-    end
+    json = File.read(@options[:instance_definition_template])
+    templ = JSON.parse(json)
+
+    templ['name']        ||= "hcf"
+    templ['vendor']      ||= "HPE"
+    templ['labels']      ||= ["my-hcf-cluster"]
+    templ['instance_id'] ||= "my-hcf-cluster"
+    templ['description'] ||= "HCF test cluster"
+
+    templ
   end
 
   def dirs_for_flavor

--- a/hcp/instance-basic-dev.template.json
+++ b/hcp/instance-basic-dev.template.json
@@ -1,10 +1,14 @@
 {
-    "name": "hcf",
-    "vendor": "HPE",
-    "labels": ["my-hcf-cluster"],
-    "instance_id": "my-hcf-cluster",
-    "description": "HCF test cluster",
-    "parameters": [],
+    "parameters": [
+        {
+            "name": "DOMAIN",
+            "value": ""
+        },
+        {
+            "name": "cluster-admin-password",
+            "value": ""
+        }
+    ],
     "scaling": [
       {
         "component": "diego-cell",

--- a/hcp/instance-ha-dev.template.json
+++ b/hcp/instance-ha-dev.template.json
@@ -1,10 +1,14 @@
 {
-    "name": "hcf",
-    "vendor": "HPE",
-    "labels": ["my-hcf-cluster"],
-    "instance_id": "my-hcf-cluster",
-    "description": "HCF test cluster",
-    "parameters": [],
+    "parameters": [
+        {
+            "name": "DOMAIN",
+            "value": ""
+        },
+        {
+            "name": "cluster-admin-password",
+            "value": ""
+        }
+    ],
     "scaling": [
       {
         "component": "api",

--- a/make/clean
+++ b/make/clean
@@ -7,6 +7,7 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 . ${GIT_ROOT}/make/include/fissile
 
 rm -rf ${FISSILE_WORK_DIR}
+rm -rf ${GIT_ROOT}/output
 
 ${GIT_ROOT}/make/images docker clean
 ${GIT_ROOT}/make/images bosh clean

--- a/make/package-hcp
+++ b/make/package-hcp
@@ -10,10 +10,15 @@ ARTIFACT=hcp-${APP_VERSION}.zip
 
 rm ${GIT_ROOT}/${ARTIFACT} 2>/dev/null || true
 
+cp hcp/instance-basic-dev.template.json output/instance-basic-simple.json
+cp hcp/instance-ha-dev.template.json output/instance-ha-simple.json
+
 cd output && zip -9 ${GIT_ROOT}/${ARTIFACT} \
     sdl.json \
     instance-basic-dev.json \
+    instance-basic-simple.json \
     instance-ha-dev.json \
+    instance-ha-simple.json \
     ${NULL:-}
 
 echo Generated ${ARTIFACT}


### PR DESCRIPTION
These are minimal instance.json files where hsm is expected to
fill in all the details.  For manual (dev) use, the rm-transformer
has to add some required fields, so that the templates can just
vecome these minimal instance.json files.
