### PR TITLE
Genocide hcf references: Update to fissile changes in generated images.

### DIFF
--- a/bin/dev/versions.sh
+++ b/bin/dev/versions.sh
@@ -8,7 +8,7 @@ set -o errexit -o nounset
 # Used in: bin/dev/install_tool.sh
 
 export CFCLI_VERSION="6.21.1"
-export FISSILE_VERSION="5.0.0+62.gba2a780"
+export FISSILE_VERSION="5.0.0+88.gab3c197"
 export HELM_VERSION="2.4.2"
 export HELM_CERTGEN_VERSION="master"
 export KK_VERSION="40a5b3756cf4bcbed940e6156272c0af"

--- a/container-host-files/etc/hcf/config/scripts/cf_acceptance_tests_suites.sh
+++ b/container-host-files/etc/hcf/config/scripts/cf_acceptance_tests_suites.sh
@@ -59,6 +59,6 @@ done
 
 for suite in ${ALL_SUITES} ; do
     if test -n "${suites[${suite}]}" ; then
-        echo "properties.acceptance_tests.include_${suite}: ${suites[${suite}]}" >> /opt/hcf/env2conf.yml
+        echo "properties.acceptance_tests.include_${suite}: ${suites[${suite}]}" >> /opt/scf/env2conf.yml
     fi
 done

--- a/container-host-files/etc/hcf/config/scripts/configure-nested-net.sh
+++ b/container-host-files/etc/hcf/config/scripts/configure-nested-net.sh
@@ -24,4 +24,4 @@ fi
 
 cell_subnet="${target_prefix}.${HCP_COMPONENT_INDEX}.0/24"
 
-perl -p -i -e "s@^properties.garden.network_pool:.*@properties.garden.network_pool: ${cell_subnet}@" /opt/hcf/env2conf.yml
+perl -p -i -e "s@^properties.garden.network_pool:.*@properties.garden.network_pool: ${cell_subnet}@" /opt/scf/env2conf.yml


### PR DESCRIPTION
https://trello.com/c/d0YPQYWg/42-2-fissile-remove-remaining-references-to-hcf-hcp
See https://github.com/SUSE/fissile/pull/250 for the base this adapts too.

Note: This will also be the integration branch when fissile gets merged, i.e. the update to install-tools.
