### PR TITLE
HCF-1081 Simplify `docker push` terminal workaround

### DIFF
--- a/make/images
+++ b/make/images
@@ -45,15 +45,11 @@ for ROLE in ${ROLES}; do
             docker tag ${PREFIX}${ROLE}:${TAG} ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}
             ;;
         publish)
-            # Redirect stdout so that docker doesn't print download progress data
-            #   - 3 is an arbitrary file descriptor greater than 2 (0,1,2 being stdin/out/err)
-            #   - using pipefail isn't cross platform
-            echo "Publishing docker image: ${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}"
-            exec 3>&1
-            exec > /dev/null
-            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION}
-            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}
-            exec 1>&3 3>&-
+            # Redirect docker stdout to avoid polluting logfiles with progressbar characters
+            echo "Publishing ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION}"
+            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION} > /dev/null
+            echo "Publishing ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}"
+            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH} > /dev/null
             ;;
         clean)
             case ${TARGET} in


### PR DESCRIPTION
Previous solution with exec didn't work and was overly complex.