### PR TITLE
Add cloud_controller.admin scope for ssh-proxy

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -2293,7 +2293,7 @@ auth:
       autoapprove: true
       override: true
       redirect-uri: /login
-      scope: openid,cloud_controller.read,cloud_controller.write
+      scope: openid,cloud_controller.read,cloud_controller.write,cloud_controller.admin
     tcp_emitter:
       authorities: routing.routes.write,routing.routes.read
       authorized-grant-types: client_credentials,refresh_token


### PR DESCRIPTION
The tokens generated using the ssh one-time code don't have the correct audience required by the cloud controller (one of `cloud_controller` or `cloud_controller_service_permissions`). They have `ssh-proxy` and `openid`.

Adding this scope because of this: https://github.com/cloudfoundry/diego-release/blame/f10748b2b765f175f7513a2f457c3ba2e0c710fe/stubs-for-cf-release/enable_diego_ssh_in_cf.yml#L16 and to see if this adds the correct audience.
