### PR TITLE
Bump the SCF version number for the alpha release.

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for SUSE Cloud Foundry
 name: scf
-version: 4.0.1
+version: 2.0.2

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1511,7 +1511,7 @@ configuration:
     description: The password for the cluster administrator.
     required: true
   - name: CLUSTER_BUILD
-    default: 1.0.0
+    default: 2.0.2
     description: "'build' attribute in the /v2/info endpoint"
     required: true
   - name: CLUSTER_DESCRIPTION


### PR DESCRIPTION
https://trello.com/c/cgfrMMuD/288-fix-version-number-in-v2-info

Subordinate PR: https://github.com/SUSE/uaa-fissile-release/pull/38
(Fix of version information in the helm charts, per @jandubois 's request in RC)
