### PR TITLE
Unpin node version in test app

### DIFF
--- a/src/hcf-release/src/acceptance-tests-brain/test-resources/node-env/package.json
+++ b/src/hcf-release/src/acceptance-tests-brain/test-resources/node-env/package.json
@@ -1,8 +1,5 @@
 {
   "name": "node-env",
   "version": "1.0.0",
-  "engines": {
-    "node": "5.x"
-  },
   "dependencies": {}
 }


### PR DESCRIPTION
That way we don't have to modify the tests whenever the assets bundled
with the nodejs-buildpack change.