### PR TITLE
HCF-1058 blobstore pre-start doesn't need to be manually

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -602,8 +602,6 @@ roles:
     release_name: routing
   - name: metron_agent
     release_name: cf
-  post_config_scripts:
-  - /var/vcap/jobs/blobstore/bin/pre-start
   processes:
   - name: blobstore_nginx
   - name: blobstore_url_signer


### PR DESCRIPTION
The pre-start script already runs automatically by virtue of its name.