### PR TITLE
Make sure the tcp-router waits for UAA to be available

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb, override|
     # Need to shorten the URL for Windows' sake
-    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-virtualbox-v2.0.4.box"
+    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-virtualbox-v2.0.5.box"
 
     # Customize the amount of memory on the VM:
     vb.memory = vm_memory.to_s

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -398,6 +398,7 @@ roles:
   - scripts/go_log_level.sh
   scripts:
   - scripts/patches/fix_haproxy_fd_requirements.sh
+  - scripts/patches/fix_tcp_routing_wait_for_uaa.sh
   - scripts/patches/fix_consul_pre_start.sh
   - scripts/authorize_internal_ca.sh
   - scripts/forward_logfiles.sh

--- a/container-host-files/etc/hcf/config/scripts/patches/fix_tcp_routing_wait_for_uaa.sh
+++ b/container-host-files/etc/hcf/config/scripts/patches/fix_tcp_routing_wait_for_uaa.sh
@@ -1,0 +1,67 @@
+set -e
+
+PATCH_DIR="/var/vcap/jobs-src/tcp_router/templates"
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+read -r -d '' setup_pre_start <<'PATCH' || true
+--- pre-start	2017-07-24 16:32:40.000000000 -0700
++++ pre-start.new	2017-07-24 15:51:13.000000000 -0700
+@@ -24,4 +24,45 @@
+ setcap_haproxy
+ chown -R vcap:vcap "${CONFIG_DIR}"
+ 
++# Report progress to the user; use as printf
++status() {
++    local fmt="${1}"
++    shift
++    printf "\n%b${fmt}%b\n" "\033[0;32m" "$@" "\033[0m"
++}
++
++# Report problem to the user; use as printf
++trouble() {
++    local fmt="${1}"
++    shift
++    printf "\n%b${fmt}%b\n" "\033[0;31m" "$@" "\033[0m"
++}
++
++# helper function to retry a command several times, with a delay between trials
++# usage: retry <max-tries> <delay> <command>...
++function retry () {
++    max=${1}
++    delay=${2}
++    i=0
++    shift 2
++
++    while test ${i} -lt ${max} ; do
++        printf "Trying: %s\n" "$*"
++        if "$@" ; then
++            status ' SUCCESS'
++            break
++        fi
++        trouble '  FAILED'
++        status "Waiting ${delay} ..."
++        sleep "${delay}"
++        i="$(expr ${i} + 1)"
++    done
++}
++
++CURL_SKIP="<%= properties.skip_ssl_validation ? '--insecure' : '' %>"
++UAA_ENDPOINT="https://<%= p('uaa.token_endpoint') %>:<%= p('uaa.tls_port') %>"
++
++status "Waiting for UAA ..."
++retry 240 30s curl --connect-timeout 5 --fail --header 'Accept: application/json' $UAA_ENDPOINT/info
++
+ exit 0
+PATCH
+
+cd "$PATCH_DIR"
+
+echo "${setup_pre_start}" | patch --force
+
+touch "${SENTINEL}"
+
+exit 0


### PR DESCRIPTION
The tcp-router does not recover from starting up without a valid UAA token.

WIP: The tcp-router also requires an update to the vagrant-box 2.0.5 to enable hairpin NAT.

Update the Vagrant file once https://github.com/SUSE/scf/pull/1052 has been merged