### PR TITLE
HCF-930 - Don't quote shellescaped values in bash.

### DIFF
--- a/src/hcf-release/jobs/acceptance-tests-autoscaler/templates/run.erb
+++ b/src/hcf-release/jobs/acceptance-tests-autoscaler/templates/run.erb
@@ -28,8 +28,8 @@ function retry () {
 }
 
 SKIP="<%= properties.ssl.skip_cert_verify ? '--skip-ssl-validation' : '' %>"
-USER="<%= username.shellescape %>"
-PASSWORD="<%= password.shellescape %>"
+USER=<%= username.shellescape %>
+PASSWORD=<%= password.shellescape %>
 HSDS=${HCP_SERVICE_DOMAIN_SUFFIX}
 
 UAA_ENDPOINT="<%= p('hcf.uaa.internal-url') %>"

--- a/src/hcf-release/jobs/autoscaler-register/templates/run.erb
+++ b/src/hcf-release/jobs/autoscaler-register/templates/run.erb
@@ -67,8 +67,8 @@ function register_service () {
 }
 
 SKIP="<%= properties.ssl.skip_cert_verify ? '--skip-ssl-validation' : '' %>"
-USER="<%= username.shellescape %>"
-PASSWORD="<%= password.shellescape %>"
+USER=<%= username.shellescape %>
+PASSWORD=<%= password.shellescape %>
 
 AS_PORT="<%= p("tomcat.http.autoscaler_servicebroker.port") %>"
 AS_USER="<%= p("autoscaler_servicebroker.auth.username") %>"

--- a/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
+++ b/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
@@ -77,8 +77,8 @@ function retarget_auth () {
 }
 
 SKIP="<%= properties.ssl.skip_cert_verify ? '--skip-ssl-validation' : '' %>"
-USER="<%= username.shellescape %>"
-PASSWORD="<%= password.shellescape %>"
+USER=<%= username.shellescape %>
+PASSWORD=<%= password.shellescape %>
 
 UAA_ENDPOINT="<%= p('hcf.uaa.internal-url') %>"
 API_ENDPOINT="api-int.${HCP_SERVICE_DOMAIN_SUFFIX}:9022"

--- a/src/hcf-release/jobs/hcf-sso-routing/templates/run.erb
+++ b/src/hcf-release/jobs/hcf-sso-routing/templates/run.erb
@@ -67,8 +67,8 @@ function register_service () {
 }
 
 SKIP="<%= properties.ssl.skip_cert_verify ? '--skip-ssl-validation' : '' %>"
-USER="<%= username.shellescape %>"
-PASS="<%= password.shellescape %>"
+USER=<%= username.shellescape %>
+PASS=<%= password.shellescape %>
 SSO_PORT="<%= p("hcf_sso.port") %>"
 SSO_USER="<%= p("hcf_sso.username") %>"
 SSO_PASS="<%= p("hcf_sso.password") %>"


### PR DESCRIPTION
This is why a password like "1234!" was getting passed to uaa as
"1234!".  No need to quote the string when it's been shellescaped:
bash itself will unescape the string and pass the intended strings to cf.
