### PR TITLE
HCF-1114 Remove duplicate UAA authorities

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -2473,5 +2473,4 @@ auth:
       authorities: routing.routes.read
       authorized-grant-types: client_credentials,refresh_token
   authorities:
-    - uaa.user
     - routing.router_groups.read


### PR DESCRIPTION
Allows HCF to be brought up on HCP 0.9.20 (which doesn't have the CAPS-1266 fix).

However, this needs to wait until HCF-1117 is fixed before it can have tests run.