### PR TITLE
Enable concurrent builds again in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,6 @@ pipeline {
     agent any
     options {
         ansiColor('xterm')
-        disableConcurrentBuilds() // Otherwise clean would delete the images
         skipDefaultCheckout() // We do our own checkout so it can be disabled
         timestamps()
         timeout(time: 10, unit: 'HOURS')


### PR DESCRIPTION
I think we turned this on for the wrong reasons. Jenkins is now largely
idle despite having build queues backed up. Trying out removing this.