### PR TITLE
kube: run controller-manager as root

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb, override|
     # Need to shorten the URL for Windows' sake
-    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-virtualbox-v2.0.3.box"
+    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-virtualbox-v2.0.4.box"
 
     # Customize the amount of memory on the VM:
     vb.memory = vm_memory.to_s
@@ -43,7 +43,7 @@ Vagrant.configure(2) do |config|
 
 # Currently not built for vmware_fusion
 # config.vm.provider "vmware_fusion" do |vb, override|
-#   override.vm.box="https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-vmware-v2.0.3.box"
+#   override.vm.box="https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-vmware-v2.0.4.box"
 #
 #   # Customize the amount of memory on the VM:
 #   vb.memory = vm_memory.to_s
@@ -69,7 +69,7 @@ Vagrant.configure(2) do |config|
 
 # Currently not built for vmware_workstation
 #  config.vm.provider "vmware_workstation" do |vb, override|
-#    override.vm.box="https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-vmware-v2.0.3.box"
+#    override.vm.box="https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-vmware-v2.0.4.box"
 #
 #    # Customize the amount of memory on the VM:
 #    vb.memory = vm_memory.to_s
@@ -91,7 +91,7 @@ Vagrant.configure(2) do |config|
 #  end
 
   config.vm.provider "libvirt" do |libvirt, override|
-    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-libvirt-v2.0.3.box"
+    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-libvirt-v2.0.4.box"
     libvirt.driver = "kvm"
     # Allow downloading boxes from sites with self-signed certs
     libvirt.memory = vm_memory

--- a/packer/http/controller-manager-vagrant-overrides.conf
+++ b/packer/http/controller-manager-vagrant-overrides.conf
@@ -4,3 +4,7 @@ ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/apiserver.crt /var/run/kubern
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/apiserver.key /var/run/kubernetes/serviceaccount.key
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/CA.kube.vagrant.crt /etc/kubernetes/ca/ca.pem
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/CA.kube.vagrant.key /etc/kubernetes/ca/ca.key
+
+# This needs to be run as root to correctly delete volumes (owned by users in containers)
+# See https://github.com/SUSE/scf/issues/999
+User=root

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "2.0.3",
+        "version": "2.0.4",
         "vm_name": "scf-vagrant-{{isotime \"20060102-1504\"}}",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",


### PR DESCRIPTION
This ensures it can delete /tmp/hostpath_pv/* (which are owned by vcap:vcap due to permission issues _inside_ the containers).  Originally this was running as kube:kube.

Fixes #999