### PR TITLE
Removed `IMAGE_` variables. Now using the proper `FISSILE_` variables.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -12,8 +12,11 @@ fi
 # Get version information
 . ${PWD}/bin/dev/versions.sh
 
-# The Docker repository name used for images
-export FISSILE_REPOSITORY=fissile
+# The Docker repository name used for images, the registry itself, and the org to use.
+# Note, this replaces "make/include/registry" and its IMAGE_* variables
+export FISSILE_REPOSITORY=${FISSILE_REPOSITORY:-scf}
+export FISSILE_DOCKER_REGISTRY="${FISSILE_DOCKER_REGISTRY:+${FISSILE_DOCKER_REGISTRY%/}/}"
+export FISSILE_DOCKER_ORGANIZATION=${FISSILE_DOCKER_ORGANIZATION:-'splatform'}
 
 # This is a comma separated list of paths to the local repositories
 # of all the releases that make up HCF

--- a/make/bosh-images
+++ b/make/bosh-images
@@ -4,6 +4,6 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. "${GIT_ROOT}/make/include/registry"
+. "${GIT_ROOT}/.envrc"
 
-fissile build images --stemcell ${FISSILE_STEMCELL} --docker-registry "${IMAGE_REGISTRY}" --docker-organization "${IMAGE_ORG}" --repository "${IMAGE_PREFIX}"
+fissile build images

--- a/make/bosh-publish
+++ b/make/bosh-publish
@@ -4,9 +4,9 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. "${GIT_ROOT}/make/include/registry"
+. "${GIT_ROOT}/.envrc"
 
-BOSH_IMAGES=${BOSH_IMAGES:-$(fissile show image --docker-registry "${IMAGE_REGISTRY}" --docker-organization "${IMAGE_ORG}" --repository "${IMAGE_PREFIX}")}
+BOSH_IMAGES=${BOSH_IMAGES:-$(fissile show image)}
 
 for image in ${BOSH_IMAGES}; do
     # Redirect docker stdout to avoid polluting logfiles with progressbar characters

--- a/make/images
+++ b/make/images
@@ -4,7 +4,7 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. ${GIT_ROOT}/make/include/registry
+. "${GIT_ROOT}/.envrc"
 . ${GIT_ROOT}/make/include/versioning
 
 ACTION=${1}
@@ -16,6 +16,8 @@ fi
 PREFIX='fissile-'
 
 for ROLE in ${ROLES}; do
+    ROLE_PREFIX="${FISSILE_DOCKER_REGISTRY}${FISSILE_DOCKER_ORGANIZATION}/${FISSILE_REPOSITORY}"
+
     case ${ACTION} in
         build)
             cd ${GIT_ROOT}/docker-images/${ROLE}
@@ -23,20 +25,20 @@ for ROLE in ${ROLES}; do
             ;;
         tag)
             TAG=$(fissile show image | awk -F : "/fissile-${ROLE}:/ {print \$2 }")
-            docker tag ${PREFIX}${ROLE}:${TAG} ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION}
-            docker tag ${PREFIX}${ROLE}:${TAG} ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}
+            docker tag ${PREFIX}${ROLE}:${TAG} ${ROLE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION}
+            docker tag ${PREFIX}${ROLE}:${TAG} ${ROLE_PREFIX}-${ROLE}:${GIT_BRANCH}
             ;;
         publish)
             # Redirect docker stdout to avoid polluting logfiles with progressbar characters
-            echo "Publishing ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION}"
-            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION} > /dev/null
-            echo "Publishing ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH}"
-            docker push ${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:${GIT_BRANCH} > /dev/null
+            echo "Publishing ${ROLE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION}"
+            docker push ${ROLE_PREFIX}-${ROLE}:${DOCKER_APP_VERSION} > /dev/null
+            echo "Publishing ${ROLE_PREFIX}-${ROLE}:${GIT_BRANCH}"
+            docker push ${ROLE_PREFIX}-${ROLE}:${GIT_BRANCH} > /dev/null
             ;;
         clean)
             # For bosh images, there may be images with stale tags we want to delete
