### PR TITLE
USB MySQL password must be immutable

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1737,6 +1737,7 @@ configuration:
     description: The password for access to the Universal Service Broker.
   - name: MYSQL_CF_USB_PASSWORD
     secret: true
+    immutable: true
     generator:
       type: Password
     example: password


### PR DESCRIPTION
We don't have a process that updates passwords for mysql users, so those secrets are not allowed to be rotated.