### PR TITLE
HCF-1078 Wait a little to make sure the tcp route is functional

### DIFF
--- a/src/hcf-release/src/acceptance-tests-brain/test-scripts/006_tcprouting_test.sh
+++ b/src/hcf-release/src/acceptance-tests-brain/test-scripts/006_tcprouting_test.sh
@@ -76,4 +76,5 @@ if [ -z "${port}" ]; then
 fi
 
 # check that the application works
+sleep 5
 curl ${CF_TCP_DOMAIN}:${port}


### PR DESCRIPTION
The tests otherwise fails on Vagrant when run inside a docker container,
but only the very first time it is executed...