### PR TITLE
Enable direnv for ~/uaa-fissile-release

### DIFF
--- a/bin/cf-hyperkube-install.sh
+++ b/bin/cf-hyperkube-install.sh
@@ -22,6 +22,7 @@ sudo gem install bosh_cli
 sudo gem install bundler
 
 cd ~/uaa-fissile-release
+direnv allow
 git submodule update --init --recursive
 
 docker pull ubuntu:14.04 #'fissile build layer compilation' fails without this 


### PR DESCRIPTION
This will set the path to the fissile binary in the Vagrant box.

Depends on https://github.com/hpcloud/uaa-fissile-release/pull/4 to actually /set/ the path correctly.