### PR TITLE
Ensure that output directory is an absolute path.

### DIFF
--- a/docker-images/cert-generator/scf-cert-generator.sh
+++ b/docker-images/cert-generator/scf-cert-generator.sh
@@ -33,7 +33,7 @@ while getopts "d:hn:o:" opt; do
         echo "Invalid -${opt} argument ${OPTARG}, must be a directory" >&2
         exit 1
       fi
-      out_dir=${OPTARG}
+      out_dir="$(cd "${OPTARG}" ; pwd)"
       ;;
   esac
 done
@@ -46,6 +46,8 @@ then
   usage
   exit 1
 fi
+
+echo Writing results to ${out_dir}
 
 docker run --rm \
 	--volume "${out_dir}":/out \


### PR DESCRIPTION
**WIP** marker because this is untested. Not because I don;'t want to, given the triviality of the change, but because docker tells me:
```
Unable to find image 'splatform/cert-generator:latest' locally
docker: Error response from daemon: repository splatform/cert-generator not found: does not exist or no pull access.
See 'docker run --help'.
```
IOW I do not have the image locally, and the image is not found on the hub either.