### PR TITLE
HCF-1031: Make TCP routing HA

### DIFF
--- a/hcp/instance-ha-dev.template.json
+++ b/hcp/instance-ha-dev.template.json
@@ -61,6 +61,14 @@
       {
         "component": "diego-cell",
         "min_instances": 1
+      },
+      {
+        "component": "routing-ha-proxy",
+        "min_instances": 3
+      },
+      {
+        "component": "routing-api",
+        "min_instances": 3
       }
     ]
 }


### PR DESCRIPTION
Nothing actually needed to be done (other than testing); we just need to bump up the instance counts.

Tested by going into the `routing-ha-proxy-0` / `routing-api-0` containers, editing their control scripts to dump the pid into the pid file and sleep forever.  Then made a TCP route and tried to access it and check the HTTP requests for the remote IP (which is the TCP router proxy) and make sure that all requests are accounted for (and there are two hosts).
