### PR TITLE
Packer: support building Jenkins slaves on Triton

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb, override|
     # Need to shorten the URL for Windows' sake
-    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-virtualbox-v2.0.6.box"
+    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-virtualbox-v2.0.7.box"
     vb_net_config = base_net_config
     if ENV.include? "VAGRANT_VBOX_BRIDGE"
       vb_net_config[:bridge] = ENV.fetch("VAGRANT_VBOX_BRIDGE")
@@ -116,7 +116,7 @@ Vagrant.configure(2) do |config|
 #  end
 
   config.vm.provider "libvirt" do |libvirt, override|
-    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-libvirt-v2.0.6.box"
+    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-libvirt-v2.0.7.box"
     libvirt.driver = "kvm"
     libvirt_net_config = base_net_config
     libvirt_net_config[:nic_model_type] = "virtio"

--- a/packer/http/autoyast.xml
+++ b/packer/http/autoyast.xml
@@ -210,41 +210,5 @@
       <file_contents><![CDATA[ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
 ]]></file_contents>
     </file>
-    <file>
-      <!-- This directory is filled in by packer -->
-      <file_path>/etc/systemd/system/kube-apiserver.service.d/</file_path>
-      <file_owner>vagrant.users</file_owner>
-      <file_permissions>0755</file_permissions>
-    </file>
-    <file>
-      <!-- This directory is filled in by packer -->
-      <file_path>/etc/systemd/system/kube-controller-manager.service.d/</file_path>
-      <file_owner>vagrant.users</file_owner>
-      <file_permissions>0755</file_permissions>
-    </file>
-    <file>
-      <!-- This directory is filled in by packer -->
-      <file_path>/etc/systemd/system/kubelet.service.d/</file_path>
-      <file_owner>vagrant.users</file_owner>
-      <file_permissions>0755</file_permissions>
-    </file>
-    <file>
-      <file_path>/etc/sysconfig/docker</file_path>
-      <file_owner>vagrant.users</file_owner>
-      <file_permissions>0644</file_permissions>
-      <file_contents>DOCKER_OPTS="--insecure-registry=0.0.0.0/0"</file_contents>
-    </file>
-    <file>
-      <file_path>/etc/security/limits.d/vagrant-nproc.conf</file_path>
-      <file_owner>root.root</file_owner>
-      <file_permissions>644</file_permissions>
-      <file_contents><![CDATA[
-# This overrides /etc/security/limits.conf to allow more processes for the
-# vagrant user (which is where all our processes go)
-
-vagrant hard nproc unlimited
-vagrant soft nproc unlimited
-      ]]></file_contents>
-    </file>
   </files>
 </profile>

--- a/packer/http/controller-manager-jenkins-overrides.conf
+++ b/packer/http/controller-manager-jenkins-overrides.conf
@@ -1,0 +1,2 @@
+[Unit]
+RequiresMountsFor=/tmp/hostpath_pv

--- a/packer/http/data-hostpath-create.service
+++ b/packer/http/data-hostpath-create.service
@@ -1,0 +1,13 @@
+[Unit]
+Requires=data.mount
+After=data.mount
+# network.target makes no sense here, but it seems to be after `/data` mounts
+After=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/mkdir -p /data/hostpath
+
+[Install]
+WantedBy=tmp-hostpath_pv.mount

--- a/packer/http/tmp-hostpath_pv.automount
+++ b/packer/http/tmp-hostpath_pv.automount
@@ -1,0 +1,6 @@
+[Unit]
+Before=local-fs.target
+RequiresMountsFor=/data /tmp
+
+[Automount]
+Where=/tmp/hostpath_pv

--- a/packer/http/tmp-hostpath_pv.mount
+++ b/packer/http/tmp-hostpath_pv.mount
@@ -1,0 +1,9 @@
+[Unit]
+Requires=data-hostpath-create.service
+After=data-hostpath-create.service
+
+[Mount]
+What=/data/hostpath
+Where=/tmp/hostpath_pv
+Type=none
+Options=bind

