### PR TITLE
HCF-958 Don't restart rsyslog if it's not running via init

### DIFF
--- a/bin/dev/install_tools.sh
+++ b/bin/dev/install_tools.sh
@@ -6,7 +6,7 @@ bin_dir="${bin_dir:-/home/vagrant/bin}"
 tools_dir="${tools_dir:-/home/vagrant/tools}"
 ubuntu_image="${ubuntu_image:-ubuntu:14.04}"
 configgin_url="${configgin_url:-https://concourse-hpe.s3.amazonaws.com/configgin-1.1.0%2B4.g999ac54.develop-linux-amd64.tgz}"
-fissile_url="${fissile_url:-https://concourse-hpe.s3.amazonaws.com/fissile-2.0.2%2B5.g7228fa8.develop-linux.amd64.tgz}"
+fissile_url="${fissile_url:-https://concourse-hpe.s3.amazonaws.com/fissile-2.0.2%2B15.gbd05e49.develop-linux.amd64.tgz}"
 cf_url="${cf_url:-https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.21.1&source=github-rel}"
 
 mkdir -p $bin_dir

--- a/container-host-files/etc/hcf/config/scripts/forward_logfiles.sh
+++ b/container-host-files/etc/hcf/config/scripts/forward_logfiles.sh
@@ -158,5 +158,9 @@ fi
 
 #make sure the logs configs are added to rsyslog.d folder
 if searchTargetDir $RSYSLOG_FORWARDER_WATCH_DIR; then
-      service rsyslog restart
+        if test -r /var/run/rsyslog.pid; then
+                if test -d /proc/$(cat /var/run/rsyslog.pid); then
+                        service rsyslog restart
+                fi
+        fi
 fi


### PR DESCRIPTION
With newer fissile, we will run rsyslog via monit instead; don't attempt to restart it via init (upstart), that just ends up with multiple copies of rsyslog and confusing everybody.

Also update fissile to have this new method of spawning monit.

[Jenkins build](https://jenkins.issueses.io/job/hcf-vagrant-in-cloud-develop/180/consoleFull) triggered, pending completion.
