### PR TITLE
HCF-1211 Revert "HCF-1059 cc: don't run migrations in pre-start"

### DIFF
--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -101,9 +101,6 @@ properties:
       blobstore_type: webdav
       webdav_config:
         username: 'blobstore_user'
-    # We turn run_prestart_migrations off so that the container containing api#0
-    # can avoid pointlessly restarting until postgres comes online
-    run_prestart_migrations: false
     security_event_logging:
       enabled: null
     security_group_definitions:


### PR DESCRIPTION
Running migrations as part of the CC startup can cause a timeout
(port must be readable within 60 seconds), which will run a second
competing run of migrations, which can cause the whole deployment
to fail.

Running migrations during prestart is the recommended and default
upstream setting.

This reverts commit d6cd0bc36097085415fcc24a4876c0e9457cf993.