### PR TITLE
remove ntpd check for kube category in kube-ready-state-check.sh

### DIFF
--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -100,8 +100,8 @@ if having_category kube ; then
     status "tiller should be running (1/1 ready)"
 fi
 
-# ntp is installed and running
-if having_category api kube node ; then
+# ntp or systemd-timesyncd is installed and running
+if having_category api node ; then
     pgrep -x ntpd >& /dev/null || pgrep -x chronyd >& /dev/null || systemctl is-active systemd-timesyncd >& /dev/null
     status "An ntp daemon or systemd-timesyncd must be installed and active"
 fi


### PR DESCRIPTION
kube category do not need ntpd or systemd-timesyncd check. This check if run from local machine or a container with  proper kube config might fail, because that machine might not have these running. This is not a requirement.