-            WANTED_TAG=$(fissile show image --docker-registry "${IMAGE_REGISTRY}" --docker-organization "${IMAGE_ORG}" | grep "^${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}:" | cut -f 2 -d :)
-            docker images "${IMAGE_REGISTRY}${IMAGE_ORG}/${IMAGE_PREFIX}-${ROLE}" | tail -n +2 | while read REPOSITORY TAG _ ; do
+            WANTED_TAG=$(fissile show image | grep "^${ROLE_PREFIX}-${ROLE}:" | cut -f 2 -d :)
+            docker images "${ROLE_PREFIX}-${ROLE}" | tail -n +2 | while read REPOSITORY TAG _ ; do
                 if test "${TAG}" != "${WANTED_TAG}" ; then
                     docker rmi "${REPOSITORY}:${TAG}"
                 fi

--- a/make/include/registry
+++ b/make/include/registry
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -o errexit -o nounset
-
-IMAGE_ORG=${IMAGE_ORG:-'splatform'}
-IMAGE_PREFIX=${IMAGE_PREFIX:-'scf'}
-IMAGE_REGISTRY="${IMAGE_REGISTRY:+${IMAGE_REGISTRY%/}/}"

--- a/make/kube
+++ b/make/kube
@@ -4,21 +4,18 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
+. "${GIT_ROOT}/.envrc"
+
 cd "${GIT_ROOT}"
 
 ENV_FILES="$(echo bin/settings/*.env bin/settings/kube/*.env)"
 
 # TODO: We currently skip memory limits for development purposes
 
-. "${GIT_ROOT}/make/include/registry"
-
 fissile build kube \
     --kube-output-dir="${GIT_ROOT}/kube" \
     --defaults-file="$(echo "${ENV_FILES}" | tr ' ' ,)" \
     --use-memory-limits=false \
