### PR TITLE
Make `make/kube` less hacky

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -95,5 +95,5 @@ export FISSILE_STEMCELL=${FISSILE_STEMCELL:-splatform/fissile-stemcell-opensuse:
 # The defaults are all for helm.
 # The make/kube script performs overrides for kube output.
 export FISSILE_USE_MEMORY_LIMITS=false
-export FISSILE_OUTPUT_DIR="${FISSILE_OUTPUT_DIR:-${PWD}/helm}"
+export FISSILE_OUTPUT_DIR="${FISSILE_OUTPUT_DIR:-${PWD}/output}"
 export FISSILE_DEFAULTS_FILE="bin/settings/certs.env,bin/settings/kube/ca.env"

--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,8 @@ _work/
 target/
 password
 *.pem
-*.tfstate*
-*.tfvars
-.terraform/
-!.fissile/.gitkeep
-!.fissile/.bosh/.gitkeep
-.fissile/*
+!.gitkeep
+/.fissile/
 .vagrant
 .bash_history
 *.box
@@ -19,11 +15,7 @@ password
 .demos
 src/*-clone
 src/buildpacks/*-clone
-/*.tf
-/*.tf.json
-bin/settings/kube/ca.env
+/bin/settings/kube/ca.env
 # `make dist` output of various forms
-output/
-helm/
-kube/
+/output/
 personal-setup

--- a/Makefile
+++ b/Makefile
@@ -203,12 +203,12 @@ show-versions:
 	${GIT_ROOT}/make/show-versions
 
 ########## KUBERNETES TARGETS ##########
-kube ${FISSILE_OUTPUT_DIR}/kube/bosh-task/post-deployment-setup.yml: uaa-kube
+kube: uaa-kube
 	${GIT_ROOT}/bin/settings/kube/ca.sh
 	${GIT_ROOT}/make/kube
 .PHONY: kube
 
-helm ${FISSILE_OUTPUT_DIR}/helm/cf/bosh-task/post-deployment-setup.yml: uaa-helm
+helm: uaa-helm
 	${GIT_ROOT}/bin/settings/kube/ca.sh
 	${GIT_ROOT}/make/kube helm
 .PHONY: helm

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ kube ${FISSILE_OUTPUT_DIR}/kube/bosh-task/post-deployment-setup.yml: uaa-kube
 	${GIT_ROOT}/make/kube
 .PHONY: kube
 
-helm ${FISSILE_OUTPUT_DIR}/helm/bosh-task/post-deployment-setup.yml: uaa-helm
+helm ${FISSILE_OUTPUT_DIR}/helm/cf/bosh-task/post-deployment-setup.yml: uaa-helm
 	${GIT_ROOT}/bin/settings/kube/ca.sh
 	${GIT_ROOT}/make/kube helm
 .PHONY: helm

--- a/Makefile
+++ b/Makefile
@@ -203,12 +203,12 @@ show-versions:
 	${GIT_ROOT}/make/show-versions
 
 ########## KUBERNETES TARGETS ##########
-kube kube/bosh-task/post-deployment-setup.yml: uaa-kube
+kube ${FISSILE_OUTPUT_DIR}/kube/bosh-task/post-deployment-setup.yml: uaa-kube
 	${GIT_ROOT}/bin/settings/kube/ca.sh
 	${GIT_ROOT}/make/kube
 .PHONY: kube
 
-helm helm/bosh-task/post-deployment-setup.yml: uaa-helm
+helm ${FISSILE_OUTPUT_DIR}/helm/bosh-task/post-deployment-setup.yml: uaa-helm
 	${GIT_ROOT}/bin/settings/kube/ca.sh
 	${GIT_ROOT}/make/kube helm
 .PHONY: helm
@@ -235,7 +235,7 @@ dist: \
 
 kube-dist: kube uaa-kube-dist
 	${GIT_ROOT}/make/kube-dist
-	rm -rf kube
+	rm -rf ${FISSILE_OUTPUT_DIR}/kube
 
 ########## SUPPORT  TARGETS ##########
 

--- a/make/cats
+++ b/make/cats
@@ -31,10 +31,10 @@ stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-cats::setup end
 stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-cats::create start
 
 # Delete left-over pod/definition from previous runs, then create/run
-kubectl delete --namespace="${NAMESPACE}" --filename="kube/bosh-task/acceptance-tests.yml" \
+kubectl delete --namespace="${NAMESPACE}" --filename="${FISSILE_OUTPUT_DIR}/kube/bosh-task/acceptance-tests.yml" \
     2> /dev/null || /bin/true
 
-kubectl create --namespace="${NAMESPACE}" --filename="kube/bosh-task/acceptance-tests.yml"
+kubectl create --namespace="${NAMESPACE}" --filename="${FISSILE_OUTPUT_DIR}/kube/bosh-task/acceptance-tests.yml"
 
 stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-cats::create end
 

--- a/make/kube
+++ b/make/kube
@@ -16,14 +16,15 @@ fi
 
 if [ "${BUILD_TARGET}" = "kube" ]; then
     # Overrides when generating kube config files instead of helm charts.
-    FISSILE_OUTPUT_DIR="${PWD}/kube"
     ENV_FILES="$(echo bin/settings/*.env bin/settings/kube/*.env)"
     FISSILE_DEFAULTS_FILE="$(echo "${ENV_FILES}" | tr ' ' ,)"
 fi
+
+export FISSILE_OUTPUT_DIR="${FISSILE_OUTPUT_DIR:-${PWD}}/${BUILD_TARGET}"
 
 rm -rf "${FISSILE_OUTPUT_DIR}"
 
 fissile build "${BUILD_TARGET}"
 
 # This is a small hack to make the output of make kube be compatible with K8s 1.6
-perl -p -i -e 's@extensions/v1beta1@batch/v1@' $(grep -rl "kind: Job" "${BUILD_TARGET}")
+perl -p -i -e 's@extensions/v1beta1@batch/v1@' $(grep -rl "kind: Job" "${FISSILE_OUTPUT_DIR}")

--- a/make/kube
+++ b/make/kube
@@ -6,25 +6,25 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 cd "${GIT_ROOT}"
 source .envrc
 
-CREATE_HELM_CHART=false
-BUILD_TARGET=kube
-
-if [ "${1:-}" = "helm" ]; then
+if test "${1:-}" = "helm" ; then
     CREATE_HELM_CHART=true
     BUILD_TARGET=helm
-fi
-
-if [ "${BUILD_TARGET}" = "kube" ]; then
+    export FISSILE_OUTPUT_DIR="${FISSILE_OUTPUT_DIR:-${PWD}}/${BUILD_TARGET}/cf"
+else
+    CREATE_HELM_CHART=false
+    BUILD_TARGET=kube
     # Overrides when generating kube config files instead of helm charts.
     ENV_FILES="$(echo bin/settings/*.env bin/settings/kube/*.env)"
-    FISSILE_DEFAULTS_FILE="$(echo "${ENV_FILES}" | tr ' ' ,)"
+    export FISSILE_DEFAULTS_FILE="$(echo "${ENV_FILES}" | tr ' ' ,)"
+    export FISSILE_OUTPUT_DIR="${FISSILE_OUTPUT_DIR:-${PWD}}/${BUILD_TARGET}"
 fi
-
-export FISSILE_OUTPUT_DIR="${FISSILE_OUTPUT_DIR:-${PWD}}/${BUILD_TARGET}"
 
 rm -rf "${FISSILE_OUTPUT_DIR}"
 
 fissile build "${BUILD_TARGET}"
 
 # This is a small hack to make the output of make kube be compatible with K8s 1.6
-perl -p -i -e 's@extensions/v1beta1@batch/v1@' $(grep -rl "kind: Job" "${FISSILE_OUTPUT_DIR}")
+jobs=($(grep -rl "kind: Job" "${FISSILE_OUTPUT_DIR}"))
+if test "${#jobs[@]}" -gt 0; then
+    perl -p -i -e 's@extensions/v1beta1@batch/v1@' "${jobs[@]}"
+fi

--- a/make/kube-dist
+++ b/make/kube-dist
@@ -14,7 +14,7 @@ rm ${GIT_ROOT}/${ARTIFACT} 2>/dev/null || true
 
 mkdir "${tmp_dir}/cf" "${tmp_dir}/uaa"
 
-cp -r "${GIT_ROOT}"/kube/* "${tmp_dir}/cf"
+cp -r "${FISSILE_OUTPUT_DIR}/kube/"* "${tmp_dir}/cf"
 cp -r "${GIT_ROOT}"/src/uaa-fissile-release/kube/* "${tmp_dir}/uaa"
 
 cd "${tmp_dir}" && zip -r9 ${GIT_ROOT}/${ARTIFACT} * \

--- a/make/run
+++ b/make/run
@@ -35,7 +35,7 @@ kubectl get storageclass persistent 2>/dev/null || {
 source bin/settings/settings.env
 source bin/settings/network.env
 
-helm install helm \
+helm install "${FISSILE_OUTPUT_DIR}/helm" \
      --namespace ${NAMESPACE} \
      --set "env.CLUSTER_ADMIN_PASSWORD=$CLUSTER_ADMIN_PASSWORD" \
      --set "env.DOMAIN=${DOMAIN}" \

--- a/make/run
+++ b/make/run
@@ -35,7 +35,7 @@ kubectl get storageclass persistent 2>/dev/null || {
 source bin/settings/settings.env
 source bin/settings/network.env
 
-helm install "${FISSILE_OUTPUT_DIR}/helm" \
+helm install "${FISSILE_OUTPUT_DIR}/helm/cf" \
      --namespace ${NAMESPACE} \
      --set "env.CLUSTER_ADMIN_PASSWORD=$CLUSTER_ADMIN_PASSWORD" \
      --set "env.DOMAIN=${DOMAIN}" \

--- a/make/smoke
+++ b/make/smoke
@@ -31,10 +31,10 @@ stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-smoke::setup end
 stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-smoke::create start
 
 # Delete left-over pod/definition from previous runs, then create/run
-kubectl delete --namespace="${NAMESPACE}" --filename="kube/bosh-task/smoke-tests.yml" \
+kubectl delete --namespace="${NAMESPACE}" --filename="${FISSILE_OUTPUT_DIR}/kube/bosh-task/smoke-tests.yml" \
     2> /dev/null || /bin/true
 
-kubectl create --namespace="${NAMESPACE}" --filename="kube/bosh-task/smoke-tests.yml"
+kubectl create --namespace="${NAMESPACE}" --filename="${FISSILE_OUTPUT_DIR}/kube/bosh-task/smoke-tests.yml"
 
 stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-smoke::create end
 


### PR DESCRIPTION
We previously had `make/kube` make some assumptions, including `${FISSILE_OUTPUT_DIR}`.  That's totally confusing (why is that set to the helm directory‽) and could lead to trouble down the road because `--output-dir` is such a sensible argument name.

This fixes it to set `FISSILE_OUTPUT_DIR` to `scf.git/output/`, and have `make/kube` append the `kube`/`helm` suffix itself.

This does not currently attempt to solve the mess that is `FISSILE_DEFAULTS_FILE`.

This was needed to try to make the concourse pipeline a bit saner.