### PR TITLE
Disable the CF-inherent rsyslogd process

### DIFF
--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -285,6 +285,8 @@ properties:
     org: smoke-test-org
     space: smoke-test-space
     skip_ssl_validation: true
+  syslog_daemon_config:
+    enable: false
   syslog_drain_binder:
     locked_memory_limit: kernel
   system_domain_organization: null


### PR DESCRIPTION
It interferes with the one started as part of the fissile/monit run.sh.
Trello: https://trello.com/c/ehyey1Bo/66-2-rsyslog-daemons-making-things-ugly
