### PR TITLE
HATS: Wait for app to be ready when testing TCP routing

### DIFF
--- a/src/hcf-release/src/acceptance-tests-brain/test-scripts/006_tcprouting_test.sh
+++ b/src/hcf-release/src/acceptance-tests-brain/test-scripts/006_tcprouting_test.sh
@@ -77,6 +77,14 @@ if [ -z "${port}" ]; then
   exit 1
 fi
 
+# Wait until the application itself is ready
+for (( i = 0; i < 12 ; i++ )) ; do
+    if curl --fail -s -o /dev/null ${APP_NAME}.${CF_DOMAIN} ; then
+        break
+    fi
+    sleep 5
+done
+
 # check that the application works
 sleep 5
 curl ${CF_TCP_DOMAIN}:${port}


### PR DESCRIPTION
Make sure that any failures we see are a result of TCP routing being down, and not because the app isn't ready to serve up requests yet.

(We appear to be in a slushy-freeze right now; please ping around before merging.)