### PR TITLE
Fix acceptance timeouts

### DIFF
--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -9,8 +9,11 @@ properties:
     include_security_groups: true
     include_internet_dependent: true
     include_services: true
-    cf_push_timeout: 300
+    async_service_operation_timeout: 5
+    broker_start_timeout: 10
+    cf_push_timeout: 5
     default_timeout: 300
+    long_curl_timeout: 5
   acceptance_tests_brain:
     user: 'admin'
     org: test-brain-org


### PR DESCRIPTION
Some of the units were wrong for the existing timeouts, and others
needed to be added to increase past the defaults.