### PR TITLE
Increased verbosity for p-d-s

### DIFF
--- a/container-host-files/etc/hcf/config/scripts/fetch_uaa_verification_key.sh
+++ b/container-host-files/etc/hcf/config/scripts/fetch_uaa_verification_key.sh
@@ -29,13 +29,13 @@ function retry_forever () {
     shift 1
 
     while true ; do
-	printf "Trying: %s\n" "$*"
+        printf "Trying: %s\n" "$*"
         if "$@" ; then
-	    status ' SUCCESS'
+            status ' SUCCESS'
             break
         fi
-	trouble '  FAILED'
-	status "Waiting ${delay} ..."
+        trouble '  FAILED'
+        status "Waiting ${delay} ..."
         sleep "${delay}"
     done
 }

--- a/container-host-files/etc/hcf/config/scripts/fetch_uaa_verification_key.sh
+++ b/container-host-files/etc/hcf/config/scripts/fetch_uaa_verification_key.sh
@@ -7,19 +7,50 @@
 
 # Note that this is *sourced* into run.sh, so we can't exit the shell.
 
-# Wait for UAA
-while true ; do
-    if curl --fail \
-        $(if test "${SKIP_CERT_VERIFY_EXTERNAL}" = "true" ; then echo "--insecure" ; fi) \
-        "${HCF_UAA_INTERNAL_URL}/token_key"
-    then
-        break
-    fi
-    sleep 10
-done
+
+# Report progress to the user; use as printf
+status() {
+    local fmt="${1}"
+    shift
+    printf "\n%b${fmt}%b\n" "\033[0;32m" "$@" "\033[0m"
+}
+
+# Report problem to the user; use as printf
+trouble() {
+    local fmt="${1}"
+    shift
+    printf "\n%b${fmt}%b\n" "\033[0;31m" "$@" "\033[0m"
+}
+
+# helper function to retry a command several times, with a delay between trials
+# usage: retry <max-tries> <delay> <command>...
+function retry_forever () {
+    delay=${1}
+    shift 1
+
+    while true ; do
+	printf "Trying: %s\n" "$*"
+        if "$@" ; then
+	    status ' SUCCESS'
+            break
+        fi
+	trouble '  FAILED'
+	status "Waiting ${delay} ..."
+        sleep "${delay}"
+    done
+}
+
+SKIP=$(if test "${SKIP_CERT_VERIFY_EXTERNAL}" = "true" ; then echo "--insecure" ; fi)
+
+status "Waiting for UAA to be available at ${HCF_UAA_INTERNAL_URL}/token_key ..."
+retry_forever 10s curl --connect-timeout 5 --fail $SKIP "${HCF_UAA_INTERNAL_URL}/token_key"
+
+status "Extract JWT public signing key"
 export JWT_SIGNING_PUB="$(\
     { curl --fail $(if test "${SKIP_CERT_VERIFY_EXTERNAL}" = "true" ; then echo "--insecure" ; fi)\
         "${HCF_UAA_INTERNAL_URL}/token_key" \
         || exit 1 \
     ; } \
     | awk 'BEGIN { RS="," ; FS="\"" } /value/ { if ($2 == "value") print $4 } ')"
+
+status DONE

