### PR TITLE
packer: enable compact script for qemu

### DIFF
--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -149,7 +149,6 @@
         },
         {
             "type": "shell",
-            "only": ["virtualbox-iso", "vmware-iso"],
             "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
             "scripts": [
                 "scripts/compact.sh"


### PR DESCRIPTION
This was turned off for development and accidentally left off.  It reduces the image from ~1.4G to ~1.1G.