### PR TITLE
Rename cf-sle12 stack to just sle12

### DIFF
--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -26,13 +26,13 @@ properties:
       lifecycle_bundles:
         - "buildpack/cflinuxfs2:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
         - "buildpack/opensuse42:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
-        - "buildpack/cf-sle12:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
+        - "buildpack/sle12:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
         - "docker:docker_app_lifecycle/docker_app_lifecycle.tgz"
     stager:
       lifecycle_bundles:
         - "buildpack/cflinuxfs2:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
         - "buildpack/opensuse42:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
-        - "buildpack/cf-sle12:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
+        - "buildpack/sle12:buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
         - "docker:docker_app_lifecycle/docker_app_lifecycle.tgz"
   cc:
     broker_client_timeout_seconds: 70
@@ -124,7 +124,7 @@ properties:
       description: Cloud Foundry Linux-based filesystem
     - name: opensuse42
       description: openSUSE-based filesystem
-    - name: cf-sle12
+    - name: sle12
       description: SLE-based filesystem
     staging_upload_user: staging_user
     system_hostnames:
@@ -199,7 +199,7 @@ properties:
       preloaded_rootfses:
         - cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs.tar
         - opensuse42:/var/vcap/packages/opensuse42/rootfs.tar
-        - cf-sle12:/var/vcap/packages/cf-sle12/rootfs.tar
+        - sle12:/var/vcap/packages/cf-sle12/rootfs.tar
       require_tls: true
     route_emitter:
       nats:


### PR DESCRIPTION
@troytop wrote: "sle12 looks better"
https://chat.microfocus.net/channel/suse-paas?msg=Rur4HZfEkhPfZRDY9

This only changes the user-visible name. We could also change the package name inside cf-sle12-release, but doesn't really feel necessary.

Tested with Vagrant box:

```
$ cf stacks
...
name         description
cflinuxfs2   Cloud Foundry Linux-based filesystem
opensuse42   openSUSE-based filesystem
sle12        SLE-based filesystem

$ cf push -s sle12
Using stack sle12...
...

$ cf ssh my-app -c "cat /etc/os-release" | grep PRETTY
PRETTY_NAME="SUSE Linux Enterprise Server 12 SP3"
```