### PR TITLE
HCF-1118 Automatically build the base fissile images if needed

### DIFF
--- a/make/compile-base
+++ b/make/compile-base
@@ -2,11 +2,29 @@
 
 set -o errexit -o nounset
 
-GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 
-. ${GIT_ROOT}/make/include/fissile
+. "${GIT_ROOT}/make/include/fissile"
 
 FISSILE_VERSION=$(fissile version | sed 's/+/-/g')
+IMAGE_NAME="fissile-cbase:${FISSILE_VERSION}"
 
-docker pull fissile/fissile-cbase:${FISSILE_VERSION}
-docker tag fissile/fissile-cbase:${FISSILE_VERSION} fissile-cbase:${FISSILE_VERSION}
+if test -n "$(docker images --format '{{.}}' "${IMAGE_NAME}")" ; then
+    exit 0 # We already have the image, don't do anything
+fi
+
+if docker pull "fissile/${IMAGE_NAME}" ; then
+    docker tag "fissile/${IMAGE_NAME}" "${IMAGE_NAME}"
+else
+    FISSILE_FROM="${UBUNTU_IMAGE:-hpe-license-on-ubuntu:14.04}"
+    if test -z "$(docker images --format '{{.}}' "${FISSILE_FROM}")" ; then
+        # We don't have the base image with the license; create it
+        UBUNTU_BASE="ubuntu:14.04"
+        LICENSE_URL="https://concourse-hpe.s3.amazonaws.com/fissile-container-LICENSE.txt"
+        LICENSE_PATH="/usr/share/doc/stackato/LICENSE.txt"
+        printf "FROM %s\n ADD %s %s" "${UBUNTU_BASE}" "${LICENSE_URL}" "${LICENSE_PATH}" | \
+            docker build --tag "${FISSILE_FROM}" -
+    fi
+    export FISSILE_FROM
+    fissile build layer compilation
+fi

--- a/make/image-base
+++ b/make/image-base
@@ -2,11 +2,29 @@
 
 set -o errexit -o nounset
 
-GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 
-. ${GIT_ROOT}/make/include/fissile
+. "${GIT_ROOT}/make/include/fissile"
 
 FISSILE_VERSION=$(fissile version | sed 's/+/-/g')
+IMAGE_NAME="fissile-role-base:${FISSILE_VERSION}"
 
-docker pull fissile/fissile-role-base:${FISSILE_VERSION}
-docker tag fissile/fissile-role-base:${FISSILE_VERSION} fissile-role-base:${FISSILE_VERSION}
+if test -n "$(docker images --format '{{.}}' "${IMAGE_NAME}")" ; then
+    exit 0 # We already have the image, don't do anything
+fi
+
+if docker pull "fissile/${IMAGE_NAME}" ; then
+    docker tag "fissile/${IMAGE_NAME}" "${IMAGE_NAME}"
+else
+    FISSILE_FROM="${UBUNTU_IMAGE:-hpe-license-on-ubuntu:14.04}"
+    if test -z "$(docker images --format '{{.}}' "${FISSILE_FROM}")" ; then
+        # We don't have the base image with the license; create it
+        UBUNTU_BASE="ubuntu:14.04"
+        LICENSE_URL="https://concourse-hpe.s3.amazonaws.com/fissile-container-LICENSE.txt"
+        LICENSE_PATH="/usr/share/doc/stackato/LICENSE.txt"
+        printf "FROM %s\n ADD %s %s" "${UBUNTU_BASE}" "${LICENSE_URL}" "${LICENSE_PATH}" | \
+            docker build --tag "${FISSILE_FROM}" -
+    fi
+    export FISSILE_FROM
+    fissile build layer stemcell
+fi


### PR DESCRIPTION
This ensures that we will build the necessary image/compile base images via fissile if we can't find them on the docker hub.
[Jenkins build](https://jenkins.issueses.io/view/HCF/job/hcf-vagrant-in-cloud-develop/439/console)