### PR TITLE
HCF-1229 Use private endpoints for routing api

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -489,8 +489,11 @@ roles:
   - scripts/patches/fix_nodejs_buildpack.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_loggregator.sh
+  - scripts/patches/use_routing_api_private_endpoint.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
+    release_name: hcf
+  - name: patch-properties
     release_name: hcf
   - name: cloud_controller_ng
     release_name: cf

--- a/container-host-files/etc/hcf/config/scripts/patches/use_routing_api_private_endpoint.sh
+++ b/container-host-files/etc/hcf/config/scripts/patches/use_routing_api_private_endpoint.sh
@@ -1,0 +1,49 @@
+set -e
+
+PATCH_DIR=/var/vcap/jobs-src/cloud_controller_ng/templates/
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+cd "$PATCH_DIR"
+
+read -r -d '' setup_patch_cc_yaml <<'PATCH' || true
+--- cloud_controller_api.yml.erb
++++ cloud_controller_api.yml.erb
+@@ -209,6 +209,7 @@ hm9000:
+
+ <% if p("routing_api.enabled") %>
+ routing_api:
++  private_endpoint: <%= "#{p('routing_api.uri')}:#{p('routing_api.port')}" %>
+   url: <%= "https://api.#{system_domain}/routing" %>
+   routing_client_name: "cc_routing"
+   routing_client_secret: <%= p("uaa.clients.cc_routing.secret") %>
+PATCH
+
+echo -e "${setup_patch_cc_yaml}" | patch --force
+
+PATCH_DIR=/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/lib/cloud_controller/
+
+cd "$PATCH_DIR"
+
+read -r -d '' setup_patch_routing_api_endpoint <<'PATCH' || true
+--- dependency_locator.rb
++++ dependency_locator.rb
+@@ -221,7 +221,7 @@ module CloudController
+       uaa_target = @config[:uaa][:url]
+       token_issuer = CF::UAA::TokenIssuer.new(uaa_target, client_id, secret, { skip_ssl_validation: skip_cert_verify })
+ 
+-      routing_api_url = @config[:routing_api] && @config[:routing_api][:url]
++      routing_api_url = @config[:routing_api] && @config[:routing_api][:private_endpoint]
+       RoutingApi::Client.new(routing_api_url, token_issuer, skip_cert_verify)
+     end
+ 
+PATCH
+
+echo -e "${setup_patch_routing_api_endpoint}" | patch --force
+
+touch "${SENTINEL}"
+
+exit 0

--- a/src/hcf-release/jobs/patches-job/spec
+++ b/src/hcf-release/jobs/patches-job/spec
@@ -24,3 +24,10 @@ properties:
 
   diego.rep.cell_id:
     description: "Name of the diego cell"
+
+  routing_api.uri:
+    description: "URL where the routing API can be reached internally"
+    default: http://routing-api.service.cf.internal
+  routing_api.port:
+    description: "Port on which Routing API is running."
+    default: 3000


### PR DESCRIPTION
The cc should be using the private endpoint for the routing-api. This allows dev instances on HCP to avoid certificate issues.