### PR TITLE
Wait for HA hosts to be valid

### DIFF
--- a/container-host-files/etc/hcf/config/scripts/configure-HA-hosts.sh
+++ b/container-host-files/etc/hcf/config/scripts/configure-HA-hosts.sh
@@ -30,8 +30,16 @@ find_cluster_ha_hosts() {
 
         # Loop over the environment to locate the component name variables.
         local hosts=''
+        local names=()
+        while true ; do
+            names=($(dig "${component_name}.${HCP_SERVICE_DOMAIN_SUFFIX}" -t SRV | awk '/IN[\t ]+A/ { print $1 }'))
+            if test "${#names[@]}" -gt 0 ; then
+                break
+            fi
+            sleep 1
+        done
         local name
-        for name in $(dig "${component_name}.${HCP_SERVICE_DOMAIN_SUFFIX}" -t SRV | awk '/IN[\t ]+A/ { print $1 }') ; do
+        for name in "${names[@]}" ; do
             hosts="${hosts},\"${name%.}\""
         done
         # Return the result, with [] around the hostnames, removing the leading comma


### PR DESCRIPTION
If we run too fast, DNS doesn't update correctly and we end up with no hosts.  This is obviously incorrect since it should at least find the current container.

This is a port of hpcloud/uaa-fissile-release#3