### PR TITLE
HCF-1236 Use a maximum of 1 routing API

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -407,7 +407,7 @@ roles:
   run:
     scaling:
       min: 1
-      max: 65535
+      max: 1
     capabilities: []
     persistent-volumes: []
     shared-volumes: []

--- a/hcp/instance-ha-dev.template.json
+++ b/hcp/instance-ha-dev.template.json
@@ -61,10 +61,6 @@
       {
         "component": "tcp-router",
         "min_instances": 3
-      },
-      {
-        "component": "routing-api",
-        "min_instances": 3
       }
     ]
 }


### PR DESCRIPTION
It turns out the routing api is active/passive, like many other components in Cloud Foundry. HCP can't handle this at the moment, so we can only deploy one at a time.