### PR TITLE
Fix sigpipe in certgen script

### DIFF
--- a/bin/generate-dev-certs.sh
+++ b/bin/generate-dev-certs.sh
@@ -63,7 +63,7 @@ KUBE_SERVICE_DOMAIN_SUFFIX="${KUBE_SERVICE_DOMAIN_SUFFIX:-\${namespace\}.svc.clu
 KUBE_SERVICE_DOMAIN_SUFFIX="${KUBE_SERVICE_DOMAIN_SUFFIX/\$\{namespace\}/${namespace}}"
 
 # Generate a random signing key passphrase
-signing_key_passphrase=$(LC_CTYPE=C tr -cd 0-9a-f < /dev/urandom | head -c64)
+signing_key_passphrase=$(head -c32 /dev/urandom | base64)
 
 # build and install `certstrap` tool if it's not installed
 command -v certstrap > /dev/null 2>&1 || {


### PR DESCRIPTION
The previous code caused a `SIGPIPE` due to `set -o pipefail`; this caused the script to abort.  Instead, use head first and just base64 the result; this has the same number of bits of entropy but doesn't fail.

Closes #1047