### PR TITLE
Increase size of data volume for garden

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1112,9 +1112,12 @@ roles:
       max: 254
     capabilities: [ALL]
     persistent-volumes:
+    - path: /var/vcap/data
+      tag: garden-data
+      size: 50
     - path: /var/vcap/data/garden
       tag: garden-graph
-      size: 5
+      size: 50
     shared-volumes: []
     memory: 4096
     virtual-cpus: 4


### PR DESCRIPTION
Also mount /var/vcap/data, so there's enough room for grootfs data, and it doesn't get stored on the container's volume.