### PR TITLE
[HCF-900] Improve the description and example fields in the SDL

### DIFF
--- a/bin/rm-transformer.rb
+++ b/bin/rm-transformer.rb
@@ -15,7 +15,8 @@ def main
   # Syntax: ?--manual? ?--provider <name>? <roles-manifest.yml>|-
   ##
   # --manual          ~ Include manually started roles in the output
-  # --property-map <file> ~ File mapping releases and jobs to the properties they use.
+  # --property-map  <file> ~ File mapping releases, jobs, and properties to their default values.
+  # --property-desc <file> ~ File mapping releases, jobs, and properties to their descriptions.
   # --provider <name> ~ Choose the output format.
   #                     Known: hcp, tf
   #                     Default: hcp
@@ -45,6 +46,7 @@ def main
     hcf_root_dir: nil,
     manual:      false,
     propmap:     nil,
+    propdesc:    nil,
     hcp_cpu_num: 6
   }
 
@@ -87,8 +89,11 @@ def main
     opts.on('-m', '--manual', 'Include manually started roles in the output') do |v|
       options[:manual] = v
     end
-    opts.on('-M', '--property-map text', 'Path to YAML file with the mapping from releases to jobs to properties') do |v|
+    opts.on('-M', '--property-map text', 'Path to YAML file with the mapping from releases to jobs to properties to default values') do |v|
       options[:propmap] = YAML.load_file(v)
+    end
+    opts.on('-M', '--property-desc text', 'Path to YAML file with the mapping from releases to jobs to properties to descriptions') do |v|
+      options[:propdesc] = YAML.load_file(v)
     end
     opts.on('-p', '--provider format', 'Chose output format') do |v|
       abort "Unknown provider: #{v}" if provider_constructor[v].nil?

--- a/make/generate
+++ b/make/generate
@@ -59,6 +59,12 @@ case ${TARGET} in
 
         OPTIONS="${OPTIONS} --property-map hcf-hcp-propmap.yaml"
 	CLEAN="${CLEAN} hcf-hcp-propmap.yaml"
+
+	( . ${GIT_ROOT}/make/include/fissile
+	  fissile show descriptions --output yaml ) > hcf-hcp-propdesc.yaml
+
+        OPTIONS="${OPTIONS} --property-desc hcf-hcp-propdesc.yaml"
+	CLEAN="${CLEAN} hcf-hcp-propdesc.yaml"
         ;;
     instance-basic-dev|instance-ha-dev)
         OUTFILE=${OUTFILE:-"output/${TARGET}.json"}


### PR DESCRIPTION
- Associate variable names with property names.
- Take the property descriptions and defaults from fissile (yaml files).
  Existing command: `fissile show properties`, option --property-map
  New command:      `fissile show descriptions`, option --property-desc
- Extended `make/generate` to supply the additional information
- Use transition and some heuristics to associate each variable name with the
  most informative property descriptions and example.
- Note: Role manifest descriptions and examples have priority over
  generated information.
