### PR TITLE
HCF-983 - Re-encode high-bit strings as utf-8 when needed.

### DIFF
--- a/bin/rm-transformer/common.rb
+++ b/bin/rm-transformer/common.rb
@@ -108,9 +108,10 @@ class Common
         exit 1
       end
       env_files.each do |env_file|
-        File.readlines(env_file, encoding:"UTF-8").each_with_index do |line, i|
-          next if line.strip.size == 0 || /^s*#/.match(line)
-          name, value = line.strip.split('=', 2)
+        File.readlines(env_file, encoding:'UTF-8').each_with_index do |line, i|
+          line.strip!
+          next if line.empty? || line.start_with?('#')
+          name, value = line.split('=', 2)
           if value.nil?
             match = /^ \s* unset \s+ (?<name>\w+) \s* $/x.match(line)
             if match


### PR DESCRIPTION
Testing shows this is only needed for File.readlines in this codebase.
The YAML reader handles utf-8 input correctly.
