### PR TITLE
Improve test for kube storage classes

### DIFF
--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -108,7 +108,7 @@ fi
 
 # At least one storage class exists in K8s
 if having_category kube ; then
-    test ! "$(kubectl get storageclasses | grep "No resources found.")"
+    test ! "$(kubectl get storageclasses 2>&1 | grep "No resources found.")"
     status "A storage class should exist in K8s"
 fi
 

--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -108,7 +108,7 @@ fi
 
 # At least one storage class exists in K8s
 if having_category kube ; then
-    test "$(kubectl get storageclasses 2>&1 | wc -l)" -gt 1
+    test ! "$(kubectl get storageclasses | grep "No resources found.")"
     status "A storage class should exist in K8s"
 fi
 


### PR DESCRIPTION
The test for kube storageclasses was broken for CaaSP2, when kubectl returns e.g. 3 lines of info in the beginning in general:

```
> ./kube-ready-state-check.sh kube
Testing kube
...
Verified: A storage class should exist in K8s
```

but that's not true, since there is no storage class:

```
> kubectl get storageclasses
2017-10-11 09:48:27.380930 I | proto: duplicate proto type registered: google.protobuf.Any
2017-10-11 09:48:27.380992 I | proto: duplicate proto type registered: google.protobuf.Duration
2017-10-11 09:48:27.381007 I | proto: duplicate proto type registered: google.protobuf.Timestamp
No resources found.
```

The fix is to return "0" when the output does not contain "No resources found.".