### PR TITLE
Add `stop-on-failure` tag to tests

### DIFF
--- a/bin/dev/versions.sh
+++ b/bin/dev/versions.sh
@@ -8,7 +8,7 @@ set -o errexit -o nounset
 # Used in: bin/dev/install_tool.sh
 
 export CFCLI_VERSION="6.21.1"
-export FISSILE_VERSION="5.0.0+107.gcc33c77"
+export FISSILE_VERSION="5.0.0+115.g7121d1b"
 export HELM_VERSION="2.4.2"
 export HELM_CERTGEN_VERSION="master"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1089,6 +1089,7 @@ roles:
       properties.diego.rep.advertise_domain: ((KUBE_POD_SERVICE))((^KUBE_POD_SERVICE))diego-cell-set.((KUBE_SERVICE_DOMAIN_SUFFIX))((/KUBE_POD_SERVICE))
 - name: acceptance-tests-brain
   type: bosh-task
+  tags: [stop-on-failure]
   scripts:
   - scripts/authorize_internal_ca.sh
   jobs:
@@ -1109,6 +1110,7 @@ roles:
     exposed-ports: []
 - name: acceptance-tests
   type: bosh-task
+  tags: [stop-on-failure]
   scripts:
   - scripts/authorize_internal_ca.sh
   - scripts/cf_acceptance_tests_suites.sh
@@ -1133,6 +1135,7 @@ roles:
       hcf.cats-suites: '"((CATS_SUITES))"'
 - name: smoke-tests
   type: bosh-task
+  tags: [stop-on-failure]
   scripts:
   - scripts/authorize_internal_ca.sh
   jobs:

--- a/make/cats
+++ b/make/cats
@@ -20,7 +20,7 @@ fi
 
 stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-cats::setup start
 
-. ${GIT_ROOT}/bin/settings/settings.env
+. "${GIT_ROOT}/bin/settings/settings.env"
 
 cf api api.cf-dev.io --skip-ssl-validation
 cf auth admin "${CLUSTER_ADMIN_PASSWORD}"

--- a/make/smoke
+++ b/make/smoke
@@ -18,15 +18,15 @@ else
     exit 1
 fi
 
-stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-cats::setup start
+stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-smoke::setup start
 
-. ${GIT_ROOT}/bin/settings/settings.env
+. "${GIT_ROOT}/bin/settings/settings.env"
 
 cf api api.cf-dev.io --skip-ssl-validation
 cf auth admin "${CLUSTER_ADMIN_PASSWORD}"
 cf enable-feature-flag diego_docker
 
-stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-cats::setup end
+stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-smoke::setup end
 
 stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-smoke::create start
 


### PR DESCRIPTION
A new feature was added to fissile to check this tag. If a bosh-task has
it, it will stop the pod when the test script fails. Without this tag,
kubernetes will restart the pod to try to get the script to finish
successfully.

https://github.com/SUSE/fissile/pull/262