### PR TITLE
HCF-960 Move vagrant box to xenial kernel

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb, override|
     # Need to shorten the URL for Windows' sake
-    override.vm.box = "https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-virtualbox-v1.0.10.box"
+    override.vm.box = "https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-virtualbox-v1.0.11.box"
 
     # Customize the amount of memory on the VM:
     vb.memory = "8192"
@@ -40,7 +40,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider "vmware_fusion" do |vb, override|
-    override.vm.box="https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-vmware-v1.0.10.box"
+    override.vm.box="https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-vmware-v1.0.11.box"
 
     # Customize the amount of memory on the VM:
     vb.memory = "8192"
@@ -65,7 +65,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider "vmware_workstation" do |vb, override|
-    override.vm.box="https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-vmware-v1.0.10.box"
+    override.vm.box="https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-vmware-v1.0.11.box"
 
     # Customize the amount of memory on the VM:
     vb.memory = "8192"
@@ -87,7 +87,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider "libvirt" do |libvirt, override|
-    override.vm.box = "https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-libvirt-v1.0.10.box"
+    override.vm.box = "https://s3-us-west-2.amazonaws.com/hcf-vagrant-box-images/hcf-libvirt-v1.0.11.box"
     libvirt.driver = "kvm"
     # Allow downloading boxes from sites with self-signed certs
     override.vm.box_download_insecure = true

--- a/container-host-files/opt/hcf/bin/docker/install_kernel.sh
+++ b/container-host-files/opt/hcf/bin/docker/install_kernel.sh
@@ -8,7 +8,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get dselect-upgrade -y
 echo "Install a kernel with quota support"
 sudo apt-get update
 # We have no hard dependency on the version, just tracking HCP
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-generic-lts-wily linux-image-extra-virtual-lts-wily
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-generic-lts-xenial linux-image-generic-lts-xenial
 
 # Load aufs at boot time
 echo "aufs" | sudo tee -a /etc/modules

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "1.0.10",
+        "version": "1.0.11",
         "vm_name": "hcf-vagrant-{{isotime \"20060102-1504\"}}",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",


### PR DESCRIPTION
I've built and uploaded new vmware and virtualbox images; somebody still needs to build and upload a qemu image on Linux before merging this.

``` bash
cd hcf/packer
packer build -only=qemu vagrant-box.json
s3cmd put hcf-libvirt-v1.0.11.box s3://hcf-vagrant-box-images
```
