### PR TITLE
Remove cc-service-dashboards UAA client

### DIFF
--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -273,9 +273,6 @@ properties:
       # Note that these clients are overridden in the dev-only UAA role; that is
       # instead used to bootstrap the default zone, whereas all of these clients
       # go into the HCF zone.
-      cc-service-dashboards:
-        authorities: clients.read,clients.write,clients.admin
-        authorized-grant-types: client_credentials
       cc_routing:
         authorities: routing.router_groups.read
         authorized-grant-types: client_credentials

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -2468,7 +2468,6 @@ configuration:
     properties.uaa.admin.client_secret: '"((UAA_ADMIN_CLIENT_SECRET))"'
     properties.uaa.ca_cert: '"((HCP_CA_CERT))((^HCP_CA_CERT))((INTERNAL_CA_CERT))((/HCP_CA_CERT))"'
     properties.uaa.client_secret: '"((UAA_CLIENTS_TCP_EMITTER_SECRET))"'
-    properties.uaa.clients.cc-service-dashboards.secret: '"((UAA_CLIENTS_CC_SERVICE_SECRET))"'
     properties.uaa.clients.cc_routing.secret: '"((UAA_CLIENTS_CC_ROUTING_SECRET))"'
     properties.uaa.clients.cf.redirect-uri: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))/login
     properties.uaa.clients.cloud_controller.secret: ((UAA_CC_CLIENT_SECRET))


### PR DESCRIPTION
because we don't deploy the dashboard, but the client may end up being
not unique:

```
Creating service broker mysql-dev as admin...
FAILED
Server error, status code: 502, error code: 270012, message: Service broker catalog is invalid:
Service mysql-dev
  Service dashboard client id must be unique

Service broker already exists - updating broker
```