### PR TITLE
Mark cert for talking to UAA as secret. 

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1686,7 +1686,7 @@ configuration:
     internal: true
     immutable: true
     description: The CA certificate for UAA
-    internal: true
+    secret: true
   - name: HCP_COMPONENT_INDEX
     type: environment
   - name: HCP_COMPONENT_NAME


### PR DESCRIPTION
Further remove duplicate `internal` marker.