### PR TITLE
HCF-1212 Don't overwrite entrypoints in the SDL

### DIFF
--- a/bin/dev/install_tools.sh
+++ b/bin/dev/install_tools.sh
@@ -4,7 +4,7 @@ set -e
 # Installs tools needed to build and run HCF
 bin_dir="${bin_dir:-/home/vagrant/bin}"
 tools_dir="${tools_dir:-/home/vagrant/tools}"
-fissile_url="${fissile_url:-https://concourse-hpe.s3.amazonaws.com/fissile-4.0.0%2B40.gd285b94.linux-amd64.tgz}"
+fissile_url="${fissile_url:-https://concourse-hpe.s3.amazonaws.com/fissile-4.0.0%2B42.g1855768.linux-amd64.tgz}"
 cf_url="${cf_url:-https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.21.1&source=github-rel}"
 stampy_url="${stampy_url:-https://concourse-hpe.s3.amazonaws.com/stampy-0.0.0%2B7.g4d305fa.master-linux.amd64.tgz}"
 

--- a/bin/rm-transformer/hcp.rb
+++ b/bin/rm-transformer/hcp.rb
@@ -227,11 +227,6 @@ class ToHCP < Common
 
     the_comp['retry_count'] = retrycount if retrycount > 0
 
-    unless role['type'] == 'docker'
-      the_comp['entrypoint'] = build_entrypoint(runtime: runtime,
-                                                role_manifest: role_manifest)
-    end
-
     # Record persistent and shared volumes, ports
     pv = runtime['persistent-volumes']
     sv = runtime['shared-volumes']
@@ -278,27 +273,6 @@ class ToHCP < Common
       map[var['name']] = vname
     end
     map
-  end
-
-  def build_entrypoint(options)
-    entrypoint = ["/usr/bin/env"]
-
-    exposed_ports = options[:runtime]['exposed-ports']
-    unless exposed_ports.any? {|port| port['public']}
-      entrypoint << 'HCP_HOSTNAME_SUFFIX=-int'
-    end
-
-    auth_info = options[:role_manifest]['auth'] || {}
-    if auth_info['clients']
-      entrypoint << "UAA_CLIENTS=#{auth_info['clients'].to_json}"
-    end
-    if auth_info['authorities']
-      entrypoint << "UAA_USER_AUTHORITIES=#{auth_info['authorities'].to_json}"
-    end
-
-    entrypoint << '/opt/hcf/run.sh'
-
-    entrypoint
   end
 
   def add_volumes(fs, component, volumes, shared_fs)

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -479,6 +479,7 @@ roles:
       properties.uaa.zones.internal.hostnames: '["uaa-int.((HCP_SERVICE_DOMAIN_SUFFIX))","uaa.((DOMAIN))"]'
 - name: api
   environment_scripts:
+  - scripts/load-hcp-env.sh
   - scripts/authorize_internal_ca.sh
   - scripts/fetch_uaa_verification_key.sh
   - scripts/configure-HA-hosts.sh
@@ -556,6 +557,7 @@ roles:
       properties.route_registrar.routes: '[{"name":"api", "port":9022, "tags":{"component":"CloudController"}, "uris":["api.((DOMAIN))"], "registration_interval":"10s"}]'
 - name: api-worker
   environment_scripts:
+  - scripts/load-hcp-env.sh
   - scripts/configure-HA-hosts.sh
   - scripts/inverted_skip_ssl.sh
   scripts:
@@ -638,6 +640,7 @@ roles:
       properties.route_registrar.routes: '[{"name":"blobstore", "port":8080, "tags":{"component":"blobstore"}, "uris":["blobstore.((DOMAIN))"], "registration_interval":"10s"}]'
 - name: clock-global
   environment_scripts:
+  - scripts/load-hcp-env.sh
   - scripts/configure-HA-hosts.sh
   - scripts/inverted_skip_ssl.sh
   scripts:
@@ -1361,6 +1364,8 @@ roles:
     exposed-ports: []
 - name: post-deployment-setup
   type: bosh-task
+  environment_scripts:
+  - scripts/load-hcp-env.sh
   scripts:
   - scripts/authorize_internal_ca.sh
   jobs:
@@ -2411,7 +2416,7 @@ configuration:
     description: Extra token expiry time while uploading big apps, in seconds.
   templates:
     index: "((HCP_COMPONENT_INDEX))((^HCP_COMPONENT_INDEX))0((/HCP_COMPONENT_INDEX))"
-    networks.default.dns_record_name: '"((#HCP_COMPONENT_NAME))((HCP_COMPONENT_NAME))((HCP_HOSTNAME_SUFFIX))((/HCP_COMPONENT_NAME))((^HCP_COMPONENT_NAME))((DNS_RECORD_NAME))((/HCP_COMPONENT_NAME))"'
+    networks.default.dns_record_name: '"((#HCP_COMPONENT_NAME))((HCP_COMPONENT_NAME))-int((/HCP_COMPONENT_NAME))((^HCP_COMPONENT_NAME))((DNS_RECORD_NAME))((/HCP_COMPONENT_NAME))"'
     networks.default.ip: '"((IP_ADDRESS))"'
     properties.acceptance_tests.admin_password: '"((CLUSTER_ADMIN_PASSWORD))"'
     properties.acceptance_tests.api: '"api.((DOMAIN))"'
