### PR TITLE
HATS 014: Force start the app after `cf restage`

### DIFF
--- a/src/hcf-release/src/acceptance-tests-brain/test-scripts/014_sso_authenticated_passthrough_test.sh
+++ b/src/hcf-release/src/acceptance-tests-brain/test-scripts/014_sso_authenticated_passthrough_test.sh
@@ -45,6 +45,8 @@ APP_NAME=${APP_DIR}-$(random_suffix)
 DESIRED_STRING="INSTANCE_INDEX=0"
 SSO_SERVICE="sso-service-test-brain"
 TMP=$(mktemp -dt 014_sso.XXXXXX)
+RED="\033[1;31m"
+NORMAL="\033[0m"
 
 ## # # ## ### Test-specific code ### ## # #
 
@@ -83,6 +85,7 @@ cf bind-route-service ${CF_DOMAIN} ${SSO_SERVICE} --hostname ${hostname}
 
 # SSO only applies after restaging
 cf restage ${APP_NAME}
+cf start ${APP_NAME}  # Only useful if restage failed to tail the logs
 
 # Check that the output is correct
 oauth_token="$(cf oauth-token | cut -d ' ' -f 2-)" # Drop the "bearer" prefix
@@ -91,7 +94,7 @@ curl --dump-header ${TMP}/headers  \
     "${url}/env" > ${TMP}/app_log
 
 if ! grep ${DESIRED_STRING} ${TMP}/app_log ; then
-    printf "%bERROR%b SSO failed to have expected output" "${RED}" "${NORMAL}"
+    printf "%bERROR%b SSO failed to have expected output\n" "${RED}" "${NORMAL}"
     command="${me} curl --cookie ssoCookie=${oauth_token:0:8}... ${url}/env"
     echo "SSO failed to have expected output"
     echo "${command} headers:"


### PR DESCRIPTION
Sometimes `cf restage` can fail to tail the logs, and finish before the app has finished starting.  If we force a `cf start` afterwards, it will do the right thing (and return success if the app was already started). This avoids an issue where the app fails to start and the router instead responds with a 404 app not found.