### PR TITLE
HCF-1089 - Speed up the time to bosh-create a release by stubbing out git.

### DIFF
--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -26,6 +26,9 @@ release_name=$2
 stampy ${ROOT}/hcf_metrics.csv "${BASH_SOURCE[0]}" create-release::${release_name} start
 stampy ${ROOT}/hcf_metrics.csv "${BASH_SOURCE[0]}" create-release::docker::${release_name} start
 
+# bosh create release calls `git status` (twice), but hcf doesn't need to know if the
+# repo is dirty, so stub it out.
+
 docker run \
     --interactive \
     --rm \
@@ -33,7 +36,7 @@ docker run \
     --volume $ROOT/:$ROOT/ \
     --env RBENV_VERSION="${RUBY_VERSION:-2.2.3}" \
     helioncf/hcf-pipeline-ruby-bosh \
-    bash -l -c "rm -rf ${ROOT}/${release_path}/dev_releases && bosh --parallel 10 create release --dir ${ROOT}/${release_path} --force --name ${release_name}"
+    bash -l -c "echo echo nothing to commit > /usr/local/bin/git && chmod +x /usr/local/bin/git && rm -rf ${ROOT}/${release_path}/dev_releases && bosh --parallel 10 create release --dir ${ROOT}/${release_path} --force --name ${release_name}"
 stampy ${ROOT}/hcf_metrics.csv "${BASH_SOURCE[0]}" create-release::docker::${release_name} done
 
 # Convert YAML to JSON to escape strings nicely so the commit hashes don't get confused as floats


### PR DESCRIPTION
The container's git is in /usr/bin, as it's installed with apt-get.

/usr/local/bin comes before /usr/bin in the path, so we can install our own git there.

In fact, `bosh create release` only uses git to get the status, so it would also be possible
to replace /usr/bin/git with our handy `echo "nothing to commit"` stub.

Doing this speeds up `make cf-release` by about 2x, and `make hcf-release` by about 4x.