### PR TITLE
HCF-1059 cc: don't run migrations in pre-start

### DIFF
--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -103,6 +103,9 @@ properties:
       blobstore_type: webdav
       webdav_config:
         username: 'blobstore_user'
+    # We turn run_prestart_migrations off so that the container containing api#0
+    # can avoid pointlessly restarting until postgres comes online
+    run_prestart_migrations: false
     security_event_logging:
       enabled: null
     security_group_definitions:


### PR DESCRIPTION
Having things fail in prestart is a bit more expensive for us than having the same fail under monit (because any pre-start failures cause the container to be completely destroyed and restarted).  Adjust cloud controller configuration to not run migrations in pre-start, and instead do so on normal startup of (the first instance of) the cloud controller.