### PR TITLE
HCF-1106 Build releases in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,21 +88,23 @@ windows-runtime-release:
 open-autoscaler-release:
 	${GIT_ROOT}/make/bosh-release src/open-Autoscaler/bosh-release cf-open-autoscaler
 
-releases: \
-	cf-release \
-	usb-release \
-	diego-release \
-	etcd-release \
-	garden-release \
-	mysql-release \
-	cflinuxfs2-rootfs-release \
-	routing-release \
-	hcf-release \
-	windows-runtime-release \
-	hcf-sso-release \
-	hcf-versions-release \
-	open-autoscaler-release \
-	${NULL}
+releases:
+	${MAKE} \
+		$(or ${MAKEFLAGS}, -j$(or ${J},4)) \
+		cf-release \
+		usb-release \
+		diego-release \
+		etcd-release \
+		garden-release \
+		mysql-release \
+		cflinuxfs2-rootfs-release \
+		routing-release \
+		hcf-release \
+		windows-runtime-release \
+		hcf-sso-release \
+		hcf-versions-release \
+		open-autoscaler-release \
+		${NULL}
 
 ########## FISSILE BUILD TARGETS ##########
 


### PR DESCRIPTION
This makes us always build releases in parallel (if the toplevel make isn't already doing it), to speed up a build a bit.

To disable this behaviour, explicitly set `J` to `1`:
```bash
J=1 make releases
```

Tested this a few times on vagrant (libvirt + virtualbox). Only problem was that osx + virtualbox had a kernel panic (‽), but it wasn't reproducible…