### PR TITLE
Restore dev-dns for vagrant

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1248,6 +1248,30 @@ roles:
   configuration:
     templates:
       properties.hcf.uaa.root-zone.url: ((HCF_UAA_ROOT_ZONE_URL))
+- name: dev-dns
+  type: docker
+  tags: [dev-only]
+  run:
+    env: []
+    scaling:
+      min: 1
+      max: 1
+    capabilities: [NET_ADMIN]
+    persistent-volumes: []
+    shared-volumes: []
+    memory: 1024
+    virtual-cpus: 1
+    exposed-ports:
+    - name: dev-dns
+      protocol: UDP
+      external: 53
+      internal: 8600
+      public: true
+    - name: dev-dns-tcp
+      protocol: TCP
+      external: 53
+      internal: 8600
+      public: true
 configuration:
   variables:
   - name: ALLOWED_CORS_DOMAINS


### PR DESCRIPTION
We still need the DNS server for vagrant, so that we can resolve DNS in the containers (for staging/running).

This is not used for k8s deployments.

Note that we never removed the code for it, just the role manifest entry, so putting it back works fine.