### PR TITLE
Avoid chown if owner of certstrap is not root

### DIFF
--- a/bin/dev/install_tools.sh
+++ b/bin/dev/install_tools.sh
@@ -59,7 +59,9 @@ chmod a+x "${bin_dir}/helm"
 echo "Installing certstrap ..."
 # We run chown in docker to avoid requiring sudo
 docker run --rm -v "${bin_dir}":/out:rw "golang:${GOLANG_VERSION}" /usr/bin/env GOBIN=/out go get github.com/square/certstrap
-docker run --rm -v "${bin_dir}":/out:rw "golang:${GOLANG_VERSION}" /bin/chown "$(id -u):$(id -g)" /out/certstrap
+if [[ $(stat -c '%u' "${bin_dir}/certstrap") -eq 0 ]]; then
+  docker run --rm -v "${bin_dir}":/out:rw "golang:${GOLANG_VERSION}" /bin/chown "$(id -u):$(id -g)" /out/certstrap
+fi
 
 echo "Pulling ruby bosh image ..."
 docker pull splatform/bosh-cli
@@ -77,7 +79,9 @@ helm_certgen_dir="$(mktemp -d)"
 trap "rm -rf '${helm_certgen_dir}'" EXIT
 git clone --branch "${HELM_CERTGEN_VERSION}" --depth 1 https://github.com/SUSE/helm-certgen.git "${helm_certgen_dir}"
 docker run --rm -v "${bin_dir}":/out:rw -v "${helm_certgen_dir}:/go/src/github.com/SUSE/helm-certgen:ro" "golang:${GOLANG_VERSION}" /usr/bin/env GOBIN=/out go get github.com/SUSE/helm-certgen
-docker run --rm -v "${bin_dir}":/out:rw "golang:${GOLANG_VERSION}" /bin/chown "$(id -u):$(id -g)" /out/helm-certgen
+if [[ $(stat -c '%u' "${bin_dir}/helm-certgen") -eq 0 ]]; then
+  docker run --rm -v "${bin_dir}":/out:rw "golang:${GOLANG_VERSION}" /bin/chown "$(id -u):$(id -g)" /out/helm-certgen
+fi
 mkdir -p "${HOME}/.helm/plugins" # Necessary if we didn't run `helm init`
 rm -rf "${HOME}/.helm/plugins/certgen"
 mv --no-target-directory "${helm_certgen_dir}/plugin" "${HOME}/.helm/plugins/certgen"


### PR DESCRIPTION
This addresses a bug where NFS mounted files on OSX are owned by the
OSX user which ran `vagrant up`, and cannot be chowned inside the VM

On Linux deployments, certstrap gets owned by root, so needs to be
chowned to the vagrant user