### PR TITLE
jenkins: force use a fixed workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
         skipDefaultCheckout() // We do our own checkout so it can be disabled
         timestamps()
         timeout(time: 5, unit: 'HOURS')
+        ws('scf')
     }
     parameters {
         booleanParam(


### PR DESCRIPTION
Combined with `disableConcurrentBuilds()` this lets us save on disk space by re-using previous builds.