### PR TITLE
cf-usb: switch to https for git repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -75,4 +75,4 @@
 	url = https://github.com/SUSE/uaa-fissile-release
 [submodule "src/cf-usb"]
 	path = src/cf-usb
-	url = git@github.com:SUSE/cf-usb
+	url = https://github.com/SUSE/cf-usb


### PR DESCRIPTION
Jenkins does not currently use SSH to check out (and has no key to do so with).