### PR TITLE
[HCF-982]. Directly access CLUSTER_ADMIN variables or secrets instead…

### DIFF
--- a/src/hcf-release/jobs/acceptance-tests-autoscaler/templates/run.erb
+++ b/src/hcf-release/jobs/acceptance-tests-autoscaler/templates/run.erb
@@ -1,13 +1,20 @@
 #!/bin/bash
 set -e
 
+<% if properties.uaa.scim.users.empty? %>
+     echo "Aborting. No admin user configured."
+     exit 1
+<% end %>
+<% if properties.uaa.scim.users.length > 1 %>
+     echo "Aborting. Configured more than one admin user: (<%= userinfo %>)"
+     exit 1
+<% end %>
+
 <% userinfo = properties.uaa.scim.users.first
    if !userinfo.include? 'cloud_controller.admin'
 %>
-
-     echo "Configured admin user is not cloud_controller.admin (<%= userinfo %>)"
+     echo "Aborting. Configured admin user is not cloud_controller.admin (<%= userinfo %>)"
      exit 1
-
 <% end
 
    username = userinfo.split('|').first

--- a/src/hcf-release/jobs/uaa-create-user/templates/run.erb
+++ b/src/hcf-release/jobs/uaa-create-user/templates/run.erb
@@ -8,6 +8,15 @@
 
 set -o errexit -o nounset
 
+<% if properties.uaa.scim.users.empty? %>
+     echo "Aborting. No admin user configured."
+     exit 1
+<% end %>
+<% if properties.uaa.scim.users.length > 1 %>
+     echo "Aborting. Configured more than one admin user: (<%= userinfo %>)"
+     exit 1
+<% end %>
+
 # Report progress to the user; use as printf
 status() {
     local fmt="${1}"


### PR DESCRIPTION
… of relying on configgin and rule-manifest properties to pass everything properly quoted.

Note 1: The new code still uses the property for the username
Note 2: The new code uses only the first user in the property instead of looping over all of them.
        Because with the CLUSTER_ADMIN variables we truly only have one, even if the property should happen to contain multiple entries.

The AAT now abort early with a proper error if the cluster admin does not have the necessary permissions, instead of failing later, in `cf auth`.
