### PR TITLE
Add kubenet to our kubernetes setup

### DIFF
--- a/packer/http/autoyast.xml
+++ b/packer/http/autoyast.xml
@@ -125,6 +125,7 @@
       <package>dmidecode</package>
       <package>jq</package>
       <package>make</package>
+      <package>man</package>
       <package>open-vm-tools</package>
       <package>openssh</package>
       <package>virtualbox-guest-kmp-default</package>

--- a/packer/scripts/install-kubernetes.sh
+++ b/packer/scripts/install-kubernetes.sh
@@ -59,7 +59,7 @@ update-ca-certificates
 perl -p -i -e 's@^(KUBE_CONTROLLER_MANAGER_ARGS=)"(.*)"@\1"\2 --enable-hostpath-provisioner --root-ca-file=/etc/kubernetes/ca/ca.pem"@' /etc/kubernetes/controller-manager
 
 # Tell kubelet to use kubedns for DNS, and give it a cluster domain (we don't care which) to have useful /etc/resolv.conf
-perl -p -i -e 's@^(KUBELET_ARGS=)"(.*)"@\1"\2 --cluster-dns=10.254.0.254 --cluster-domain=cluster.local --cgroups-per-qos=false --enforce-node-allocatable='"''"'"@' /etc/kubernetes/kubelet
+perl -p -i -e 's@^(KUBELET_ARGS=)"(.*)"@\1"\2 --cluster-dns=10.254.0.254 --cluster-domain=cluster.local --cgroups-per-qos=false --enforce-node-allocatable='"''"' --network-plugin='"'"'kubenet'"'"' --non-masquerade-cidr=172.16.0.0/16 --pod-cidr=172.16.0.0/16 --network-plugin-dir=/usr/lib/cni/"@' /etc/kubernetes/kubelet
 
 # Pin kubedns to the IP address we gave to kubelet, and give it more RAM so it doesn't fall over repeatedly
 perl -p -i -e '

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "2.0.4",
+        "version": "2.0.5",
         "vm_name": "scf-vagrant-{{isotime \"20060102-1504\"}}",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",


### PR DESCRIPTION
This is required for kube-proxy to support hairpin-mode, which is used
by the tcp-emitter to connect to the routing-api.

Also add `man` to the Vagrantbox.