### PR TITLE
HCF-1204 Add offline Java buildpack

### DIFF
--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -63,10 +63,10 @@ properties:
     install_buildpacks:
     - name: staticfile_buildpack
       package: staticfile-buildpack
-    - name: java_offline_buildpack
-      package: java-offline-buildpack
     - name: java_buildpack
       package: java-buildpack
+    - name: java_offline_buildpack
+      package: java-offline-buildpack
     - name: ruby_buildpack
       package: ruby-buildpack
     - name: nodejs_buildpack

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -515,9 +515,9 @@ roles:
     release_name: cf
   - name: staticfile-buildpack
     release_name: cf
-  - name: java-offline-buildpack
-    release_name: cf
   - name: java-buildpack
+    release_name: cf
+  - name: java-offline-buildpack
     release_name: cf
   - name: cf_iis_buildpack
     release_name: windows-runtime-release


### PR DESCRIPTION
Priority will be for the offline buildpack as most of our customers will
be using it. The priority can be changed by the user with the `cf
update-buildpack` command