### PR TITLE
HCF-1182 Add GARDEN_DOCKER_REGISTRY default

### DIFF
--- a/bin/settings/settings.env
+++ b/bin/settings/settings.env
@@ -30,8 +30,9 @@ DISABLE_CUSTOM_BUILDPACKS=false
 DNS_HEALTH_CHECK_HOST=example.com.
 DROPLET_MAX_STAGED_STORED=5
 FORCE_FORWARDED_PROTO_AS_HTTPS=false
-# Leaving unset to invoke the system default baked into the garden-linux executable
-#GARDEN_DOCKER_REGISTRY=
+# Although leaving GARDEN_DOCKER_REGISTRY unset would invoke the system default baked into the garden-linux executable,
+# this would cause problems with HCP and HSM, so we hardcode the default in
+GARDEN_DOCKER_REGISTRY=registry-1.docker.io
 GARDEN_INSECURE_DOCKER_REGISTRIES=
 HCF_SSO_OAUTH_ID=hcf-sso
 HCF_SSO_PASSWORD=hcf_sso_secret


### PR DESCRIPTION
Hardcoding the garden-linux default, which is here: https://github.com/cloudfoundry-attic/garden-linux/blob/1f1b19bf10a005c8a81abb72b4548d0856192408/main.go#L161