### PR TITLE
HCF-986 - remove the uaa role from the template source file

### DIFF
--- a/hcp/instance-ha-dev.template.json
+++ b/hcp/instance-ha-dev.template.json
@@ -26,11 +26,6 @@
         "max_instances": 3
       },
       {
-        "component": "uaa",
-        "min_instances": 3,
-        "max_instances": 3
-      },
-      {
         "component": "loggregator",
         "min_instances": 3,
         "max_instances": 3


### PR DESCRIPTION
In the hcp world, hcf uses hcp's uaa server, no need for hcf's own.
