### PR TITLE
generate-dev-certs: stop trying to find certstrap

### DIFF
--- a/bin/dev/install_tools.sh
+++ b/bin/dev/install_tools.sh
@@ -18,6 +18,7 @@ thefissile="fissile-$(echo "${FISSILE_VERSION}" | sed -e 's/+/%2B/')"
 
 fissile_url="${fissile_url:-${s3}/${thefissile}.linux-amd64.tgz}"
 stampy_url="${stampy_url:-https://github.com/SUSE/stampy/releases/download/${STAMPY_MAJOR}/stampy-${STAMPY_VERSION}.linux-amd64.tgz}"
+certstrap_url="${certstrap_url:-https://cf-opensusefs2.s3.amazonaws.com/certstrap/certstrap-${CERTSTRAP_VERSION}.linux-amd64.tgz}"
 
 mkdir -p "${SCF_BIN_DIR}"
 
@@ -30,9 +31,13 @@ wget -q "$fissile_url"   -O - | tar xz --to-stdout fissile > "${FISSILE_BINARY}"
 echo "Fetching stampy $stampy_url ..."
 wget -q "$stampy_url"   -O - | tar xz -C "${SCF_BIN_DIR}" stampy
 
+echo "Fetching certstrap from ${certstrap_url} ..."
+wget -q "${certstrap_url}" -O - | tar -xzC "${SCF_BIN_DIR}" --overwrite certstrap
+
 echo "Making binaries executable ..."
 chmod a+x "${FISSILE_BINARY}"
 chmod a+x "${SCF_BIN_DIR}/stampy"
+chmod a+x "${SCF_BIN_DIR}/certstrap"
 
 echo "Installed: $("${FISSILE_BINARY}" version)"
 

--- a/bin/generate-dev-certs.sh
+++ b/bin/generate-dev-certs.sh
@@ -81,12 +81,6 @@ KUBE_SERVICE_DOMAIN_SUFFIX="${KUBE_SERVICE_DOMAIN_SUFFIX/\$\{namespace\}/${names
 # Generate a random signing key passphrase
 signing_key_passphrase=$(head -c32 /dev/urandom | base64)
 
-# build and install `certstrap` tool if it's not installed
-command -v certstrap > /dev/null 2>&1 || {
-  docker run --rm -v "${HOME}/bin":/out:rw golang:${GOLANG_VERSION} /usr/bin/env GOBIN=/out go get github.com/square/certstrap
-  sudo chown "$(id -un):$(id -gn)" "${HOME}/bin/certstrap"
-}
-
 # Certificate generation
 certs_path="/tmp/scf/certs"
 hcf_certs_path="${certs_path}/hcf"


### PR DESCRIPTION
On Jenkins (master only), the default shell is `/bin/false`, so we never launch bash directly, and `${HOME}/bin` doesn't seem to get set as part of `${PATH}` correctly.  Try to remedy that by copying the logic from UAA's `generate-certs.sh` over.