### PR TITLE
HCF-1005 Allow scaling up of diego-database for HA

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -256,7 +256,7 @@ roles:
   run:
     scaling:
       min: 1
-      max: 1
+      max: 65535
     capabilities: []
     persistent-volumes:
       - path: /var/vcap/store

--- a/hcp/instance-ha-dev.template.json
+++ b/hcp/instance-ha-dev.template.json
@@ -41,6 +41,11 @@
         "max_instances": 3
       },
       {
+        "component": "diego-database",
+        "min_instances": 3,
+        "max_instances": 3
+      },
+      {
         "component": "diego-cc-bridge",
         "min_instances": 3,
         "max_instances": 3


### PR DESCRIPTION
This was previously disabled due to some issues with etcd.  Hopefully
it will work as-is now that BBS uses mysql as the database instead.
