### PR TITLE
HCF-994 Automatically cap diego-cell memory limits

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1080,6 +1080,7 @@ roles:
 - name: diego-cell
   environment_scripts:
   - scripts/configure-HA-hosts.sh
+  - scripts/set-diego-cell-memory-limits.sh
   scripts:
   - scripts/authorize_internal_ca.sh
   - scripts/prevent_apparmor_disable.sh

--- a/container-host-files/etc/hcf/config/scripts/set-diego-cell-memory-limits.sh
+++ b/container-host-files/etc/hcf/config/scripts/set-diego-cell-memory-limits.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This script sets the diego-cell / rep memory limits on this node, since `auto`
+# can be incorrect when running inside a nested container (in which case the
+# physical limits are much larger than the container limits)
+
+# Note that this is sourced in the environment (before the BOSH templates are
+# evaluated), and as such we should avoid setting unnecessary variables
+
+if test "${DIEGO_CELL_MEMORY_CAPACITY_MB:-}" = "auto" ; then
+    if test \
+            $(cat /proc/meminfo | awk '/MemTotal:/ { printf "%.0f\n", $2 * 1024 }') \
+        -gt \
+            $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes || echo 0)
+    then
+        export DIEGO_CELL_MEMORY_CAPACITY_MB=$(
+            awk '{ printf "%.0f\n", $1 / 1024 / 1024 }' /sys/fs/cgroup/memory/memory.limit_in_bytes
+        )
+    fi
+fi


### PR DESCRIPTION
When running inside a containerized system where the physical memory limit is larger than the container memory limit, we need to manually tell diego what the limits are so that it doesn't attempt to use more
than is actually available (because it was looking at the wrong place for information).
