### PR TITLE
HCF-1081 Change method of hiding tty from docker

### DIFF
--- a/make/images
+++ b/make/images
@@ -46,13 +46,14 @@ for ROLE in ${ROLES}; do
             ;;
         publish)
             # Redirect stdout so that docker doesn't print download progress data
-            # (using pipefail isn't cross platform)
+            #   - 3 is an arbitrary file descriptor greater than 2 (0,1,2 being stdin/out/err)
+            #   - using pipefail isn't cross platform
             echo "Publishing docker image: ${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}"
-            exec 6>&1
+            exec 3>&1
             exec > /dev/null
             docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION}
             docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}
-            exec 1>&6 6>&-
+            exec 1>&3 3>&-
             ;;
         clean)
             case ${TARGET} in


### PR DESCRIPTION
Piping to `cat` masks the error code, so exec must be used here.