### PR TITLE
Added test for tiller to the readiness checker.

### DIFF
--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -87,7 +87,13 @@ fi
 # kube-dns shows 4/4 ready
 if having_category kube ; then
     kubectl get pods --namespace=kube-system --selector k8s-app=kube-dns | grep -Eq '([0-9])/\1 *Running'
-    status "kube-dns should shows 4/4 ready"
+    status "kube-dns should be running (show 4/4 ready)"
+fi
+
+# tiller-deploy shows 4/4 ready
+if having_category kube ; then
+    kubectl get pods --namespace=kube-system --selector name=tiller | grep -Eq '([0-9])/\1 *Running'
+    status "tiller should be running (1/1 ready)"
 fi
 
 # ntp is installed and running

--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -86,13 +86,13 @@ fi
 
 # kube-dns shows 4/4 ready
 if having_category kube ; then
-    kubectl get pods --namespace=kube-system --selector k8s-app=kube-dns | grep -Eq '([0-9])/\1 *Running'
+    kubectl get pods --namespace=kube-system --selector k8s-app=kube-dns 2> /dev/null | grep -Eq '([0-9])/\1 *Running'
     status "kube-dns should be running (show 4/4 ready)"
 fi
 
 # tiller-deploy shows 4/4 ready
 if having_category kube ; then
-    kubectl get pods --namespace=kube-system --selector name=tiller | grep -Eq '([0-9])/\1 *Running'
+    kubectl get pods --namespace=kube-system --selector name=tiller 2> /dev/null | grep -Eq '([0-9])/\1 *Running'
     status "tiller should be running (1/1 ready)"
 fi
 


### PR DESCRIPTION
Ref: https://trello.com/c/cCgf3Rsr/271-1-ci-kube-ready-state-checksh-must-include-tiller-install-check

Tweaked the messages a bit.

Testing:
- On a (newly-made) vagrant box the check should succeed without any special work.
- For testing the other side `helm reset --force` uninstalls tiller. After that the check should fail.
- And redoing `helm init` should make it succeed again (after a while, tiller takes a bit to be fully running).
