### PR TITLE
[HCF-1285] Don't scale roles that are active/passive and use consul locks

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -200,7 +200,7 @@ roles:
   run:
     scaling:
       min: 1
-      max: 65535
+      max: 1
     capabilities: []
     persistent-volumes: []
     shared-volumes: []
@@ -942,7 +942,7 @@ roles:
   run:
     scaling:
       min: 1
-      max: 65535
+      max: 1
     capabilities: []
     persistent-volumes: []
     shared-volumes: []
@@ -1023,7 +1023,7 @@ roles:
   run:
     scaling:
       min: 1
-      max: 65535
+      max: 1
     capabilities: []
     persistent-volumes: []
     shared-volumes: []
@@ -1059,7 +1059,7 @@ roles:
   run:
     scaling:
       min: 1
-      max: 65535
+      max: 3
     capabilities: []
     persistent-volumes: []
     shared-volumes: []

--- a/hcp/instance-ha-dev.template.json
+++ b/hcp/instance-ha-dev.template.json
@@ -11,6 +11,10 @@
     ],
     "scaling": [
       {
+        "component": "diego-cell",
+        "min_instances": 1
+      },
+      {
         "component": "api",
         "min_instances": 3
       },
@@ -31,14 +35,6 @@
         "min_instances": 3
       },
       {
-        "component": "diego-cc-bridge",
-        "min_instances": 3
-      },
-      {
-        "component": "diego-route-emitter",
-        "min_instances": 3
-      },
-      {
         "component": "nats",
         "min_instances": 3
       },
@@ -53,10 +49,6 @@
       {
         "component": "mysql",
         "min_instances": 3
-      },
-      {
-        "component": "diego-cell",
-        "min_instances": 1
       },
       {
         "component": "tcp-router",


### PR DESCRIPTION
Upstream uses consul locks to select the master for these roles, and then uses consul's DNS to direct traffic to the master copy only. This doesn't work on HCP, we don't have the mechanism to tell load balancers to ignore passive copies.