### PR TITLE
HCF-922 Use the UAA certificate from HCP

### DIFF
--- a/bin/settings/hcp/settings.env
+++ b/bin/settings/hcp/settings.env
@@ -1,3 +1,0 @@
-# because for a dev instance.json that has all certs pre-configured
-# the certs won't have the correct domains for UAA
-SKIP_CERT_VERIFY_INTERNAL=true

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -2163,7 +2163,7 @@ configuration:
     properties.tomcat.http.autoscaler_api.route: '"((AUTOSCALER_API_HOST))"'
     properties.tomcat.http.autoscaler_server.route: '"((AUTOSCALER_SERVER_HOST))"'
     properties.uaa.admin.client_secret: '"((UAA_ADMIN_CLIENT_SECRET))"'
-    properties.uaa.ca_cert: '"((INTERNAL_CA_CERT))"'
+    properties.uaa.ca_cert: '"((HCP_CA_CERT))((^HCP_CA_CERT))((INTERNAL_CA_CERT))((/HCP_CA_CERT))"'
     properties.uaa.clients: ((UAA_CLIENTS))((^UAA_CLIENTS)){}((/UAA_CLIENTS)) # This is _not_ quoted to let the JSON expand in configgin
     properties.uaa.clients.cc-service-dashboards.secret: '"((UAA_CLIENTS_CC_SERVICE_SECRET))"'
     properties.uaa.clients.cc_routing.secret: '"((UAA_CLIENTS_CC_ROUTING_SECRET))"'


### PR DESCRIPTION
Now that CAPS-922 is fixed, we can always validate the certificate from UAA, and therefore no longer need to skip verifying any of the cluster-internal certificates.

Note that we need to update `properties.uaa.ca_cert` to get it passed to places like the router where they specify which CA to use.
