### PR TITLE
.envrc: don't override FISSILE_BINARY, HCF_PACKAGE_COMPILATION_CACHE

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -63,7 +63,7 @@ export FISSILE_WORK_DIR="${FISSILE_WORK_DIR:-${PWD}/output/fissile}"
 export FISSILE_CACHE_DIR="${FISSILE_CACHE_DIR:-${PWD}/output/bosh-cache}"
 
 # Path to fissile binary (not actually used by fissile)
-export FISSILE_BINARY="${PWD}/output/bin/fissile"
+export FISSILE_BINARY="${FISSILE_BINARY:-${PWD}/output/bin/fissile}"
 mkdir -p "$(dirname "${FISSILE_BINARY}")"
 PATH="$(dirname "${FISSILE_BINARY}")${PATH:+:${PATH}}"
 export PATH
@@ -72,7 +72,7 @@ export PATH
 export FISSILE_CONFIG_PREFIX=hcf
 
 # We will persist compilation results to the VM here
-export HCF_PACKAGE_COMPILATION_CACHE="${PWD}/.fissile/compilation"
+export HCF_PACKAGE_COMPILATION_CACHE="${HCF_PACKAGE_COMPILATION_CACHE:-${PWD}/.fissile/compilation}"
 
 # The following is for fish support: run this script as `bash $0 fish`, and it
 # will print out the fish commands for you to source.


### PR DESCRIPTION
Necessary in CI (because we don't want to automatically download fissile but use the CI-approved version instead).