### PR TITLE
Unbreak the generation of sdl.json.

### DIFF
--- a/bin/rm-transformer/common.rb
+++ b/bin/rm-transformer/common.rb
@@ -65,6 +65,26 @@ class Common
     initialize_dtr_information
   end
 
+  def convert_properties(map)
+    # Quick access to the loaded properties: (release -> job -> property -> default-value)
+    # For the filtering we need:             (release -> job -> list(property))
+    property = Hash.new do |props, release|
+      props[release] = Hash.new do |release_hash, job|
+        release_hash[job] = []
+      end
+    end
+
+    map.each do |release, jobs|
+      jobs.each do |job, properties|
+        properties.each_key do |property_name|
+          property[release][job] << property_name
+        end
+      end
+    end
+
+    property
+  end
+
   def initialize_dtr_information
     # Get options, set defaults for missing parts
     @dtr          = @options[:dtr]

--- a/bin/rm-transformer/hcp.rb
+++ b/bin/rm-transformer/hcp.rb
@@ -17,8 +17,7 @@ class ToHCP < Common
     @hcf_version.gsub!(/[^a-zA-Z0-9.-]/, '-')
     @hcf_version = @hcf_version.slice(0,63)
 
-    # Quick access to the loaded properties (release -> job -> list(property-name))
-    @property = @options[:propmap]
+    @property = convert_properties(@options[:propmap])
 
     # And the map (component -> list(parameter-name)).
     # This is created in "determine_component_parameters" (if @property)

--- a/bin/rm-transformer/vagrant.rb
+++ b/bin/rm-transformer/vagrant.rb
@@ -11,22 +11,7 @@ class ToVAGRANT < Common
   def initialize(options)
     super(options)
 
-    # Quick access to the loaded properties: (release -> job -> property -> default-value)
-    # For the filtering we need:             (release -> job -> list(property))
-
-    @property = Hash.new do |props, release|
-      props[release] = Hash.new do |release_hash, job|
-        release_hash[job] = []
-      end
-    end
-
-    @options[:propmap].each do |release, jobs|
-      jobs.each do |job, properties|
-        properties.each_key do |property|
-          @property[release][job] << property
-        end
-      end
-    end
+    @property = convert_properties(@options[:propmap])
   end
 
   # Public API


### PR DESCRIPTION
 Commit 331555 did this for vagrant, but not for hcp.
Factored the relevant code into Common for proper sharing in the two backends.
