### PR TITLE
create-release: pin bosh-cli docker image version

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -7,6 +7,7 @@ set -o errexit -o nounset
 
 # Used in: bin/dev/install_tool.sh
 
+export BOSH_CLI_VERSION="3b63a0e24bda00325369a4f31d8ee0d924047866"
 export CFCLI_VERSION="6.21.1"
 export FISSILE_VERSION="5.0.0+236.g32ae02a"
 export HELM_VERSION="2.5.1"
@@ -21,9 +22,6 @@ export UBUNTU_VERSION="14.04"
 # For stampy we need the major+minor+patch as a separate value.
 export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$//')
 
-# Notes
-# splatform/bosh-cli - Unversioned docker pull
-
 # Used in: .envrc
 
 export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.2-15.g38c573e-29.12}
@@ -36,14 +34,12 @@ export GOLANG_VERSION=1.7
 
 export CF_VERSION=265
 
-# Notes
-# github.com/square/certstrap - Unversioned `go get`
-
 # Show versions, if called on its own.
 # # ## ### ##### ######## ############# #####################
 
 if [ "X$(basename "$0")" = "Xversions.sh" ]
 then
+    echo bosh-cli '     =' $BOSH_CLI_VERSION
     echo cf '           =' $CF_VERSION
     echo cf-cli '       =' $CFCLI_VERSION
     echo fissile '      =' $FISSILE_VERSION

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -117,7 +117,7 @@ docker run \
     ${proxies} \
     --env MAVEN_OPTS="$MO" \
     --env JAVA_OPTS="$MO" \
-    splatform/bosh-cli \
+    "splatform/bosh-cli:${BOSH_CLI_VERSION:-latest}" \
     /usr/local/bin/create-release.sh \
         "$(id -u)" "$(id -g)" /bosh-cache --dir ${ROOT}/${release_path} --force --name "${release_name}"
 

--- a/bin/dev/install_tools.sh
+++ b/bin/dev/install_tools.sh
@@ -37,7 +37,7 @@ chmod a+x "${SCF_BIN_DIR}/stampy"
 echo "Installed: $("${FISSILE_BINARY}" version)"
 
 echo "Pulling ruby bosh image ..."
-docker pull splatform/bosh-cli
+docker pull "splatform/bosh-cli:${BOSH_CLI_VERSION:-latest}"
 
 echo "Installing helm-certgen ..."
 

--- a/bin/validation.sh
+++ b/bin/validation.sh
@@ -24,7 +24,7 @@ docker < ${PROPS} run \
     --volume ${FISSILE_CACHE_DIR}:/root/.bosh/cache:ro \
     --volume $ROOT/:$ROOT/:ro \
     --env RUBY_VERSION=2.2.3 \
-    splatform/bosh-cli \
+    "splatform/bosh-cli:${BOSH_CLI_VERSION:-latest}" \
     bash --login -c "${ROOT}/bin/config-validator.rb"
 
 stampy "${ROOT}/scf_metrics.csv" "${BASH_SOURCE[0]}" validation::docker "done"


### PR DESCRIPTION
This makes it easier to co-ordinate changes to the `bosh-cli` image.
This requires a UAA bump for SUSE/uaa-fissile-release#48