### PR TITLE
makefile: make fissile depend on versions.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ print-version:
 
 ########## TOOL DOWNLOAD TARGETS ##########
 
-${FISSILE_BINARY}: bin/dev/install_tools.sh
+${FISSILE_BINARY}: bin/dev/install_tools.sh bin/common/versions.sh
 	bin/dev/install_tools.sh
 
 ########## VAGRANT VM TARGETS ##########


### PR DESCRIPTION
This ensures that we will re-download fissile when a different version is desired.