### PR TITLE
create-release: bosh v2 compat

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,16 +2,12 @@
 # This file is both used via direnv, as well as by directly sourcing it in a
 # shell (when being run from CI).
 
-# prevent cd from printing the directory it changes to. This breaks
-# cd/pwd constructions (See **).
-unset CDPATH
-
 if type source_up >/dev/null 2>/dev/null; then
     # Using direnv; load any higher up .envrc
     source_up || true
 else
     # (**)
-    PWD="$(cd "$(dirname "${BASH_SOURCE[0]:-${KSH_VERSION:+${.sh.file}}${KSH_VERSION:-$0}}")" && pwd)"
+    PWD="$(unset CDPATH ; cd "$(dirname "${BASH_SOURCE[0]:-${KSH_VERSION:+${.sh.file}}${KSH_VERSION:-$0}}")" && pwd)"
 fi
 
 # Get version information

--- a/bin/cert-generator-wrapper.sh.in
+++ b/bin/cert-generator-wrapper.sh.in
@@ -2,10 +2,6 @@
 set -o errexit
 set -o nounset
 
-# prevent cd from printing the directory it changes to. This breaks
-# cd/pwd constructions (See **1 **2).
-unset CDPATH
-
 usage() {
 	cat <<EOF
 $(basename "${0}"): SCF Certificate Generator
@@ -18,8 +14,7 @@ EOF
 }
 
 namespace=cf
-# (**1)
-scripts_dir="$(cd "$(dirname "$0")/scripts/" && pwd)"
+scripts_dir="$(unset CDPATH ; cd "$(dirname "$0")/scripts/" && pwd)"
 out_dir="$(pwd)"
 
 while getopts "d:hn:o:" opt; do
@@ -40,7 +35,7 @@ while getopts "d:hn:o:" opt; do
         exit 1
       fi
       # (**2)
-      out_dir="$(cd "${OPTARG}" ; pwd)"
+      out_dir="$(unset CDPATH ; cd "${OPTARG}" ; pwd)"
       ;;
   esac
 done

--- a/bin/common/install_tools.sh
+++ b/bin/common/install_tools.sh
@@ -2,8 +2,6 @@
 set -o errexit -o nounset
 set -vx
 
-# See notes on CDPATH in dev/install_tools.sh:
-unset CDPATH
 # Get version information and set destination dirs
 . "$(dirname "$0")/versions.sh"
 
@@ -17,7 +15,7 @@ helm_url="${helm_url:-https://kubernetes-helm.storage.googleapis.com/helm-v${HEL
 
 mkdir -p "${SCF_BIN_DIR}"
 
-SCF_BIN_DIR="$(cd "${SCF_BIN_DIR}" && pwd)"
+SCF_BIN_DIR="$(unset CDPATH ; cd "${SCF_BIN_DIR}" && pwd)"
 
 echo "Fetching cf CLI $cf_url ..."
 wget -q "$cf_url" -O "/tmp/cf.tgz"

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -7,7 +7,7 @@ set -o errexit -o nounset
 
 # Used in: bin/dev/install_tool.sh
 
-export BOSH_CLI_VERSION="3b63a0e24bda00325369a4f31d8ee0d924047866"
+export BOSH_CLI_VERSION="39747e9d1fbc1d32af3672f903b6c4b73e1e1a9e"
 export CFCLI_VERSION="6.21.1"
 export FISSILE_VERSION="5.0.0+259.g25b32de"
 export HELM_VERSION="2.5.1"

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -101,6 +101,9 @@ done
 # This is undesirable when working with newer releases, then switching back
 # to older ones
 rm -rf ${ROOT}/${release_path}/dev_releases
+# This is the new path for BOSH v2; deleting this also resolves an issue where
+# BOSH will fail to create-release if the BOSH cache was manually deleted.
+rm -rf ${ROOT}/${release_path}/.dev_builds
 
 if test -n "$(find "${ROOT}/${release_path}/blobs/" -type l 2>/dev/null)"; then
   # Migrating from BOSH CLI v1 (ruby) to BOSH CLI v2 (golang)

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -2,12 +2,7 @@
 set -o errexit
 set -o nounset
 
