### PR TITLE
Make btrfs the default grootfs driver

### DIFF
--- a/bin/settings/settings.env
+++ b/bin/settings/settings.env
@@ -38,7 +38,7 @@ FORCE_FORWARDED_PROTO_AS_HTTPS=false
 # Previous platforms required that this was hardcoded, though it shouldn't be
 GARDEN_DOCKER_REGISTRY=registry-1.docker.io
 GARDEN_INSECURE_DOCKER_REGISTRIES=
-GARDEN_ROOTFS_DRIVER=overlay-xfs
+GARDEN_ROOTFS_DRIVER=btrfs
 INTERNAL_API_PASSWORD=internal_password
 LOGGREGATOR_SHARED_SECRET=loggregator_endpoint_secret
 LOG_LEVEL=debug

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1709,7 +1709,7 @@ configuration:
     default: ""
     description: 'Override DNS servers to be used in containers; defaults to the same as the host.'
   - name: GARDEN_ROOTFS_DRIVER
-    default: overlay-xfs
+    default: btrfs
     description: The filesystem driver to use (btrfs or overlay-xfs).
     required: true
   - name: GO_LOG_LEVEL


### PR DESCRIPTION
`overlay-xfs` doesn't work on all SUSE kernels