### PR TITLE
HCF-1119 Stop building the hpe-license-from-ubuntu

### DIFF
--- a/make/compile-base
+++ b/make/compile-base
@@ -18,5 +18,6 @@ if docker pull "fissile/${IMAGE_NAME}" ; then
 else
     FISSILE_FROM="fissile/${UBUNTU_IMAGE:-hpe-license-on-ubuntu:14.04}"
     export FISSILE_FROM
+    docker pull "${FISSILE_FROM}"
     fissile build layer compilation
 fi

--- a/make/image-base
+++ b/make/image-base
@@ -18,5 +18,6 @@ if docker pull "fissile/${IMAGE_NAME}" ; then
 else
     FISSILE_FROM="fissile/${UBUNTU_IMAGE:-hpe-license-on-ubuntu:14.04}"
     export FISSILE_FROM
+    docker pull "${FISSILE_FROM}"
     fissile build layer stemcell
 fi


### PR DESCRIPTION
This pull request removes building the hpe-license-on-ubuntu layer, since it's always updated by CI now and always available on public docker hub.