### PR TITLE
HCF-789 - move setting of FISSILE-* env vars to hcf/bin/.fissilerc

### DIFF
--- a/bin/.fissilerc
+++ b/bin/.fissilerc
@@ -1,9 +1,6 @@
 if [ -z "${GIT_ROOT:-}" ] ; then
-    case $0 in
-      -bash) SRC="${BASH_SOURCE[0]}" ;;
-      *) SRC="$0" ;;
-    esac
-    GIT_ROOT=$(dirname $(cd $(dirname "${SRC}") ; echo ${PWD}))
+    # This file should only be sourced, so ${BASH_SOURCE} should be set.
+    GIT_ROOT=$(dirname $(cd $(dirname "${BASH_SOURCE[0]}") && echo ${PWD}))
 fi
 
 # The Docker repository name used for images
@@ -28,9 +25,9 @@ for RELEASE in $(echo '
       windows-runtime-release
       open-Autoscaler/bosh-release
       '); do
-    FISSILE_RELEASE=${FISSILE_RELEASE},${GIT_ROOT}/src/${RELEASE};
+    FISSILE_RELEASE="${FISSILE_RELEASE},${GIT_ROOT}/src/${RELEASE}"
 done
-export FISSILE_RELEASE=$(echo ${FISSILE_RELEASE} | sed 's/,//')
+export FISSILE_RELEASE="$(echo ${FISSILE_RELEASE} | sed 's/,//')"
 
 # This is a comma separated list of dev release names
 # Ordering of the names needs to match the list in FISSILE_DEV_RELEASE

--- a/make/include/fissile
+++ b/make/include/fissile
@@ -1,16 +1,12 @@
 #!/bin/sh
 
 # This file can be called numerous times from the various flows through `make *`, but
-# only set the FISSILE-* env vars if they're unset, or this file is sourced, not exec'ed.
+# only set the FISSILE-* env vars if they're unset, 
+# or this file is sourced from an interactive shell.
 
-if [ -z "${GIT_ROOT:-}" ] ; then
-    # If this file is sourced from other hcf/make files, GIT_ROOT will be set,
-    # so we can use this method for finding ROOT
-    case $0 in
-	-bash) SRC="${BASH_SOURCE[0]}" ;;  # file is sourced
-	*) SRC="$0" ;;                     # file is exec'ed
-    esac
-    echo $SRC
-    GIT_ROOT=$(dirname $(dirname $(cd $(dirname "${SRC}") ; echo ${PWD})))
+if [ -z "${FISSILE_RELEASE:-}" ] || ( [ $0 = "-bash" ] && [ -n "${BASH_SOURCE:-}" ] && [ ${#BASH_SOURCE[@]} -eq 1 ] ) ; then
+    if [ -z "${GIT_ROOT:-}" ] ; then
+	GIT_ROOT=$(dirname $(dirname $(cd $(dirname "${BASH_SOURCE[0]}") && echo ${PWD})))
+    fi
+    . ${GIT_ROOT}/bin/.fissilerc
 fi
-. $GIT_ROOT/bin/.fissilerc


### PR DESCRIPTION
make/include/fissile ensures GIT_ROOT is set and sources .../bin/.fissilerc
