### PR TITLE
[HCF-1207] Run cleanup of domain used for TCP routing, to keep within limits

### DIFF
--- a/src/hcf-release/src/acceptance-tests-brain/test-scripts/006_tcprouting_test.sh
+++ b/src/hcf-release/src/acceptance-tests-brain/test-scripts/006_tcprouting_test.sh
@@ -61,6 +61,8 @@ cd ${APP}
 cf push ${APP_NAME}
 
 # set up tcp routing
+cf delete-shared-domain -f ${CF_TCP_DOMAIN} || true
+
 cf create-shared-domain ${CF_TCP_DOMAIN} --router-group default-tcp
 cf update-quota default --reserved-route-ports -1
 

--- a/src/hcf-release/src/acceptance-tests-brain/test-scripts/007_usb_test.sh
+++ b/src/hcf-release/src/acceptance-tests-brain/test-scripts/007_usb_test.sh
@@ -63,6 +63,8 @@ function test_cleanup() {
 trap test_cleanup EXIT ERR
 
 # allow tcp routing
+cf delete-shared-domain -f ${CF_TCP_DOMAIN} || true
+
 cf create-shared-domain ${CF_TCP_DOMAIN} --router-group default-tcp
 cf update-quota default --reserved-route-ports -1
 


### PR DESCRIPTION
Specific to execution HCP where the domain is the same across runs and tests.
No effect for Vagrant with its randomized domain names.