--- a/container-host-files/etc/hcf/config/scripts/fetch_uaa_verification_key.sh
+++ b/container-host-files/etc/hcf/config/scripts/fetch_uaa_verification_key.sh
@@ -42,7 +42,7 @@ function retry_forever () {
 
 SKIP=$(if test "${SKIP_CERT_VERIFY_EXTERNAL}" = "true" ; then echo "--insecure" ; fi)
 
-status "Waiting for UAA to be available at ${HCF_UAA_INTERNAL_URL}/token_key ..."
+status "Waiting for UAA to be available ..."
 retry_forever 10s curl --connect-timeout 5 --fail $SKIP "${HCF_UAA_INTERNAL_URL}/token_key"
 
 status "Extract JWT public signing key"

--- a/container-host-files/etc/hcf/config/scripts/fetch_uaa_verification_key.sh
+++ b/container-host-files/etc/hcf/config/scripts/fetch_uaa_verification_key.sh
@@ -22,8 +22,8 @@ trouble() {
     printf "\n%b${fmt}%b\n" "\033[0;31m" "$@" "\033[0m"
 }
 
-# helper function to retry a command several times, with a delay between trials
-# usage: retry <max-tries> <delay> <command>...
+# helper function to retry a command until it suceeds, with a delay between trials
+# usage: retry_forever <delay> <command>...
 function retry_forever () {
     delay=${1}
     shift 1

--- a/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
+++ b/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
@@ -81,10 +81,10 @@ CURL_SKIP="<%= properties.ssl.skip_cert_verify ? '--insecure' : '' %>"
 UAA_ENDPOINT="<%= p('hcf.uaa.internal-url') %>"
 API_ENDPOINT="<%= p("cc.srv_api_uri") %>"
 
-status "Waiting for CC ... $CF_SKIP at $API_ENDPOINT"
+status "Waiting for CC ..."
 retry 240 30s cf api $CF_SKIP "$API_ENDPOINT"
 
-status "Waiting for UAA ... at $CURL_SKIP $UAA_ENDPOINT/info"
+status "Waiting for UAA ..."
 retry 240 30s curl --connect-timeout 5 --fail --header 'Accept: application/json' $UAA_ENDPOINT/info
 
 insert_cf_client_auth_token.rb "$UAA_ENDPOINT" hcf_auto_config:<%= p("uaa.clients.hcf_auto_config.secret").shellescape %> ${CURL_SKIP}

--- a/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
+++ b/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
@@ -40,6 +40,20 @@ if_p("hcf_set_proxy.running_no_proxy") do |val|
 end
 %>
 
+# Report progress to the user; use as printf
+status() {
+    local fmt="${1}"
+    shift
+    printf "\n%b${fmt}%b\n" "\033[0;32m" "$@" "\033[0m"
+}
+
+# Report problem to the user; use as printf
+trouble() {
+    local fmt="${1}"
+    shift
+    printf "\n%b${fmt}%b\n" "\033[0;31m" "$@" "\033[0m"
+}
+
 # helper function to retry a command several times, with a delay between trials
 # usage: retry <max-tries> <delay> <command>...
 function retry () {
@@ -49,9 +63,13 @@ function retry () {
     shift 2
 
     while test ${i} -lt ${max} ; do
+	printf "Trying: %s\n" "$*"
         if "$@" ; then
+	    status ' SUCCESS'
             break
         fi
+	trouble '  FAILED'
+	status "Waiting ${delay} ..."
         sleep "${delay}"
         i="$(expr ${i} + 1)"
     done
@@ -63,11 +81,11 @@ CURL_SKIP="<%= properties.ssl.skip_cert_verify ? '--insecure' : '' %>"
 UAA_ENDPOINT="<%= p('hcf.uaa.internal-url') %>"
 API_ENDPOINT="<%= p("cc.srv_api_uri") %>"
 
-echo "Waiting for CC... $CF_SKIP $API_ENDPOINT"
+status "Waiting for CC ... $CF_SKIP at $API_ENDPOINT"
 retry 240 30s cf api $CF_SKIP "$API_ENDPOINT"
 
-echo "Waiting for UAA... $CURL_SKIP $UAA_ENDPOINT"
-retry 240 30s curl --fail --silent --header 'Accept: application/json' $UAA_ENDPOINT/info
+status "Waiting for UAA ... at $CURL_SKIP $UAA_ENDPOINT/info"
+retry 240 30s curl --fail --header 'Accept: application/json' $UAA_ENDPOINT/info
 
 insert_cf_client_auth_token.rb "$UAA_ENDPOINT" hcf_auto_config:<%= p("uaa.clients.hcf_auto_config.secret").shellescape %> ${CURL_SKIP}
 
@@ -78,7 +96,7 @@ cf set-<%= runtime %>-environment-variable-group <%= env[runtime].to_json.shelle
 <%end
 end %>
 
-echo "Remove temporary users"
+status "Remove temporary users"
 remove_temporary_users.rb "${API_ENDPOINT}" "${CURL_SKIP}"
 
-echo "Setting of external proxies complete."
+status "Setting of external proxies complete."

--- a/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
+++ b/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
@@ -85,7 +85,7 @@ status "Waiting for CC ... $CF_SKIP at $API_ENDPOINT"
 retry 240 30s cf api $CF_SKIP "$API_ENDPOINT"
 
 status "Waiting for UAA ... at $CURL_SKIP $UAA_ENDPOINT/info"
-retry 240 30s curl --fail --header 'Accept: application/json' $UAA_ENDPOINT/info
+retry 240 30s curl --connect-timeout 5 --fail --header 'Accept: application/json' $UAA_ENDPOINT/info
 
 insert_cf_client_auth_token.rb "$UAA_ENDPOINT" hcf_auto_config:<%= p("uaa.clients.hcf_auto_config.secret").shellescape %> ${CURL_SKIP}
 

--- a/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
+++ b/src/hcf-release/jobs/hcf-set-proxy/templates/run.erb
@@ -63,13 +63,13 @@ function retry () {
     shift 2
 
     while test ${i} -lt ${max} ; do
-	printf "Trying: %s\n" "$*"
+        printf "Trying: %s\n" "$*"
         if "$@" ; then
-	    status ' SUCCESS'
+            status ' SUCCESS'
             break
         fi
-	trouble '  FAILED'
-	status "Waiting ${delay} ..."
+        trouble '  FAILED'
+        status "Waiting ${delay} ..."
         sleep "${delay}"
         i="$(expr ${i} + 1)"
     done

--- a/src/hcf-release/jobs/uaa-create-user/templates/run.erb
+++ b/src/hcf-release/jobs/uaa-create-user/templates/run.erb
@@ -43,13 +43,13 @@ function retry () {
     shift 2
 
     while test ${i} -lt ${max} ; do
-	printf "Trying: %s\n" "$*"
+        printf "Trying: %s\n" "$*"
         if "$@" ; then
-	    status ' SUCCESS'
+            status ' SUCCESS'
             break
         fi
-	trouble '  FAILED'
-	status "Waiting ${delay} ..."
+        trouble '  FAILED'
+        status "Waiting ${delay} ..."
         sleep "${delay}"
         i="$(expr ${i} + 1)"
     done
@@ -191,10 +191,10 @@ if uaac user get <%= username %> ; then
 else
     status "Creating user %s" <%= username %>
     uaac user add <%= username %> \
-	--given_name '' \
-	--family_name '' \
-	--emails <%= username %> \
-	--password <%= password %>
+        --given_name '' \
+        --family_name '' \
+        --emails <%= username %> \
+        --password <%= password %>
 fi
 
 user_id=$(uaac user get <%= username %> | awk '/^  id:/ { print $2 }')

--- a/src/hcf-release/jobs/uaa-create-user/templates/run.erb
+++ b/src/hcf-release/jobs/uaa-create-user/templates/run.erb
@@ -7,6 +7,10 @@
 
 set -o errexit -o nounset
 
+# Default: verbose operation. Uncomment 2nd line to quiet this job
+SILENT=
+#SILENT=--silent
+
 <% if properties.uaa.scim.users.empty? %>
      echo "Aborting. No admin user configured."
      exit 1
@@ -23,6 +27,13 @@ status() {
     printf "\n%b${fmt}%b\n" "\033[0;32m" "$@" "\033[0m"
 }
 
+# Report problem to the user; use as printf
+trouble() {
+    local fmt="${1}"
+    shift
+    printf "\n%b${fmt}%b\n" "\033[0;31m" "$@" "\033[0m"
+}
+
 # helper function to retry a command several times, with a delay between trials
 # usage: retry <max-tries> <delay> <command>...
 function retry () {
@@ -32,9 +43,13 @@ function retry () {
     shift 2
 
     while test ${i} -lt ${max} ; do
+	printf "Trying: %s\n" "$*"
         if "$@" ; then
+	    status ' SUCCESS'
             break
         fi
+	trouble '  FAILED'
+	status "Waiting ${delay} ..."
         sleep "${delay}"
         i="$(expr ${i} + 1)"
     done
@@ -54,8 +69,8 @@ if test -z "${HCP_INSTANCE_ID:-}" ; then
 
     UAA_ZONE_ID="${KUBERNETES_NAMESPACE:-hcf}"
 
-    status "Waiting for root UAA to be available..."
-    retry 240 30s curl --silent --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.root-zone.url") %>/info'
+    status "Waiting for root UAA to be available at %s ..." '<%= p("hcf.uaa.internal-url") %>'
+    retry 240 30s curl ${SILENT} --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.root-zone.url") %>/info'
 
     # We need to create the HCF zone manually
     status "Checking for UAA zone ${UAA_ZONE_ID}..."
@@ -75,7 +90,9 @@ if test -z "${HCP_INSTANCE_ID:-}" ; then
     status "Creating groups..."
     <% p('uaa.user.authorities', []).each do |group_name| %>
         if ! uaac --zone "${UAA_ZONE_ID}" group get '<%= group_name %>' ; then
+            status "- Group <%= group_name %> ..."
             uaac --zone "${UAA_ZONE_ID}" group add '<%= group_name %>'
+            status "- Group <%= group_name %> /done"
         fi
     <% end %>
 
@@ -108,8 +125,8 @@ if test -z "${HCP_INSTANCE_ID:-}" ; then
 else
     # Due to CAPS-969, our UAA clients are missing `autoapprove` and `redirect-uri` configs
     # We update them manually to work around the issue.
-    status "Waiting for UAA zone to be availabile..."
-    retry 240 30s curl --silent --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.internal-url") %>/info'
+    status "Waiting for UAA zone to be available at %s ..." '<%= p("hcf.uaa.internal-url") %>'
+    retry 240 30s curl ${SILENT} --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.internal-url") %>/info'
 
     status "Logging in to %s" '<%= p("hcf.uaa.internal-url") %>'
     uaac target <%= uaac_ssl %> <%= p("hcf.uaa.internal-url") %>
@@ -152,8 +169,8 @@ else
     set -o errexit
 fi
 
-status "Waiting for UAA to be availabile at %s..." '<%= p("hcf.uaa.internal-url") %>'
-retry 240 30s curl --silent --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.internal-url") %>/info'
+status "Waiting for UAA zone to be available at %s ..." '<%= p("hcf.uaa.internal-url") %>'
+retry 240 30s curl ${SILENT} --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.internal-url") %>/info'
 
 status "Logging in to %s" '<%= p("hcf.uaa.internal-url") %>'
 uaac target <%= uaac_ssl %> <%= p("hcf.uaa.internal-url") %>

--- a/src/hcf-release/jobs/uaa-create-user/templates/run.erb
+++ b/src/hcf-release/jobs/uaa-create-user/templates/run.erb
@@ -70,7 +70,7 @@ if test -z "${HCP_INSTANCE_ID:-}" ; then
     UAA_ZONE_ID="${KUBERNETES_NAMESPACE:-hcf}"
 
     status "Waiting for root UAA to be available at %s ..." '<%= p("hcf.uaa.internal-url") %>'
-    retry 240 30s curl ${SILENT} --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.root-zone.url") %>/info'
+    retry 240 30s curl ${SILENT} --connect-timeout 5 --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.root-zone.url") %>/info'
 
     # We need to create the HCF zone manually
     status "Checking for UAA zone ${UAA_ZONE_ID}..."
@@ -126,7 +126,7 @@ else
     # Due to CAPS-969, our UAA clients are missing `autoapprove` and `redirect-uri` configs
     # We update them manually to work around the issue.
     status "Waiting for UAA zone to be available at %s ..." '<%= p("hcf.uaa.internal-url") %>'
-    retry 240 30s curl ${SILENT} --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.internal-url") %>/info'
+    retry 240 30s curl ${SILENT} --connect-timeout 5 --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.internal-url") %>/info'
 
     status "Logging in to %s" '<%= p("hcf.uaa.internal-url") %>'
     uaac target <%= uaac_ssl %> <%= p("hcf.uaa.internal-url") %>
@@ -170,7 +170,7 @@ else
 fi
 
 status "Waiting for UAA zone to be available at %s ..." '<%= p("hcf.uaa.internal-url") %>'
-retry 240 30s curl ${SILENT} --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.internal-url") %>/info'
+retry 240 30s curl ${SILENT} --connect-timeout 5 --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.internal-url") %>/info'
 
 status "Logging in to %s" '<%= p("hcf.uaa.internal-url") %>'
 uaac target <%= uaac_ssl %> <%= p("hcf.uaa.internal-url") %>

--- a/src/hcf-release/jobs/uaa-create-user/templates/run.erb
+++ b/src/hcf-release/jobs/uaa-create-user/templates/run.erb
@@ -69,7 +69,7 @@ if test -z "${HCP_INSTANCE_ID:-}" ; then
 
     UAA_ZONE_ID="${KUBERNETES_NAMESPACE:-hcf}"
 
-    status "Waiting for root UAA to be available at %s ..." '<%= p("hcf.uaa.internal-url") %>'
+    status "Waiting for root UAA to be available ..."
     retry 240 30s curl ${SILENT} --connect-timeout 5 --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.root-zone.url") %>/info'
 
     # We need to create the HCF zone manually
@@ -125,7 +125,7 @@ if test -z "${HCP_INSTANCE_ID:-}" ; then
 else
     # Due to CAPS-969, our UAA clients are missing `autoapprove` and `redirect-uri` configs
     # We update them manually to work around the issue.
-    status "Waiting for UAA zone to be available at %s ..." '<%= p("hcf.uaa.internal-url") %>'
+    status "Waiting for UAA zone to be available ..."
     retry 240 30s curl ${SILENT} --connect-timeout 5 --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.internal-url") %>/info'
 
     status "Logging in to %s" '<%= p("hcf.uaa.internal-url") %>'
@@ -169,7 +169,7 @@ else
     set -o errexit
 fi
 
-status "Waiting for UAA zone to be available at %s ..." '<%= p("hcf.uaa.internal-url") %>'
+status "Waiting for UAA zone to be available ..."
 retry 240 30s curl ${SILENT} --connect-timeout 5 --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("hcf.uaa.internal-url") %>/info'
 
 status "Logging in to %s" '<%= p("hcf.uaa.internal-url") %>'


### PR DESCRIPTION
https://trello.com/c/8sPDuSg3/174-2-post-deployment-api-routing-api-setup-needs-to-output-something
Role `post-deployment`: `uaa-create-user` - Increase verbosity
- curl more verbose
- retry shows command invoked, explicitly notes success/failure, waiting times
- Extended status messages (added url), fixed typos, normalized to a single form.
Ditto same role job `cf-set-proxy`
Ditto role `api, script `fetch_uaa_...`
