### PR TITLE
Don't use y2j; it runs inside docker

### DIFF
--- a/make/include/versioning
+++ b/make/include/versioning
@@ -6,7 +6,7 @@ test -n "${XTRACE}" && set -o xtrace
 
 set -o errexit -o nounset
 
-CF_VERSION=$(cat src/cf-release/releases/index.yml | y2j | jq '.builds[].version' | sed -e 's/"//g' | sort -nr | head -1)
+CF_VERSION=$(perl -ne '$v = $1 if /^\s+version: .?(\d+)/; END { print $v }' src/cf-release/releases/index.yml)
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 GIT_DESCRIBE=${GIT_DESCRIBE:-$(git describe --tags --long)}


### PR DESCRIPTION
The replace runs a local perl command instead.  It assumes that there
are no other "version:" fields in the file, and that versions remain
sorted (last version is highest/current).