### PR TITLE
Use different tags on the diego-cell volume claims

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1116,7 +1116,7 @@ roles:
       tag: garden-data
       size: 50
     - path: /var/vcap/data/grootfs
-      tag: garden-data
+      tag: grootfs-data
       size: 50
     shared-volumes: []
     memory: 4096


### PR DESCRIPTION
Using the same tag will mount the same volume to both locations.