-    --docker-registry "${IMAGE_REGISTRY}" \
-    --docker-organization "${IMAGE_ORG}" \
-    --repository "${IMAGE_PREFIX}"
 
 # This is a small hack to make the output of make kube be compatible with K8s 1.6
 perl -p -i -e 's@extensions/v1beta1@batch/v1@' kube/bosh-task/*.yml

--- a/make/show-docker-setup
+++ b/make/show-docker-setup
@@ -4,10 +4,10 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. ${GIT_ROOT}/make/include/registry
+. "${GIT_ROOT}/.envrc"
 . ${GIT_ROOT}/make/include/versioning
 
-echo "docker registry = '${IMAGE_REGISTRY}'"
-echo "docker org      = '${IMAGE_ORG}'"
-echo "hcf version     = '${GIT_BRANCH}'"
-echo "hcf prefix      = '${IMAGE_PREFIX}'"
+echo "docker registry = '${FISSILE_DOCKER_REGISTRY}'"
+echo "docker org      = '${FISSILE_DOCKER_ORGANIZATION}'"
+echo "scf version     = '${GIT_BRANCH}'"
+echo "scf prefix      = '${FISSILE_REPOSITORY}'"

--- a/make/uaa-certs
+++ b/make/uaa-certs
@@ -4,15 +4,15 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. "${GIT_ROOT}/make/include/registry"
+. "${GIT_ROOT}/.envrc"
 . "${GIT_ROOT}/src/uaa-fissile-release/.envrc"
 
-# IMAGE_REGISTRY and ORG have the same defaults, and pass through also.
-# IMAGE_PREFIX we must not pass, on pain of getting images with the
-# same name for different roles in SCF and UAA (mysql, uaa,
-# role-packages).
+# FISSILE_DOCKER_REGISTRY and FISSILE_DOCKER_ORGANIZATION have the
+# same defaults, and pass through also. FOSSIL_REPOSITORY we must not
+# pass, on pain of getting images with the same name for different
+# roles in SCF and UAA (mysql, uaa, role-packages).
 
-unset IMAGE_PREFIX
+unset FOSSIL_REPOSITORY
 
 make -C "${GIT_ROOT}/src/uaa-fissile-release" \
     certs

--- a/make/uaa-images
+++ b/make/uaa-images
@@ -4,15 +4,15 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. "${GIT_ROOT}/make/include/registry"
+. "${GIT_ROOT}/.envrc"
 . "${GIT_ROOT}/src/uaa-fissile-release/.envrc"
 
-# IMAGE_REGISTRY and ORG have the same defaults, and pass through also.
-# IMAGE_PREFIX we must not pass, on pain of getting images with the
-# same name for different roles in SCF and UAA (mysql, uaa,
-# role-packages).
+# FISSILE_DOCKER_REGISTRY and FISSILE_DOCKER_ORGANIZATION have the
+# same defaults, and pass through also. FOSSIL_REPOSITORY we must not
+# pass, on pain of getting images with the same name for different
+# roles in SCF and UAA (mysql, uaa, role-packages).
 
-unset IMAGE_PREFIX
+unset FOSSIL_REPOSITORY
 
 make -C "${GIT_ROOT}/src/uaa-fissile-release" \
     build

--- a/make/uaa-kube
+++ b/make/uaa-kube
@@ -4,15 +4,15 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. "${GIT_ROOT}/make/include/registry"
+. "${GIT_ROOT}/.envrc"
 . "${GIT_ROOT}/src/uaa-fissile-release/.envrc"
 
-# IMAGE_REGISTRY and ORG have the same defaults, and pass through also.
-# IMAGE_PREFIX we must not pass, on pain of getting images with the
-# same name for different roles in SCF and UAA (mysql, uaa,
-# role-packages).
+# FISSILE_DOCKER_REGISTRY and FISSILE_DOCKER_ORGANIZATION have the
+# same defaults, and pass through also. FOSSIL_REPOSITORY we must not
+# pass, on pain of getting images with the same name for different
+# roles in SCF and UAA (mysql, uaa, role-packages).
 
-unset IMAGE_PREFIX
+unset FOSSIL_REPOSITORY
 
 make -C "${GIT_ROOT}/src/uaa-fissile-release" \
     kube-configs

--- a/make/uaa-publish
+++ b/make/uaa-publish
@@ -4,15 +4,15 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. "${GIT_ROOT}/make/include/registry"
+. "${GIT_ROOT}/.envrc"
 . "${GIT_ROOT}/src/uaa-fissile-release/.envrc"
 
-# IMAGE_REGISTRY and ORG have the same defaults, and pass through also.
-# IMAGE_PREFIX we must not pass, on pain of getting images with the
-# same name for different roles in SCF and UAA (mysql, uaa,
-# role-packages).
+# FISSILE_DOCKER_REGISTRY and FISSILE_DOCKER_ORGANIZATION have the
+# same defaults, and pass through also. FOSSIL_REPOSITORY we must not
+# pass, on pain of getting images with the same name for different
+# roles in SCF and UAA (mysql, uaa, role-packages).
 
-unset IMAGE_PREFIX
+unset FOSSIL_REPOSITORY
 
 make -C "${GIT_ROOT}/src/uaa-fissile-release" \
     publish

--- a/make/uaa-run
+++ b/make/uaa-run
@@ -4,7 +4,7 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. "${GIT_ROOT}/make/include/registry"
+. "${GIT_ROOT}/.envrc"
 . "${GIT_ROOT}/src/uaa-fissile-release/.envrc"
 
 make -C "${GIT_ROOT}/src/uaa-fissile-release" run

--- a/make/uaa-stop
+++ b/make/uaa-stop
@@ -4,7 +4,7 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. "${GIT_ROOT}/make/include/registry"
+. "${GIT_ROOT}/.envrc"
 . "${GIT_ROOT}/src/uaa-fissile-release/.envrc"
 
 make -C "${GIT_ROOT}/src/uaa-fissile-release" stop

--- a/make/vagrant-setup-env
+++ b/make/vagrant-setup-env
@@ -4,7 +4,7 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-. ${GIT_ROOT}/make/include/registry
+. "${GIT_ROOT}/.envrc"
 . ${GIT_ROOT}/make/include/versioning
 
 ${GIT_ROOT}/bin/validation.sh
@@ -16,7 +16,7 @@ ${GIT_ROOT}/bin/validation.sh
 
 PROPMAP=$(mktemp -t vagrant-propmap.XXXXXX.yml)
 OPTIONS=$(echo \
-    --scf-prefix \"${IMAGE_PREFIX}\" \
+    --scf-prefix \"${FISSILE_REPOSITORY}\" \
     --scf-tag \"${DOCKER_APP_VERSION}\" \
     --scf-version \"${APP_VERSION}\" \
     --scf-root-dir \"${GIT_ROOT}\" \


### PR DESCRIPTION
https://trello.com/c/QlFH99Qh/172-2-make-images-and-fissile-build-images-should-be-the-same

Definitions in `.envrc`
Removed now superfluous `make/include/registry`.
Updated all affected make scripts.
Imported equivalent changes for u-f-r.