### PR TITLE
D5GZQLOg Fix validation errors due to missing bin/settings/kube/*.env files

### DIFF
--- a/bin/config-validator.rb
+++ b/bin/config-validator.rb
@@ -75,8 +75,8 @@ def main
 
   STDOUT.puts "\nAll vars in env files must exist in the role manifest".cyan
   env_dir = File.expand_path(File.join(__FILE__, '../settings'))
-  all_env_dirs = Dir.glob(File.join(env_dir, "**/*/")) << env_dir
-  dev_env = Common.collect_dev_env(all_env_dirs)
+  all_env_files = Dir.glob(File.join(env_dir, "**/*.env"))
+  dev_env = Common.collect_dev_env(all_env_files)
   check_env_files(manifest, dev_env)
 
   STDOUT.puts "\nAll role manifest params must be used".cyan

--- a/bin/vagrant-setup/common.rb
+++ b/bin/vagrant-setup/common.rb
@@ -98,31 +98,24 @@ class Common
   end
 
   # # ## ### ##### ########
-  def self.collect_dev_env(env_dir_list)
+  def self.collect_dev_env(env_files)
     collected_env = {}
 
-    env_dir_list.each do |env_dir|
-      env_files = Dir.glob(File.join(env_dir, "*.env")).sort
-      if env_files.empty?
-        STDERR.puts "--env-dir #{env_dir} does not contain any *.env files"
-        exit 1
-      end
-      env_files.each do |env_file|
-        File.readlines(env_file, encoding:'UTF-8').each_with_index do |line, i|
-          line.strip!
-          next if line.empty? || line.start_with?('#')
-          name, value = line.split('=', 2)
-          if value.nil?
-            match = /^ \s* unset \s+ (?<name>\w+) \s* $/x.match(line)
-            if match
-              collected_env.delete match['name']
-            else
-              STDERR.puts "Cannot parse line #{i} in #{env_file}: #{line}"
-              exit 1
-            end
+    env_files.each do |env_file|
+      File.readlines(env_file, encoding:'UTF-8').each_with_index do |line, i|
+        line.strip!
+        next if line.empty? || line.start_with?('#')
+        name, value = line.split('=', 2)
+        if value.nil?
+          match = /^ \s* unset \s+ (?<name>\w+) \s* $/x.match(line)
+          if match
+            collected_env.delete match['name']
           else
-            collected_env[name] = [env_file, value]
+            STDERR.puts "Cannot parse line #{i} in #{env_file}: #{line}"
+            exit 1
           end
+        else
+          collected_env[name] = [env_file, value]
         end
       end
     end


### PR DESCRIPTION
The ca.env file may not exist at the time validation is being run, and this should not break validation.