### PR TITLE
HATS: Allow customizing docker registry for test app

### DIFF
--- a/src/hcf-release/src/acceptance-tests-brain/test-scripts/004_dockerapp_test.sh
+++ b/src/hcf-release/src/acceptance-tests-brain/test-scripts/004_dockerapp_test.sh
@@ -50,4 +50,4 @@ trap test_cleanup EXIT ERR
 
 # Test pushing a docker app
 cf enable-feature-flag diego_docker
-cf push ${DOCKERAPP} -o viovanov/node-env-tiny
+cf push ${DOCKERAPP} -o "${TESTBRAIN_DOCKER_REGISTRY:+${TESTBRAIN_DOCKER_REGISTRY%/}/}viovanov/node-env-tiny"

--- a/src/hcf-release/src/acceptance-tests-brain/test-scripts/005_sso_test.sh
+++ b/src/hcf-release/src/acceptance-tests-brain/test-scripts/005_sso_test.sh
@@ -56,7 +56,7 @@ trap test_cleanup EXIT ERR
 
 # Push a docker app to redirect
 cf enable-feature-flag diego_docker
-cf push ${DOCKERAPP} -o viovanov/node-env-tiny
+cf push ${DOCKERAPP} -o "${TESTBRAIN_DOCKER_REGISTRY:+${TESTBRAIN_DOCKER_REGISTRY%/}/}viovanov/node-env-tiny"
 
 cf create-service sso-routing default ${DOCKERSERVICE}
 cf bind-route-service ${CF_DOMAIN} ${DOCKERSERVICE} --hostname ${DOCKERAPP}

--- a/src/hcf-release/src/acceptance-tests-brain/test-scripts/007_usb_test.sh
+++ b/src/hcf-release/src/acceptance-tests-brain/test-scripts/007_usb_test.sh
@@ -71,7 +71,7 @@ cf update-quota default --reserved-route-ports -1
 # run hsm passthrough docker
 cf enable-feature-flag diego_docker
 cf push "${HSM_SERVICE_INSTANCE}" \
-    -o 'helioncf/hcf-usb-sidecar-test' \
+    -o "${TESTBRAIN_DOCKER_REGISTRY:+${TESTBRAIN_DOCKER_REGISTRY%/}/}helioncf/hcf-usb-sidecar-test" \
     -d "${CF_TCP_DOMAIN}" --random-route \
     --no-start | tee "${TMP}/log"
 cf set-env "${HSM_SERVICE_INSTANCE}" SIDECAR_API_KEY string_empty

--- a/src/hcf-release/src/acceptance-tests-brain/test-scripts/016_persi_test.sh
+++ b/src/hcf-release/src/acceptance-tests-brain/test-scripts/016_persi_test.sh
@@ -58,7 +58,7 @@ trap test_cleanup EXIT ERR
 
 # Push a docker app
 cf enable-feature-flag diego_docker
-cf push ${DOCKERAPP} -o viovanov/node-env-tiny -i 2
+cf push ${DOCKERAPP} -o "${TESTBRAIN_DOCKER_REGISTRY:+${TESTBRAIN_DOCKER_REGISTRY%/}/}viovanov/node-env-tiny" -i 2
 
 cf create-service shared-volume default ${DOCKERSERVICE}
 cf bind-service ${DOCKERAPP} ${DOCKERSERVICE}


### PR DESCRIPTION
This makes it possible to run HATS on an air-gapped cluster by providing a custom docker registry with the appropriate images.  By default this is not set (and the main docker.io registry is used).

This does not allow all of HATS to pass due to the use of packagist.org by composer when pushing PHP apps.