### PR TITLE
[HCF-900] A number of description overrides to be more suitable/readable than the auto-generated text.

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1593,7 +1593,7 @@ configuration:
     description: The number of versions of an application to keep. You will be able
       to rollback to this amount of versions.
   - name: DNS_HEALTH_CHECK_HOST
-    default: example.com
+    default: "127.0.0.1"
     description: The host to ping for confirmation of DNS resolution.
   - name: DNS_RECORD_NAME
     required: false


### PR DESCRIPTION
**Note:** A number of changes (removed double-quotes, mostly) are because of the fact that Troy's changes were applied via script, and the ruby `.to_yaml` used by it.
