### PR TITLE
HCFRO-465 Fix the v2 info version number

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1762,7 +1762,7 @@ configuration:
     immutable: true
     description: The password for the cluster administrator.
   - name: CLUSTER_BUILD
-    default: 4.0.1
+    default: 4.1.1
     description: "'build' attribute in the /v2/info endpoint"
   - name: CLUSTER_DESCRIPTION
     default: HPE Helion Cloud Foundry


### PR DESCRIPTION
- Should have said 4.1.1 from the beginning, it's in an obscure place
  that we forget to bump.