### PR TITLE
Add ARTIFACT_NAME back to the code generating various zip files

### DIFF
--- a/make/package-hcp
+++ b/make/package-hcp
@@ -6,7 +6,7 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
 . ${GIT_ROOT}/make/include/versioning
 
-ARTIFACT=hcp-${ARTIFACT_NAME}-${APP_VERSION}.zip
+ARTIFACT=${ARTIFACT_NAME}-hcp-${APP_VERSION}.zip
 
 rm ${GIT_ROOT}/${ARTIFACT} 2>/dev/null || true
 

--- a/make/package-terraform
+++ b/make/package-terraform
@@ -13,7 +13,7 @@ STEM=$(echo ${TARGET} | sed -e 's@-.*@@')
 WORKDIR=$(mktemp -d $(echo ${TARGET} | tr - _)_XXXXXXXXXX)
 trap "rm -rf ${WORKDIR}" HUP INT TERM EXIT
 
-ARTIFACT=${TARGET}-${ARTIFACT_NAME}-${APP_VERSION}.zip
+ARTIFACT=${ARTIFACT_NAME}-${TARGET}-${APP_VERSION}.zip
 
 mkdir -p ${WORKDIR}/${TARGET}
 


### PR DESCRIPTION
We want the reference to `hcf` back for them.
We removed it from the APP_VERSION to not have it in the pure version information placed into the SDL/IDF json files.