--- a/packer/http/user-limits.conf
+++ b/packer/http/user-limits.conf
@@ -1,4 +1,5 @@
-# Bump up process limits, otherwise the build fails and we can't get back in to
-# clean up after ourselves.
-vagrant soft nproc 5000
-vagrant hard nproc 10000
+# This overrides /etc/security/limits.conf to allow more processes for the
+# vagrant user (which is where all our processes go)
+
+vagrant hard nproc unlimited
+vagrant soft nproc unlimited

--- a/packer/http/user-limits.conf
+++ b/packer/http/user-limits.conf
@@ -1,0 +1,4 @@
+# Bump up process limits, otherwise the build fails and we can't get back in to
+# clean up after ourselves.
+vagrant soft nproc 5000
+vagrant hard nproc 10000

--- a/packer/scripts/create-kube-certs.sh
+++ b/packer/scripts/create-kube-certs.sh
@@ -2,6 +2,8 @@
 
 set -o errexit -o xtrace
 
+export PATH="${PATH}:/usr/local/bin/"
+
 mkdir -p /run/certstrap
 certstrap --depot-path "/run/certstrap" init --common-name "CA.kube.vagrant" --passphrase "" --years 10
 certstrap --depot-path "/run/certstrap" request-cert --common-name "apiserver" --passphrase "" --ip 127.0.0.1,192.168.77.77,172.17.0.1,10.254.0.1 --domain kubernetes.default.svc,kubernetes.default,kubernetes,localhost

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "2.0.6+{{isotime \"20060102-1504\"}}",
+        "version": "2.0.6",
         "vm_name": "scf-vagrant",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",
