### PR TITLE
Update sizing configurations for some of the roles

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -179,7 +179,7 @@ roles:
       properties.cf_mysql.external_host: ((DOMAIN))
       properties.cf_mysql.mysql.admin_password: ((MYSQL_ADMIN_PASSWORD))
       properties.cf_mysql.mysql.cluster_health.password: ((MYSQL_CLUSTER_HEALTH_PASSWORD))
-      properties.cf_mysql.mysql.cluster_ips: ((KUBE_MYSQL_CLUSTER_IPS))
+      properties.cf_mysql.mysql.cluster_ips: ((KUBE_MYSQL_CLUSTER_IPS))((#KUBE_SIZING_MYSQL_COUNT))((/KUBE_SIZING_MYSQL_COUNT))
       properties.cf_mysql.mysql.galera_healthcheck.db_password: ((MYSQL_ADMIN_PASSWORD))
       properties.cf_mysql.mysql.galera_healthcheck.endpoint_password: ((MYSQL_GALERA_HEALTHCHECK_ENDPOINT_PASSWORD))
       properties.cf_mysql.proxy.api_password: ((MYSQL_PROXY_ADMIN_PASSWORD))
@@ -232,7 +232,7 @@ roles:
     templates:
       properties.cf_mysql.external_host: ((DOMAIN))
       properties.cf_mysql.mysql.admin_password: ((MYSQL_ADMIN_PASSWORD))
-      properties.cf_mysql.mysql.cluster_ips: ((KUBE_MYSQL_CLUSTER_IPS))
+      properties.cf_mysql.mysql.cluster_ips: ((KUBE_MYSQL_CLUSTER_IPS))((#KUBE_SIZING_MYSQL_COUNT))((/KUBE_SIZING_MYSQL_COUNT))
       properties.cf_mysql.mysql.galera_healthcheck.endpoint_password: ((MYSQL_GALERA_HEALTHCHECK_ENDPOINT_PASSWORD))
       properties.cf_mysql.proxy.api_password: ((MYSQL_PROXY_ADMIN_PASSWORD))
       properties.cf_mysql.proxy.proxy_ips: '["mysql-proxy.((KUBE_SERVICE_DOMAIN_SUFFIX))"]'
@@ -274,7 +274,7 @@ roles:
       properties.cf_mysql.external_host: ((DOMAIN))
       properties.cf_mysql.mysql.admin_password: ((MYSQL_ADMIN_PASSWORD))
       properties.cf_mysql.mysql.cluster_health.password: ((MYSQL_CLUSTER_HEALTH_PASSWORD))
-      properties.cf_mysql.mysql.cluster_ips: ((KUBE_MYSQL_CLUSTER_IPS))
+      properties.cf_mysql.mysql.cluster_ips: ((KUBE_MYSQL_CLUSTER_IPS))((#KUBE_SIZING_MYSQL_COUNT))((/KUBE_SIZING_MYSQL_COUNT))
       properties.cf_mysql.mysql.galera_healthcheck.db_password: ((MYSQL_ADMIN_PASSWORD))
       properties.cf_mysql.mysql.galera_healthcheck.endpoint_password: ((MYSQL_GALERA_HEALTHCHECK_ENDPOINT_PASSWORD))
       properties.cf_mysql.proxy.api_password: ((MYSQL_PROXY_ADMIN_PASSWORD))
@@ -304,7 +304,7 @@ roles:
   run:
     scaling:
       min: 1
-      max: 1
+      max: 3
     capabilities: []
     persistent-volumes: []
     shared-volumes: []
@@ -330,7 +330,6 @@ roles:
   - scripts/consul_agent_log_level.sh
   - scripts/go_log_level.sh
   scripts:
-  - scripts/chown_vcap_store.sh
   - scripts/patches/fix_consul_pre_start.sh
   - scripts/authorize_internal_ca.sh
   - scripts/forward_logfiles.sh
@@ -352,12 +351,9 @@ roles:
   run:
     scaling:
       min: 1
-      max: 1
+      max: 3
     capabilities: []
-    persistent-volumes:
-    - path: /var/vcap/store
-      tag: diego-database-data
-      size: 2
+    persistent-volumes: []
     shared-volumes: []
     memory: 256
     virtual-cpus: 2
@@ -512,7 +508,7 @@ roles:
   run:
     scaling:
       min: 1
-      max: 1
+      max: 3
     capabilities: []
     persistent-volumes: []
     shared-volumes: []
@@ -961,7 +957,7 @@ roles:
   run:
     scaling:
       min: 1
-      max: 1
+      max: 3
     capabilities: []
     persistent-volumes: []
     shared-volumes: []
@@ -1046,7 +1042,7 @@ roles:
   run:
     scaling:
       min: 1
-      max: 1
+      max: 3
     capabilities: []
     persistent-volumes: []
     shared-volumes: []
@@ -1862,6 +1858,22 @@ configuration:
       runtime configuration.
     immutable: true
     required: false
+  - name: KUBE_SIZING_CONSUL_COUNT
+    description: >
+      The number of consul replicas deployed.
+      This value is set automatically by the helm charts of SCF.
+  - name: KUBE_SIZING_ETCD_COUNT
+    description: >
+      The number of etcd replicas deployed.
+      This value is set automatically by the helm charts of SCF.
+  - name: KUBE_SIZING_MYSQL_COUNT
+    description: >
+      The number of mysql replicas deployed.
+      This value is set automatically by the helm charts of SCF.
+  - name: KUBE_SIZING_NATS_COUNT
+    description: >
+      The number of nats replicas deployed.
+      This value is set automatically by the helm charts of SCF.
   - name: LOGGREGATOR_SHARED_SECRET
     secret: true
     immutable: true
@@ -2378,7 +2390,7 @@ configuration:
     properties.cflinuxfs2-rootfs.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))"'
     properties.consul.agent.domain: ((KUBERNETES_NAMESPACE))((^KUBERNETES_NAMESPACE))hcf((/KUBERNETES_NAMESPACE))
     properties.consul.agent.log_level: '"((CONSUL_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
-    properties.consul.agent.servers.lan: ((KUBE_CONSUL_CLUSTER_IPS))
+    properties.consul.agent.servers.lan: ((KUBE_CONSUL_CLUSTER_IPS))((#KUBE_SIZING_CONSUL_COUNT))((/KUBE_SIZING_CONSUL_COUNT))
     properties.consul.agent_cert: '"((CONSUL_AGENT_CERT))"'
     properties.consul.agent_key: '"((CONSUL_AGENT_KEY))"'
     properties.consul.ca_cert: '"((INTERNAL_CA_CERT))"'
@@ -2433,7 +2445,7 @@ configuration:
     properties.diego.route_emitter.bbs.client_cert: '"((BBS_CLIENT_CRT))"'
     properties.diego.route_emitter.bbs.client_key: '"((BBS_CLIENT_KEY))"'
     properties.diego.route_emitter.log_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
-    properties.diego.route_emitter.nats.machines: ((KUBE_NATS_CLUSTER_IPS))
+    properties.diego.route_emitter.nats.machines: ((KUBE_NATS_CLUSTER_IPS))((#KUBE_SIZING_NATS_COUNT))((/KUBE_SIZING_NATS_COUNT))
     properties.diego.route_emitter.nats.password: '"((NATS_PASSWORD))"'
     properties.diego.ssh_proxy.bbs.api_location: diego-database.((KUBE_SERVICE_DOMAIN_SUFFIX)):8889
     properties.diego.ssh_proxy.bbs.ca_cert: '"((INTERNAL_CA_CERT))"'
@@ -2454,7 +2466,7 @@ configuration:
     properties.etcd.client_cert: '"((ETCD_CLIENT_CRT))"'
     properties.etcd.client_key: '"((ETCD_CLIENT_KEY))"'
     properties.etcd.dns_health_check_host: '"((DNS_HEALTH_CHECK_HOST))"'
-    properties.etcd.machines: ((KUBE_ETCD_CLUSTER_IPS))
+    properties.etcd.machines: ((KUBE_ETCD_CLUSTER_IPS))((#KUBE_SIZING_ETCD_COUNT))((/KUBE_SIZING_ETCD_COUNT))
     properties.etcd.peer_ca_cert: '"((INTERNAL_CA_CERT))"'
     properties.etcd.peer_cert: '"((ETCD_PEER_CRT))"'
     properties.etcd.peer_key: '"((ETCD_PEER_KEY))"'
@@ -2487,7 +2499,7 @@ configuration:
     # How to reach the capi.cc_uploader
     properties.internal_hostname: '"cc-uploader.((KUBE_SERVICE_DOMAIN_SUFFIX))"'
     properties.loggregator.etcd.ca_cert: '"((INTERNAL_CA_CERT))"'
-    properties.loggregator.etcd.machines: ((KUBE_ETCD_CLUSTER_IPS))
+    properties.loggregator.etcd.machines: ((KUBE_ETCD_CLUSTER_IPS))((#KUBE_SIZING_ETCD_COUNT))((/KUBE_SIZING_ETCD_COUNT))
     properties.loggregator.tls.ca_cert: '"((INTERNAL_CA_CERT))"'
     properties.loggregator.tls.doppler.cert: '"((DOPPLER_CERT))"'
     properties.loggregator.tls.doppler.key: '"((DOPPLER_KEY))"'
@@ -2502,7 +2514,7 @@ configuration:
     properties.metron_agent.zone: '"((KUBE_AZ))"'
     # CLUSTER_NAME is not wrapped in quotes because it has quotes in the dev env file.
     properties.name: ((CLUSTER_NAME))
-    properties.nats.machines: ((KUBE_NATS_CLUSTER_IPS))
+    properties.nats.machines: ((KUBE_NATS_CLUSTER_IPS))((#KUBE_SIZING_NATS_COUNT))((/KUBE_SIZING_NATS_COUNT))
     properties.nats.password: '"((NATS_PASSWORD))"'
     properties.opensuse42-rootfs.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))"'
     properties.router.balancing_algorithm: '"((ROUTER_BALANCING_ALGORITHM))"'
@@ -2516,7 +2528,7 @@ configuration:
     properties.routing_api.etcd.ca_cert: '"((INTERNAL_CA_CERT))"'
     properties.routing_api.etcd.client_cert: '"((ETCD_CLIENT_CRT))"'
     properties.routing_api.etcd.client_key: '"((ETCD_CLIENT_KEY))"'
-    properties.routing_api.etcd.servers: ((KUBE_ETCD_CLUSTER_IPS))
+    properties.routing_api.etcd.servers: ((KUBE_ETCD_CLUSTER_IPS))((#KUBE_SIZING_ETCD_COUNT))((/KUBE_SIZING_ETCD_COUNT))
     properties.routing_api.log_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
     properties.routing_api.port: 3000((#KUBERNETES_NAMESPACE))((/KUBERNETES_NAMESPACE))
     properties.routing_api.router_groups: '[{"name":"default-tcp", "type":"tcp", "reservable_ports":"((RESERVABLE_PORTS))"}]'


### PR DESCRIPTION
This also includes using `KUBE_SIZING_*_COOUNT` variables to trigger a reconfiguration for roles that need to be directly aware of all members of clustered roles.