### PR TITLE
Make sure that the generated dev router certs have the correct suffix

### DIFF
--- a/bin/generate-dev-certs.sh
+++ b/bin/generate-dev-certs.sh
@@ -161,7 +161,7 @@ certstrap --depot-path "${internal_certs_dir}"  sign cfUsbBrokerServer --CA inte
 uaa_server_key="${certs_path}/uaa_private_key.pem"
 uaa_server_crt="${certs_path}/uaa_ca.crt"
 
-certstrap --depot-path "${internal_certs_dir}" request-cert --common-name "uaa" --domain "uaa-int.hcf,*.uaa-int.hcf" --passphrase ""
+certstrap --depot-path "${internal_certs_dir}" request-cert --common-name "uaa" --domain "$(make_domains "uaa-int")" --passphrase ""
 certstrap --depot-path "${internal_certs_dir}" sign "uaa" --CA internalCA --passphrase "${signing_key_passphrase}"
 cp "${internal_certs_dir}/uaa.crt" "${uaa_server_crt}"
 cat "${internal_certs_dir}/uaa.crt" "${internal_certs_dir}/uaa.key" > "${uaa_server_key}"
@@ -169,7 +169,7 @@ cat "${internal_certs_dir}/uaa.crt" "${internal_certs_dir}/uaa.key" > "${uaa_ser
 # We include hcf.uaa.${DOMAIN} because it's not covered by *.${DOMAIN} and it's
 # required by the dev UAA server
 server_cn=router_ssl
-certstrap --depot-path "${internal_certs_dir}" request-cert --passphrase '' --common-name "${server_cn}" --domain "router-int,router-int.hcf,${DOMAIN},*.${DOMAIN},hcf.uaa.${DOMAIN}"
+certstrap --depot-path "${internal_certs_dir}" request-cert --passphrase '' --common-name "${server_cn}" --domain "router-int,router-int.${HCP_SERVICE_DOMAIN_SUFFIX:-hcf},${DOMAIN},*.${DOMAIN},hcf.uaa.${DOMAIN}"
 certstrap --depot-path "${internal_certs_dir}" sign "${server_cn}" --CA internalCA --passphrase "${signing_key_passphrase}"
 mv -f "${internal_certs_dir}/${server_cn}.key" "${certs_path}/router_ssl.key"
 mv -f "${internal_certs_dir}/${server_cn}.crt" "${certs_path}/router_ssl.cert"


### PR DESCRIPTION
When deploying for HCP, it shouldn't say `.hcf` (on the router cert).
