### PR TITLE
HCF-977 Unset proxies before creating UAA users

### DIFF
--- a/src/hcf-release/jobs/uaa-create-user/templates/run.erb
+++ b/src/hcf-release/jobs/uaa-create-user/templates/run.erb
@@ -35,6 +35,12 @@ function retry () {
 export PATH="${PATH}:/var/vcap/packages/ruby-2.3/bin:/var/vcap/packages/cf-uaac/bin"
 export GEM_HOME=/var/vcap/packages/cf-uaac/vendor/bundle/ruby/2.3.0/
 
+# None of this requires access to outside the cluster - or even anything but UAA
+# However, if HTTP_PROXY is set, uaac will ignore NO_PROXY and try to go through
+# the proxy and everything falls over.  Work around this by unsetting all proxy-
+# related environment variables.
+unset HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy
+
 <%
 curl_ssl = properties.ssl.skip_cert_verify ? '--insecure' : ''
 uaac_ssl = properties.ssl.skip_cert_verify ? '--skip-ssl-validation' : ''


### PR DESCRIPTION
The `uaac` client will look at `$HTTP_PROXY` to figure out what proxy it should use, but it does _not_ obey `$NO_PROXY` which causes it to go through the proxy to hit UAA.  This is totally incorrect as UAA is
within the same HCP cluster, and it causes attempts to talk to UAA to fail.  Workaround this by unsetting all the proxy-related environment variables at the top of the file before running `uaac`.

Jenkins run [queued](https://jenkins.issueses.io/view/HCF/job/hcf-vagrant-in-cloud-develop/195/consoleFull).