@@ -21,7 +21,7 @@
         {
             "type": "vmware-iso",
             "headless": true,
-            "vm_name": "{{user `vm_name`}}",
+            "vm_name": "{{user `vm_name`}}+{{isotime \"20060102-1504\"}}",
             "guest_os_type": "suse-64",
             "disk_size": 120480,
             "ssh_username": "{{user `ssh_username`}}",
@@ -47,7 +47,7 @@
         {
             "type": "virtualbox-iso",
             "headless": true,
-            "vm_name": "{{user `vm_name`}}",
+            "vm_name": "{{user `vm_name`}}+{{isotime \"20060102-1504\"}}",
             "guest_os_type": "OpenSUSE_64",
             "guest_additions_mode": "disable",
             "disk_size": 120480,
@@ -76,7 +76,7 @@
         {
             "type": "qemu",
             "headless": true,
-            "vm_name": "{{user `vm_name`}}",
+            "vm_name": "{{user `vm_name`}}+{{isotime \"20060102-1504\"}}",
             "disk_size": 120480,
             "disk_interface": "virtio",
             "disk_compression": true,
@@ -103,7 +103,7 @@
         {
             "type": "triton",
             "image_name": "{{ user `vm_name` }}",
-            "image_version": "{{ user `version` }}",
+            "image_version": "{{ user `version` }}+{{isotime \"20060102-1504\"}}",
             "source_machine_image": "{{ user `source_machine_image` }}",
             "source_machine_package": "{{ user `source_machine_package` }}",
             "ssh_private_key_file": "{{ user `ssh_private_key_file` }}",

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "version": "2.0.6",
-        "vm_name": "scf-vagrant-{{isotime \"20060102-1504\"}}",
+        "version": "2.0.6+{{isotime \"20060102-1504\"}}",
+        "vm_name": "scf-vagrant",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",
         "iso_url": "http://download.opensuse.org/distribution/leap/42.2/iso/openSUSE-Leap-42.2-NET-x86_64.iso",
@@ -9,6 +9,12 @@
         "iso_checksum_type": "sha256",
         "http_directory": "http",
         "ssh_wait_timeout": "300m",
+        "source_machine_package": "{{ env `SOURCE_MACHINE_PACKAGE` }}",
+        "source_machine_image": "{{ env `SOURCE_MACHINE_IMAGE` }}",
+        "ssh_private_key_file": "{{ env `SSH_PRIVATE_KEY_FILE` }}",
+        "triton_account": "{{ env `TRITON_ACCOUNT` }}",
+        "triton_key_id": "{{ env `TRITON_KEY_ID` }}",
+        "triton_url": "{{ env `TRITON_URL` }}",
         "shutdown_command": "echo vagrant | sudo -S shutdown -P now"
     },
     "builders": [
@@ -93,14 +99,46 @@
                 "autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/autoyast.xml ",
                 "<enter><wait>"
             ]
+        },
+        {
+            "type": "triton",
+            "image_name": "{{ user `vm_name` }}",
+            "image_version": "{{ user `version` }}",
+            "source_machine_image": "{{ user `source_machine_image` }}",
+            "source_machine_package": "{{ user `source_machine_package` }}",
+            "ssh_private_key_file": "{{ user `ssh_private_key_file` }}",
+            "ssh_username": "root",
+            "triton_account": "{{ user `triton_account` }}",
+            "triton_key_id": "{{ user `triton_key_id` }}",
+            "triton_key_material": "{{ user `ssh_private_key_file` }}",
+            "triton_url": "{{ user `triton_url` }}"
         }
     ],
     "provisioners": [
         {
             "type": "shell",
+            "only": ["triton"],
+            "inline": [
+                "# Create vagrant user",
+                "useradd --create-home vagrant",
+                "echo vagrant:vagrant | chpasswd"
+            ]
+        },
+        {
+            "type": "shell",
             "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
             "scripts": [
                 "scripts/install-kubernetes.sh"
+            ]
+        },
+        {
+            "type": "shell",
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
+            "inline": [
+                "# Create directories to ensure packer doesn't mess up",
+                "mkdir -p /etc/systemd/system/kube-apiserver.service.d/",
+                "mkdir -p /etc/systemd/system/kube-controller-manager.service.d/",
+                "mkdir -p /etc/systemd/system/kubelet.service.d/"
             ]
         },
         {
@@ -119,6 +157,30 @@
             "destination": "/etc/systemd/system/kube-controller-manager.service.d/vagrant-overrides.conf"
         },
         {
+            "only": ["triton"],
+            "type": "file",
+            "source": "http/controller-manager-jenkins-overrides.conf",
+            "destination": "/etc/systemd/system/kube-controller-manager.service.d/jenkins-overrides.conf"
+        },
+        {
+            "only": ["triton"],
+            "type": "file",
+            "source": "http/data-hostpath-create.service",
+            "destination": "/etc/systemd/system/data-hostpath-create.service"
+        },
+        {
+            "only": ["triton"],
+            "type": "file",
+            "source": "http/tmp-hostpath_pv.automount",
+            "destination": "/etc/systemd/system/tmp-hostpath_pv.automount"
+        },
+        {
+            "only": ["triton"],
+            "type": "file",
+            "source": "http/tmp-hostpath_pv.mount",
+            "destination": "/etc/systemd/system/tmp-hostpath_pv.mount"
+        },
+        {
             "type": "file",
             "source": "http/kubelet-vagrant-overrides.conf",
             "destination": "/etc/systemd/system/kubelet.service.d/vagrant-overrides.conf"
@@ -130,8 +192,20 @@
         },
         {
             "type": "file",
+            "source": "http/user-limits.conf",
+            "destination": "/etc/security/limits.d/vagrant.conf"
+        },
+        {
+            "type": "file",
             "source": "http/docker.conf",
             "destination": "/etc/sysconfig/docker"
+        },
+        {
+            "type": "shell",
+            "only": ["triton"],
+            "inline": [
+                "perl -p -i -e 's@(DOCKER_OPTS)=\"(.*)\"@$1=\"$2 --graph=/data/docker\"@' /etc/sysconfig/docker"
+            ]
         },
         {
             "type": "shell",
@@ -151,7 +225,25 @@
                 "scripts/install-certstrap.sh",
                 "scripts/usr-local-bin-to-path.sh",
                 "scripts/create-kube-certs.sh",
-                "scripts/create-kubedns.sh",
+                "scripts/create-kubedns.sh"
+            ],
+            "start_retry_timeout": "7m"
+        },
+        {
+            "type": "shell",
+            "only": ["triton"],
+            "inline": [
+                "# Install helm",
+                "wget -O - https://kubernetes-helm.storage.googleapis.com/helm-v2.5.1-linux-amd64.tar.gz | tar xz -C /usr/local/bin --no-same-owner --strip-components=1 linux-amd64/helm",
+                "sudo -i -u vagrant helm init",
+                "# Install Java",
+                "zypper --non-interactive install jre-openjdk-headless"
+            ]
+        },
+        {
+            "type": "shell",
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
+            "scripts": [
                 "scripts/compact.sh"
             ],
             "start_retry_timeout": "7m"
@@ -160,6 +252,7 @@
     "post-processors": [
         {
             "type": "vagrant",
+            "only": ["vmware-iso", "virtualbox-iso", "qemu"],
             "output": "scf-{{.Provider}}-v{{user `version`}}.box",
             "vagrantfile_template": "Vagrantfile.template"
         }

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -121,7 +121,10 @@
             "inline": [
                 "# Create vagrant user",
                 "useradd --create-home vagrant",
-                "echo vagrant:vagrant | chpasswd"
+                "echo vagrant:vagrant | chpasswd",
+                "# Enable swap accounting",
+                "perl -p -i -e 's@^(GRUB_CMDLINE_LINUX_DEFAULT)=\"(.*)\"@$1=\"$2 swapaccount=1\"@' /etc/default/grub",
+                "grub2-mkconfig -o /boot/grub2/grub.cfg"
             ]
         },
         {
@@ -236,8 +239,8 @@
                 "# Install helm",
                 "wget -O - https://kubernetes-helm.storage.googleapis.com/helm-v2.5.1-linux-amd64.tar.gz | tar xz -C /usr/local/bin --no-same-owner --strip-components=1 linux-amd64/helm",
                 "sudo -i -u vagrant helm init",
-                "# Install Java",
-                "zypper --non-interactive install jre-openjdk-headless"
+                "# Install additional packages",
+                "zypper --non-interactive install jre-openjdk-headless make zip"
             ]
         },
         {

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "2.0.6",
+        "version": "2.0.7",
         "vm_name": "scf-vagrant",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",
@@ -135,78 +135,86 @@
             ]
         },
         {
+            "type": "file",
+            "source": "http/apiserver-vagrant-overrides.conf",
+            "destination": "/tmp/apiserver-vagrant-overrides.conf"
+        },
+        {
+            "type": "file",
+            "source": "http/apiserver-vagrant-overrides.env",
+            "destination": "/tmp/apiserver-vagrant-overrides.env"
+        },
+        {
+            "type": "file",
+            "source": "http/controller-manager-vagrant-overrides.conf",
+            "destination": "/tmp/controller-manager-vagrant-overrides.conf"
+        },
+        {
+            "type": "file",
+            "source": "http/kubelet-vagrant-overrides.conf",
+            "destination": "/tmp/kubelet-vagrant-overrides.conf"
+        },
+        {
+            "type": "file",
+            "source": "http/kubelet-vagrant-overrides.env",
+            "destination": "/tmp/kubelet-vagrant-overrides.env"
+        },
+        {
+            "type": "file",
+            "source": "http/user-limits.conf",
+            "destination": "/tmp/user-limits.conf"
+        },
+        {
+            "type": "file",
+            "source": "http/docker.conf",
+            "destination": "/tmp/docker.conf"
+        },
+        {
             "type": "shell",
             "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
             "inline": [
                 "# Create directories to ensure packer doesn't mess up",
                 "mkdir -p /etc/systemd/system/kube-apiserver.service.d/",
+                "mv /tmp/apiserver-vagrant-overrides.conf /etc/systemd/system/kube-apiserver.service.d/vagrant-overrides.conf",
+                "mv /tmp/apiserver-vagrant-overrides.env /etc/systemd/system/kube-apiserver.service.d/vagrant-overrides.env",
                 "mkdir -p /etc/systemd/system/kube-controller-manager.service.d/",
-                "mkdir -p /etc/systemd/system/kubelet.service.d/"
+                "mv /tmp/controller-manager-vagrant-overrides.conf /etc/systemd/system/kube-controller-manager.service.d/vagrant-overrides.conf",
+                "mkdir -p /etc/systemd/system/kubelet.service.d/",
+                "mv /tmp/kubelet-vagrant-overrides.conf /etc/systemd/system/kubelet.service.d/vagrant-overrides.conf",
+                "mv /tmp/kubelet-vagrant-overrides.env /etc/systemd/system/kubelet.service.d/vagrant-overrides.env",
+                "mv /tmp/user-limits.conf /etc/security/limits.d/vagrant-nproc.conf",
+                "mv /tmp/docker.conf /etc/sysconfig/docker"
             ]
         },
         {
             "type": "file",
-            "source": "http/apiserver-vagrant-overrides.conf",
-            "destination": "/etc/systemd/system/kube-apiserver.service.d/vagrant-overrides.conf"
-        },
-        {
-            "type": "file",
-            "source": "http/apiserver-vagrant-overrides.env",
-            "destination": "/etc/systemd/system/kube-apiserver.service.d/vagrant-overrides.env"
-        },
-        {
-            "type": "file",
-            "source": "http/controller-manager-vagrant-overrides.conf",
-            "destination": "/etc/systemd/system/kube-controller-manager.service.d/vagrant-overrides.conf"
-        },
-        {
             "only": ["triton"],
-            "type": "file",
             "source": "http/controller-manager-jenkins-overrides.conf",
             "destination": "/etc/systemd/system/kube-controller-manager.service.d/jenkins-overrides.conf"
         },
         {
-            "only": ["triton"],
             "type": "file",
+            "only": ["triton"],
             "source": "http/data-hostpath-create.service",
             "destination": "/etc/systemd/system/data-hostpath-create.service"
         },
         {
-            "only": ["triton"],
             "type": "file",
+            "only": ["triton"],
             "source": "http/tmp-hostpath_pv.automount",
             "destination": "/etc/systemd/system/tmp-hostpath_pv.automount"
         },
         {
-            "only": ["triton"],
             "type": "file",
+            "only": ["triton"],
             "source": "http/tmp-hostpath_pv.mount",
             "destination": "/etc/systemd/system/tmp-hostpath_pv.mount"
-        },
-        {
-            "type": "file",
-            "source": "http/kubelet-vagrant-overrides.conf",
-            "destination": "/etc/systemd/system/kubelet.service.d/vagrant-overrides.conf"
-        },
-        {
-            "type": "file",
-            "source": "http/kubelet-vagrant-overrides.env",
-            "destination": "/etc/systemd/system/kubelet.service.d/vagrant-overrides.env"
-        },
-        {
-            "type": "file",
-            "source": "http/user-limits.conf",
-            "destination": "/etc/security/limits.d/vagrant.conf"
-        },
-        {
-            "type": "file",
-            "source": "http/docker.conf",
-            "destination": "/etc/sysconfig/docker"
         },
         {
             "type": "shell",
             "only": ["triton"],
             "inline": [
+                "# Triton needs to put docker graph in /data for the larger disk",
                 "perl -p -i -e 's@(DOCKER_OPTS)=\"(.*)\"@$1=\"$2 --graph=/data/docker\"@' /etc/sysconfig/docker"
             ]
         },


### PR DESCRIPTION
Triton uses a different base image, so we need to add the vagrant user and install helm separately. We also need Java for Jenkins.  Since it requires a secondary disk for bulk storage, we need a bunch of systemd units to line things up correctly to ensure we mount the hostpath stuff on that disk.