### PR TITLE
Add iptables rule to allow connecting to docker from outside vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb, override|
     # Need to shorten the URL for Windows' sake
-    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-virtualbox-v2.0.1.box"
+    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-virtualbox-v2.0.3.box"
 
     # Customize the amount of memory on the VM:
     vb.memory = vm_memory.to_s
@@ -43,7 +43,7 @@ Vagrant.configure(2) do |config|
 
 # Currently not built for vmware_fusion
 # config.vm.provider "vmware_fusion" do |vb, override|
-#   override.vm.box="https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-vmware-v2.0.1.box"
+#   override.vm.box="https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-vmware-v2.0.3.box"
 #
 #   # Customize the amount of memory on the VM:
 #   vb.memory = vm_memory.to_s
@@ -69,7 +69,7 @@ Vagrant.configure(2) do |config|
 
 # Currently not built for vmware_workstation
 #  config.vm.provider "vmware_workstation" do |vb, override|
-#    override.vm.box="https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-vmware-v2.0.1.box"
+#    override.vm.box="https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-vmware-v2.0.3.box"
 #
 #    # Customize the amount of memory on the VM:
 #    vb.memory = vm_memory.to_s
@@ -91,7 +91,7 @@ Vagrant.configure(2) do |config|
 #  end
 
   config.vm.provider "libvirt" do |libvirt, override|
-    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-libvirt-v2.0.2.box"
+    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-libvirt-v2.0.3.box"
     libvirt.driver = "kvm"
     # Allow downloading boxes from sites with self-signed certs
     libvirt.memory = vm_memory

--- a/packer/http/kubelet-vagrant-overrides.conf
+++ b/packer/http/kubelet-vagrant-overrides.conf
@@ -2,5 +2,7 @@
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/kubelet.crt /var/run/kubernetes/kubelet.crt
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/kubelet.key /var/run/kubernetes/kubelet.key
 ExecStartPre=/usr/bin/chown kube:kube /tmp/hostpath_pv/
-ExecStartPost=/usr/sbin/iptables -t filter -I FORWARD 1 -o docker0 -m comment --comment "Fix exposed services" -j ACCEPT
+# Allow machines outside vagrant box to talk to kubernetes &c
+# https://docs.docker.com/engine/userguide/networking/default_network/container-communication/#container-communication-between-hosts
+ExecStartPost=/usr/sbin/iptables -t filter -P FORWARD ACCEPT
 EnvironmentFile=/etc/systemd/system/kubelet.service.d/vagrant-overrides.env

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "2.0.2",
+        "version": "2.0.3",
         "vm_name": "scf-vagrant-{{isotime \"20060102-1504\"}}",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",


### PR DESCRIPTION
https://docs.docker.com/engine/userguide/networking/default_network/container-communication/

Trying to connect to the running cf instance from outside the vagrant box fails because of the iptables rules in the box. E.g.

Running `cf api --skip-ssl-validation https://api.cf-dev.io` fails (api.cf-dev.io does resolve to 192.168.77.77). 

I think the above link explains the issue and the solution. We need to `ACCEPT` the FORWARD chain. I'm not sure if this is the right place to set this rule. Also, I only tried this but setting `run: "always"` and running `vagrant reload` to avoid running everything from scratch (described [here](https://www.vagrantup.com/docs/provisioning/basic_usage.html#run-once-or-always)).