### PR TITLE
kube: install cni-plugins

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb, override|
     # Need to shorten the URL for Windows' sake
-    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-virtualbox-v2.0.7.box"
+    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-virtualbox-v2.0.8.box"
     vb_net_config = base_net_config
     if ENV.include? "VAGRANT_VBOX_BRIDGE"
       vb_net_config[:bridge] = ENV.fetch("VAGRANT_VBOX_BRIDGE")
@@ -116,7 +116,7 @@ Vagrant.configure(2) do |config|
 #  end
 
   config.vm.provider "libvirt" do |libvirt, override|
-    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-libvirt-v2.0.7.box"
+    override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-libvirt-v2.0.8.box"
     libvirt.driver = "kvm"
     libvirt_net_config = base_net_config
     libvirt_net_config[:nic_model_type] = "virtio"

--- a/packer/scripts/install-kubernetes.sh
+++ b/packer/scripts/install-kubernetes.sh
@@ -12,6 +12,7 @@ zypper --non-interactive addrepo --gpgcheck --refresh --priority 120 --check \
 zypper --non-interactive --gpg-auto-import-keys refresh
 zypper --non-interactive repos --uri # for troubleshooting
 zypper --non-interactive install --no-confirm --from Virtualization:containers \
+    cni-plugins \
     docker \
     etcd-3.2.4 \
     kubernetes-common-1.6.1 \

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "2.0.7",
+        "version": "2.0.8",
         "vm_name": "scf-vagrant",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",
@@ -247,8 +247,19 @@
                 "# Install helm",
                 "wget -O - https://kubernetes-helm.storage.googleapis.com/helm-v2.5.1-linux-amd64.tar.gz | tar xz -C /usr/local/bin --no-same-owner --strip-components=1 linux-amd64/helm",
                 "sudo -i -u vagrant helm init",
+                "systemctl stop kube-apiserver kube-controller-manager kube-proxy kube-scheduler kubelet docker",
+                "rm -rf /data/docker/image/* /data/docker/containers/* /data/docker/overlay2",
                 "# Install additional packages",
                 "zypper --non-interactive install jre-openjdk-headless make zip"
+            ]
+        },
+        {
+            "type": "shell",
+            "only": ["vmware-iso", "virtualbox-iso", "qemu"],
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
+            "inline": [
+                "systemctl stop kube-apiserver kube-controller-manager kube-proxy kube-scheduler kubelet docker",
+                "rm -rf /var/lib/docker/image/* /var/lib/docker/continers/* /var/lib/docker/overlay2"
             ]
         },
         {


### PR DESCRIPTION
It was previously all in the `cni` package, which is required by docker. It's now split into a separate package, and is required to run kubelet.