### PR TITLE
vagrant: use virtio for libvirt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,7 +91,7 @@ Vagrant.configure(2) do |config|
 #  end
 
   config.vm.provider "libvirt" do |libvirt, override|
-    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-libvirt-v2.0.1.box"
+    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-libvirt-v2.0.2.box"
     libvirt.driver = "kvm"
     # Allow downloading boxes from sites with self-signed certs
     libvirt.memory = vm_memory

--- a/packer/Vagrantfile.template
+++ b/packer/Vagrantfile.template
@@ -8,11 +8,8 @@ Vagrant.configure('2') do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provider :libvirt do |libvirt|
-    # We require a secondary disk at /dev/sdb for /var/lib/kubelet
-    # This means the primary must be /dev/sda (to bump the available names)
-    # This stuff was done in packer for VirtualBox
-    libvirt.disk_bus = 'scsi'
-    libvirt.storage :file, :size => '100G', bus: 'scsi', device: 'sdb'
+    libvirt.disk_bus = 'virtio'
+    libvirt.storage :file, :size => '100G', bus: 'virtio', device: 'vdb'
 
     if ENV['VAGRANT_LIBVIRT_URI']
       require 'uri'
@@ -38,16 +35,20 @@ Vagrant.configure('2') do |config|
   # do it on `vagrant up`.
   config.vm.provision :shell, privileged: true, inline: <<-SHELL
     set -o errexit -o xtrace
-    parted --script /dev/sdb mklabel gpt
-    parted --script /dev/sdb mkpart kubelet-data ext4 0% 100%
+    disk=/dev/sdb
+    if test -e /dev/vdb ; then
+      disk=/dev/vdb
+    fi
+    parted --script "${disk}" mklabel gpt
+    parted --script "${disk}" mkpart kubelet-data ext4 0% 100%
     echo "Waiting for new partition to show up..."
-    while ! test -e /dev/sdb1 ; do
-      partprobe /dev/sdb
+    while ! test -e "${disk}1" ; do
+      partprobe "${disk}"
       sleep 1
     done
-    mkfs.ext4 /dev/sdb1
-    eval $(blkid -s UUID -o export /dev/sdb1)
-    mount /dev/sdb1 /mnt
+    mkfs.ext4 "${disk}1"
+    eval $(blkid -s UUID -o export "${disk}1")
+    mount "${disk}1" /mnt
     mkdir /mnt/{docker,kubelet,hostpath,fissile}
     chown kube:kube /mnt/hostpath
     chown vagrant:users /mnt/fissile

--- a/packer/http/autoyast.xml
+++ b/packer/http/autoyast.xml
@@ -55,7 +55,6 @@
 
   <partitioning config:type="list">
     <drive>
-      <device>/dev/sda</device>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list">
         <partition>

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "2.0.1",
+        "version": "2.0.2",
         "vm_name": "scf-vagrant-{{isotime \"20060102-1504\"}}",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",
@@ -77,7 +77,7 @@
             "headless": true,
             "vm_name": "{{user `vm_name`}}",
             "disk_size": 20480,
-            "disk_interface": "scsi",
+            "disk_interface": "virtio",
             "disk_compression": true,
             "net_device": "virtio-net",
             "ssh_username": "{{user `ssh_username`}}",


### PR DESCRIPTION
This makes things a lot faster, especially cloud controller initial migration.

I've already pushed the necessary vagrant box (we can overwrite it if we want changes).