### PR TITLE
HCF-1124: Add specs to patch-properties to replace global access to the old property tree.

### DIFF
--- a/src/hcf-release/jobs/patches-job/spec
+++ b/src/hcf-release/jobs/patches-job/spec
@@ -12,11 +12,23 @@ properties:
   cf_mysql.mysql.advertise_host:
     description: "Used to patch mysql's advertising mechanism"
 
-  routing_api.uri:
-    description: "Used to patch the router's configuration for the routing api"
-
   uaa.token_endpoint:
     description: "Used to patch the router's configuration"
 
   etcd.bootstrap_node:
     description: "Used to patch etcd server bootstrap"
+
+  # These two are here for routing-api and routing-ha-proxy
+  routing_api.uri:
+    description: "Used to patch the router's configuration for the routing api"
+
+  routing_api.port:
+    description: "Used to patch the router's configuration for the routing api"
+    default: 3000
+
+  # These two are here because autoscaler_api uses them but doesn't define them in its spec
+  autoscaler_server.internal_auth.username:
+        description: the autoscaler-server's username
+
+  autoscaler_server.internal_auth.password:
+        description: the autoscaler-server's password


### PR DESCRIPTION
This affects the routing-api, routing-ha-proxy, and sclr-api roles.