-# prevent cd from printing the directory it changes to. This breaks
-# cd/pwd constructions (See **).
-unset CDPATH
-
-# (**)
-ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+ROOT="$( unset CDPATH ; cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
 if [[ $# -lt 2 || -z "${1:-}" || -z "${2:-}" ]]; then
   cat <<HELP

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -102,7 +102,7 @@ done
 # to older ones
 rm -rf ${ROOT}/${release_path}/dev_releases
 
-if find "${ROOT}/${release_path}/blobs/" -type l >/dev/null 2>/dev/null; then
+if test -n "$(find "${ROOT}/${release_path}/blobs/" -type l 2>/dev/null)"; then
   # Migrating from BOSH CLI v1 (ruby) to BOSH CLI v2 (golang)
   docker run \
     --interactive \

--- a/bin/dev/install_tools.sh
+++ b/bin/dev/install_tools.sh
@@ -2,10 +2,6 @@
 set -o errexit -o nounset
 set -vx
 # Get version information and set destination paths
-# prevent cd from printing the directory it changes to. This breaks
-# cd/pwd constructions (See **).
-unset CDPATH
-# Get version information
 . "$(dirname "$0")/../common/versions.sh"
 
 SCF_BIN_DIR="${SCF_BIN_DIR:-output/bin}"
@@ -21,8 +17,7 @@ stampy_url="${stampy_url:-https://github.com/SUSE/stampy/releases/download/${STA
 
 mkdir -p "${SCF_BIN_DIR}"
 
-# (**)
-export SCF_BIN_DIR="$(cd "${SCF_BIN_DIR}" && pwd)"
+export SCF_BIN_DIR="$(unset CDPATH ; cd "${SCF_BIN_DIR}" && pwd)"
 
 echo "Fetching fissile $fissile_url ..."
 wget -q "$fissile_url"   -O - | tar xz --to-stdout fissile > "${FISSILE_BINARY}"

--- a/bin/generate-dev-certs.sh
+++ b/bin/generate-dev-certs.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 
-# prevent cd from printing the directory it changes to. This breaks
-# cd/pwd constructions (See **).
-unset CDPATH
-
 load_env() {
     local dir="${1}"
     DOMAIN=${DOMAIN:-}
@@ -70,8 +66,7 @@ if test -z "${output_path}" ; then
 fi
 
 if test "${has_env}" = "no" ; then
-    # (**)
-    load_env "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/settings/"
+    load_env "$( unset CDPATH ; cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/settings/"
 fi
 
 # Replace the stubbed-out namespace info

--- a/bin/init-host-for-vagrant.sh
+++ b/bin/init-host-for-vagrant.sh
@@ -3,16 +3,11 @@
 # This script pulls in the various cf-*-release submodules so the
 # VM can use them.
 
-# prevent cd from printing the directory it changes to. This breaks
-# cd/pwd constructions (See **).
-unset CDPATH
-
 function has_upstream() {
     git rev-parse @{u} > /dev/null 2>&1
 }
 
-# (**)
-ROOT=$(dirname $(cd $(dirname $0) && pwd))
+ROOT=$(dirname $(unset CDPATH ; cd $(dirname $0) && pwd))
 cd ${ROOT}/src
 
 # Some of the submodules contain files called scripts/update -- run them

--- a/bin/validation.sh
+++ b/bin/validation.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# prevent cd from printing the directory it changes to. This breaks
-# cd/pwd constructions (See **).
-unset CDPATH
-
-# (**)
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)"
+ROOT="$(unset CDPATH ; cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)"
 
 stampy "${ROOT}/scf_metrics.csv" "${BASH_SOURCE[0]}" validation start
 stampy "${ROOT}/scf_metrics.csv" "${BASH_SOURCE[0]}" validation::show-properties start

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -988,12 +988,7 @@ roles:
     templates:
       # On k8s, we want the FQDN: etcd-set.hcf.svc.cluster.local
       properties.etcd.advertise_urls_dns_suffix: etcd-set.((KUBE_SERVICE_DOMAIN_SUFFIX))
-      # The default of null in the bosh release does not seem to
-      # define the property properly. Setting it here does define the
-      # property, with a value of null. Note, placement in the
-      # opinions is blocked by the configuration validator,
-      # complaining about it 'matching the default'. So, here it is.
-      properties.etcd.cluster: null
+      properties.etcd.cluster: '[{"name": "etcd", "instances": ((KUBE_SIZING_ETCD_COUNT))}]'
       properties.etcd_metrics_server.etcd.dns_suffix: etcd-set.((KUBE_SERVICE_DOMAIN_SUFFIX))
 - name: loggregator
   environment_scripts:

--- a/container-host-files/etc/hcf/config/scripts/patches/fix_etcd_cluster_hostnames.sh
+++ b/container-host-files/etc/hcf/config/scripts/patches/fix_etcd_cluster_hostnames.sh
@@ -14,59 +14,21 @@ SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
 
 if [ ! -f "${SENTINEL}" ]; then
 
-  read -r -d '' setup_patch_etcd_bosh_utils <<'PATCH' || true
---- etcd_bosh_utils.sh.erb.orig	2017-06-30 12:52:53.903674583 -0700
-+++ etcd_bosh_utils.sh.erb	2017-07-04 14:34:58.514590178 -0700
-@@ -36,26 +36,28 @@
-   end
- 
-   def advertise_peer_url
--    if p("etcd.require_ssl") || p("etcd.peer_require_ssl")
-+    if p("etcd.cluster")
-       "#{peer_protocol}://#{node_name}.#{p("etcd.advertise_urls_dns_suffix")}:7001"
-     else
--      my_ip = discover_external_ip
--      "http://#{my_ip}:7001"
-+      # [1] Note, the hostname|sed transformer is inserted by ERB into
-+      # the shell script, at the place invoking this def. Then when
-+      # the script runs it is actually run to perform the substitution.
-+      "#{peer_protocol}://$(hostname -s | sed 's/\(etcd-[0-9]\+\)-.*/\1/').#{p("etcd.advertise_urls_dns_suffix")}:7001"
-     end
-   end
- 
-   def advertise_client_url
--    if p("etcd.require_ssl") || p("etcd.peer_require_ssl")
-+    if p("etcd.cluster")
-       "#{client_protocol}://#{node_name}.#{p("etcd.advertise_urls_dns_suffix")}:4001"
-     else
--      my_ip = discover_external_ip
--      "http://#{my_ip}:4001"
-+      # See [1] above
-+      "#{client_protocol}://$(hostname -s | sed 's/\(etcd-[0-9]\+\)-.*/\1/').#{p("etcd.advertise_urls_dns_suffix")}:4001"
-     end
-   end
- 
-   def cluster_member_ips
+  patch -d "${PATCH_DIR}" -p 4 --force <<'PATCH'
+diff --git a/jobs/etcd/templates/etcd_bosh_utils.sh.erb b/jobs/etcd/templates/etcd_bosh_utils.sh.erb
+index 5711254..c28cbf5 100644
+--- a/jobs/etcd/templates/etcd_bosh_utils.sh.erb
++++ b/jobs/etcd/templates/etcd_bosh_utils.sh.erb
+@@ -57,7 +57,7 @@ DATA_DIR=${STORE_DIR}/etcd
      ips = nil
--    if_p("etcd.machines") { |machines| ips = machines.map { |m| "http://#{m}:4001" } }
-+    if_p("etcd.machines") { |machines| ips = machines.map { |m| "#{client_protocol}://#{m}:4001" } }
+     if_p("etcd.machines") { |machines| ips = machines.map { |m| "http://#{m}:4001" } }
      unless ips
-       ips = link("etcd").instances.map { |i| "http://#{i.address}:4001" }
+-      ips = link("etcd").instances.map { |i| "http://#{i.address}:4001" }
++      ips = link("etcd").instances.map { |i| "#{client_protocol}://#{i.address}:4001" }
      end
-@@ -72,7 +74,7 @@
+     ips
    end
- 
-   def consistency_checker_cluster_members
--    if p("etcd.require_ssl") || p("etcd.peer_require_ssl")
-+    if p("etcd.cluster")
-       cluster_member_urls = nil
-       if_link("etcd") do |etcd_link|
-         urls = []
 PATCH
-
-  cd "$PATCH_DIR"
-  
-  echo -e "${setup_patch_etcd_bosh_utils}" | patch --force
   
   touch "${SENTINEL}"
   fi
@@ -76,7 +38,7 @@ METRICS_SENTINEL="${METRICS_PATCH_DIR}/${0##*/}.sentinel"
 
 if [ ! -f "${METRICS_SENTINEL}" ]; then
 
-  read -r -d '' setup_patch_etcd_metrics_server_ctl <<'PATCH' || true
+  patch -d "${METRICS_PATCH_DIR}" -p 0 --force <<'PATCH'
 --- etcd_metrics_server_ctl.erb.orig    2016-09-29 16:44:42.807075932 +0000
 +++ etcd_metrics_server_ctl.erb 2016-09-29 16:45:46.942871812 +0000
 @@ -21,7 +21,7 @@
@@ -89,10 +51,6 @@ if [ ! -f "${METRICS_SENTINEL}" ]; then
    /var/vcap/packages/etcd_metrics_server/bin/etcd-metrics-server \
        -index=<%= spec.index %> \
 PATCH
-
-  cd "$METRICS_PATCH_DIR"
-  
-  echo -e "${setup_patch_etcd_metrics_server_ctl}" | patch --force
   
   touch "${METRICS_SENTINEL}"
 fi


### PR DESCRIPTION
Also bumps UAA for same

Depends on related PRs:
SUSE/cloudfoundry#57
SUSE/uaa-fissile-release#47
SUSE/fissile#283 (to handle releases with zero packages)

Should probably co-ordinate between all four (especially for the docker image change for `splatform/bosh-cli`).  This one will need an updated uaa-fissile-release (on the merge) and the fissile version string.