### PR TITLE
Revert "Drop use of xxd in cert generation"

### DIFF
--- a/bin/generate-dev-certs.sh
+++ b/bin/generate-dev-certs.sh
@@ -63,7 +63,7 @@ KUBE_SERVICE_DOMAIN_SUFFIX="${KUBE_SERVICE_DOMAIN_SUFFIX:-\${namespace\}.svc.clu
 KUBE_SERVICE_DOMAIN_SUFFIX="${KUBE_SERVICE_DOMAIN_SUFFIX/\$\{namespace\}/${namespace}}"
 
 # Generate a random signing key passphrase
-signing_key_passphrase=$(LC_CTYPE=C tr -cd 0-9a-f < /dev/urandom | head -c64)
+signing_key_passphrase=$(head -c 32 /dev/urandom | xxd -ps -c 32)
 
 # build and install `certstrap` tool if it's not installed
 command -v certstrap > /dev/null 2>&1 || {


### PR DESCRIPTION
Reverts SUSE/scf#1037
Turns out this doesn't work. :/