### PR TITLE
Bump fissile for affinity declaration support

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -8,7 +8,7 @@ set -o errexit -o nounset
 # Used in: bin/dev/install_tool.sh
 
 export CFCLI_VERSION="6.21.1"
-export FISSILE_VERSION="5.0.0+223.g3748660"
+export FISSILE_VERSION="5.0.0+236.g32ae02a"
 export HELM_VERSION="2.5.1"
 export HELM_CERTGEN_VERSION="master"
 export CERTSTRAP_VERSION="v1.0.1-11-g0e00d5c"

--- a/make/kube
+++ b/make/kube
@@ -31,4 +31,4 @@ if [ "${BUILD_TARGET}" = "helm" ]; then
 fi
 
 # This is a small hack to make the output of make kube be compatible with K8s 1.6
-perl -p -i -e 's@extensions/v1beta1@batch/v1@' $(grep -rl "kind: Job" "${BUILD_TARGET}")
+perl -p -i -e 's@ extensions/v1beta1@ batch/v1@' $(grep -rl 'kind: "Job"' "${BUILD_TARGET}")


### PR DESCRIPTION
Also needs a change to make/kube because "Pods" in kube configs is
now inside quotes and the apiVersion is now a template expression
for helm charts.