### PR TITLE
Make direnv optional

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -73,7 +73,7 @@ export HCF_PACKAGE_COMPILATION_CACHE="${PWD}/.fissile/compilation"
 
 # The following is for fish support: run this script as `bash $0 fish`, and it
 # will print out the fish commands for you to source.
-if test "${BASH_ARGV:+${BASH_ARGV[-1]}}" = "fish" ; then
+if test "${BASH_ARGV:+${BASH_ARGV[0]}}" = "fish" ; then
     for var in $(env | grep -E '^(FISSILE_|HCF_)' | cut -d= -f1) ; do
         echo "set -x ${var} '${!var}'"
     done


### PR DESCRIPTION
Instead of using direnv, `source .envrc` should now also work correctly. For fish users, `bash .envrc fish | source` is required.

This should work with fish (special syntax), bash, ksh, and zsh.