@@ -2514,7 +2519,7 @@ configuration:
     properties.cf-usb.mysql_password: "((MYSQL_CF_USB_PASSWORD))"
     properties.cf-usb.mysql_address: 'mysql-int.((HCP_SERVICE_DOMAIN_SUFFIX))'
     properties.cf.skip_ssl_validation: '((SKIP_CERT_VERIFY_INTERNAL))'
-    properties.cf_mysql.mysql.advertise_host: '((#HCP_COMPONENT_NAME))"((HCP_COMPONENT_NAME))-((HCP_COMPONENT_INDEX))((HCP_HOSTNAME_SUFFIX)).((HCP_SERVICE_DOMAIN_SUFFIX))"((/HCP_COMPONENT_NAME))((^HCP_COMPONENT_NAME))nil((/HCP_COMPONENT_NAME))'
+    properties.cf_mysql.mysql.advertise_host: '((#HCP_COMPONENT_NAME))"((HCP_COMPONENT_NAME))-((HCP_COMPONENT_INDEX))-int.((HCP_SERVICE_DOMAIN_SUFFIX))"((/HCP_COMPONENT_NAME))((^HCP_COMPONENT_NAME))nil((/HCP_COMPONENT_NAME))'
     properties.cf_mysql.mysql.seeded_databases: '[{"name":"ccdb", "username":"ccadmin", "password": "((CCDB_ROLE_PASSWORD))"}, {"name":"uaadb", "username": "uaaadmin", "password":"((UAADB_PASSWORD))"}, {"name":"diego", "username": "diego", "password":"((MYSQL_DIEGO_PASSWORD))"},{"name":"usb", "username": "usb", "password":"((MYSQL_CF_USB_PASSWORD))"}]'
     properties.cflinuxfs2-rootfs.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))"'
     properties.consul.agent.log_level: '"((LOG_LEVEL))"'

--- a/container-host-files/etc/hcf/config/scripts/load-hcp-env.sh
+++ b/container-host-files/etc/hcf/config/scripts/load-hcp-env.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script is sourced by the run.sh entrypoint
+# It sets up various environment variables needed in HCP
+
+# Note that this is *sourced* into run.sh, so we can't exit the shell.
+
+if test -n "${HCP_INSTANCE_ID:-}" ; then
+  # export any UAA clients we need
+  export UAA_CLIENTS=`cat /var/vcap/packages/role-manifest/uaa_clients.json`
+
+  # export any UAA authorities we may need
+  export UAA_USER_AUTHORITIES=`cat /var/vcap/packages/role-manifest/uaa_authorities.json`
+fi

--- a/src/hcf-release/jobs/global-properties/spec
+++ b/src/hcf-release/jobs/global-properties/spec
@@ -6,6 +6,7 @@ templates:
   run.erb: bin/run
 
 packages:
+  - role-manifest
 
 properties:
 

--- a/src/hcf-release/packages/role-manifest/packaging
+++ b/src/hcf-release/packages/role-manifest/packaging
@@ -1,0 +1,4 @@
+set -e -x
+
+cp -a uaa_clients.json ${BOSH_INSTALL_TARGET}
+cp -a uaa_authorities.json ${BOSH_INSTALL_TARGET}

--- a/src/hcf-release/packages/role-manifest/pre_packaging
+++ b/src/hcf-release/packages/role-manifest/pre_packaging
@@ -1,0 +1,26 @@
+# abort script on any command that exits with a non zero value
+set -e -x
+
+# Run some ruby to extract whatever information we require from the role
+# manifest. We don't want to include the entire role manifest in the images,
+# just the required information. We shouldn't process build-time things at
+# run-time.
+/usr/bin/env ruby <<-EORUBY
+  require 'yaml'
+  require 'json'
+
+  rm = YAML.load_file('hcf-config/role-manifest.yml')
+
+  File.open('uaa_clients.json', 'w') do |f|
+    f.write(rm['auth']['clients'].to_json)
+  end
+
+  File.open('uaa_authorities.json', 'w') do |f|
+    f.write(rm['auth']['authorities'].to_json)
+  end
+EORUBY
+
+# Remove all traces of the role manifest and other scripts, we don't want them
+# included in our package (they would change the signature of the package and
+# cause things to recompile even though we don't use the information)
+rm -rf hcf-config

--- a/src/hcf-release/packages/role-manifest/spec
+++ b/src/hcf-release/packages/role-manifest/spec
@@ -1,0 +1,7 @@
+---
+name: role-manifest
+
+description: Contains various artifacts derived directly from HCF's role-manifest
+
+files:
+  - hcf-config/role-manifest.yml


### PR DESCRIPTION
We want to keep the default run.sh entrypoint from fissile, because that uses dumb-init correctly. Changing the entrypoint causes run.sh to stop working correctly.
This means that the custom env vars that we were loading as part of the entrypoint are now movin to scripts that get sourced as part of the normal startup of a fissile generated role.