### PR TITLE
Set graph_cleanup_threshold_in_mb to 3 GB

### DIFF
--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -216,7 +216,10 @@ properties:
     # internet and services is configured using proper CF security group
     # rules.
     deny_networks: [0.0.0.0/0]
-    graph_cleanup_threshold_in_mb: 0
+    # Garden should at least be able to cache the cflinuxfs2 rootfs
+    # to avoid copy operations on every garden healthcheck from rep
+    # when there is no app running with the healthcheck rootfs.
+    graph_cleanup_threshold_in_mb: 3000
     listen_address: 0.0.0.0:7777
     listen_network: tcp
     persistent_image_list:


### PR DESCRIPTION
Garden should at least be able to cache the cflinuxfs2 rootfs to avoid copy operations on every garden healthcheck from rep when there is no app running with the healthcheck rootfs.

@mihaibuzgau knows more about this issue