### PR TITLE
hcf-release/acceptance-tests-brain: don't ship golang

### DIFF
--- a/src/hcf-release/jobs/acceptance-tests-brain/spec
+++ b/src/hcf-release/jobs/acceptance-tests-brain/spec
@@ -4,7 +4,6 @@ name: acceptance-tests-brain
 description: This job will run the testbrain CLI, running all acceptance test scripts in src/testbrain/test-scripts
 
 packages:
-  - golang1.6
   - cli
   - acceptance-tests-brain
 

--- a/src/hcf-release/jobs/acceptance-tests-brain/templates/run.erb
+++ b/src/hcf-release/jobs/acceptance-tests-brain/templates/run.erb
@@ -2,9 +2,6 @@
 
 set -o errexit
 
-export GOROOT="$(readlink -nf /var/vcap/packages/golang1.6)"
-export PATH="${GOROOT}/bin:${PATH}"
-
 export PATH="/var/vcap/packages/cli/bin:${PATH}" # put the cli on the path
 export PATH="/var/vcap/packages/acceptance-tests-brain/bin:${PATH}" # put testbrain on the path
 
@@ -16,7 +13,6 @@ export BRAIN=/var/vcap/packages/acceptance-tests-brain
 export ASSETS="${BRAIN}/test-resources"
 export SCRIPTS_FOLDER="${BRAIN}/test-scripts"
 
-go version
 echo "SCRIPTS_FOLDER=${SCRIPTS_FOLDER}"
 echo "CF_API=${CF_API}"
 


### PR DESCRIPTION
There's no need to actually ship golang in the acceptance-tests-brain image; we just need it to build the binaries that go into that image.
