### PR TITLE
Increase mysql volume size and bump uaa-fissile-release

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -141,7 +141,7 @@ roles:
     persistent-volumes:
     - path: /var/vcap/store
       tag: mysql-data
-      size: 2
+      size: 20
     shared-volumes: []
     memory: 3072
     virtual-cpus: 2


### PR DESCRIPTION
Mysql writes ~2.4GB on startup only, the old default was not enough.