### PR TITLE
Properly define parameter for CATs testsuites to get user settings (if made) into the system.

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -1487,6 +1487,9 @@ configuration:
       type: Password
     description: The password for the bulk api.
     required: true
+  - name: CATS_SUITES
+    internal: true
+    description: The set of CAT test suites to run. If not specified it falls back to a hardwired set of suites.
   - name: CCDB_ROLE_PASSWORD
     secret: true
     immutable: true


### PR DESCRIPTION
This PR has no trello ticket associated with it.
It grew out of work on https://trello.com/c/AK24MJA3/235-3-scf-config-reckoning
while testing changes and having to run only a subset of the :cat: