### PR TITLE
bump uaa-fissile-release for certstrap changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,7 +153,7 @@ pipeline {
                         source ${PWD}/.envrc
                         set -x
                         unset HCF_PACKAGE_COMPILATION_CACHE
-                        rm scf-*-amd64-*.zip
+                        rm -f scf-*-amd64-*.zip
                         make helm bundle-dist
                     '''
                 }


### PR DESCRIPTION
Also fixes an issue with jenkins deleting files that don't exist