### PR TITLE
Prep for fissile supporting `--tag-extra`. 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -100,3 +100,5 @@ export FISSILE_STEMCELL=${FISSILE_STEMCELL:-splatform/fissile-stemcell-opensuse:
 export FISSILE_USE_MEMORY_LIMITS=false
 export FISSILE_OUTPUT_DIR="${FISSILE_OUTPUT_DIR:-${PWD}/helm}"
 export FISSILE_DEFAULTS_FILE="bin/settings/certs.env,bin/settings/kube/ca.env"
+
+export FISSILE_TAG_EXTRA=$(git describe --tags --long | awk -F - '{ print $NF }' )


### PR DESCRIPTION
Use current commit hash as additional key.

 🚧 (Needs official fissile build to be added to `bin/common/versions.sh`)

See https://github.com/SUSE/fissile/pull/287 for the fissile change.