### PR TITLE
Replaced `cd/pwd` construct to get absolute path with `readlink -f`.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,10 +2,15 @@
 # This file is both used via direnv, as well as by directly sourcing it in a
 # shell (when being run from CI).
 
+# prevent cd from printing the directory it changes to. This breaks
+# cd/pwd constructions (See **).
+unset CDPATH
+
 if type source_up >/dev/null 2>/dev/null; then
     # Using direnv; load any higher up .envrc
     source_up || true
 else
+    # (**)
     PWD="$(cd "$(dirname "${BASH_SOURCE[0]:-${KSH_VERSION:+${.sh.file}}${KSH_VERSION:-$0}}")" && pwd)"
 fi
 

--- a/bin/cert-generator-wrapper.sh.in
+++ b/bin/cert-generator-wrapper.sh.in
@@ -2,6 +2,10 @@
 set -o errexit
 set -o nounset
 
+# prevent cd from printing the directory it changes to. This breaks
+# cd/pwd constructions (See **1 **2).
+unset CDPATH
+
 usage() {
 	cat <<EOF
 $(basename "${0}"): SCF Certificate Generator
@@ -14,6 +18,7 @@ EOF
 }
 
 namespace=cf
+# (**1)
 scripts_dir="$(cd "$(dirname "$0")/scripts/" && pwd)"
 out_dir="$(pwd)"
 
@@ -34,6 +39,7 @@ while getopts "d:hn:o:" opt; do
         echo "Invalid -${opt} argument ${OPTARG}, must be a directory" >&2
         exit 1
       fi
+      # (**2)
       out_dir="$(cd "${OPTARG}" ; pwd)"
       ;;
   esac

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -2,6 +2,11 @@
 set -o errexit
 set -o nounset
 
+# prevent cd from printing the directory it changes to. This breaks
+# cd/pwd constructions (See **).
+unset CDPATH
+
+# (**)
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
 if [[ $# -lt 2 || -z "${1:-}" || -z "${2:-}" ]]; then

--- a/bin/dev/install_tools.sh
+++ b/bin/dev/install_tools.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -o errexit -o nounset
 
+# prevent cd from printing the directory it changes to. This breaks
+# cd/pwd constructions (See **).
+unset CDPATH
+
 # Get version information
 . "$(dirname "$0")/versions.sh"
 
@@ -25,6 +29,7 @@ helm_url="${helm_url:-https://kubernetes-helm.storage.googleapis.com/helm-v${HEL
 mkdir -p "${bin_dir}"
 mkdir -p "${tools_dir}"
 
+# (**)
 bin_dir="$(cd "${bin_dir}" && pwd)"
 
 echo "Fetching cf CLI $cf_url ..."

--- a/bin/dev/vagrant-envrc
+++ b/bin/dev/vagrant-envrc
@@ -1,4 +1,10 @@
-ROOT=`readlink -f "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../"`
+
+# prevent cd from printing the directory it changes to. This breaks
+# cd/pwd constructions (See **).
+unset CDPATH
+
+# (**)
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)"
 
 # Directory used when mounting volumes to containers
 export HCF_RUN_STORE="$HOME/.run/store"

--- a/bin/generate-dev-certs.sh
+++ b/bin/generate-dev-certs.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 
+# prevent cd from printing the directory it changes to. This breaks
+# cd/pwd constructions (See **).
+unset CDPATH
+
 load_env() {
     local dir="${1}"
     for f in $(ls "${dir}"/*.env | sort | grep -vE '/certs\.env$' | grep -vE '/ca\.env$') ; do
@@ -55,6 +59,7 @@ if test -z "${output_path}" ; then
 fi
 
 if test "${has_env}" = "no" ; then
+    # (**)
     load_env "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/settings/"
 fi
 

--- a/bin/init-host-for-vagrant.sh
+++ b/bin/init-host-for-vagrant.sh
@@ -3,10 +3,15 @@
 # This script pulls in the various cf-*-release submodules so the
 # VM can use them.
 
+# prevent cd from printing the directory it changes to. This breaks
+# cd/pwd constructions (See **).
+unset CDPATH
+
 function has_upstream() {
     git rev-parse @{u} > /dev/null 2>&1
 }
 
+# (**)
 ROOT=$(dirname $(cd $(dirname $0) && pwd))
 cd ${ROOT}/src
 

--- a/bin/validation.sh
+++ b/bin/validation.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-ROOT="$(readlink -f "$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )")"
+# prevent cd from printing the directory it changes to. This breaks
+# cd/pwd constructions (See **).
+unset CDPATH
+
+# (**)
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)"
 
 stampy "${ROOT}/scf_metrics.csv" "${BASH_SOURCE[0]}" validation start
 stampy "${ROOT}/scf_metrics.csv" "${BASH_SOURCE[0]}" validation::show-properties start


### PR DESCRIPTION
https://trello.com/c/FTwkoGmF/297-unset-cdpath-in-certgen-script

The construct broke due to ev `CDPATH` causing the `cd` to generate additional output.
Instead of removing `CDPATH` the `readlink` gives us the same functionality without hassle.

Eight more places.
(Note: Currently unable to test myself, the local concourse blocks me from playing with vagrant).