### PR TITLE
role-manifest: explicitly mark exported bosh links

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -9,7 +9,7 @@ set -o errexit -o nounset
 
 export BOSH_CLI_VERSION="39747e9d1fbc1d32af3672f903b6c4b73e1e1a9e"
 export CFCLI_VERSION="6.21.1"
-export FISSILE_VERSION="5.0.0+287.g57b982a"
+export FISSILE_VERSION="5.0.0+299.ga9b2d92"
 export HELM_VERSION="2.6.2"
 export HELM_CERTGEN_VERSION="master"
 export CERTSTRAP_VERSION="v1.0.1-11-g0e00d5c"

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -24,7 +24,7 @@ export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$
 
 # Used in: .envrc
 
-export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.2-15.g38c573e-29.12}
+export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.2-15.g38c573e-29.44}
 
 # Used in: bin/generate-dev-certs.sh
 

--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -10,6 +10,8 @@ roles:
     release_name: hcf
   - name: nats
     release_name: nats
+    provides:
+      nats: {}
   - name: metron_agent
     release_name: loggregator
   processes:
@@ -64,6 +66,8 @@ roles:
     release_name: hcf
   - name: consul_agent
     release_name: consul
+    provides:
+      consul: {}
   - name: metron_agent
     release_name: loggregator
   processes:
@@ -151,6 +155,8 @@ roles:
     release_name: hcf
   - name: mysql
     release_name: cf-mysql
+    provides:
+      mysql: {}
   processes:
   - name: mariadb_ctrl
   - name: galera-healthcheck
@@ -237,6 +243,8 @@ roles:
     release_name: hcf
   - name: proxy
     release_name: cf-mysql
+    provides:
+      proxy: {}
   processes:
   - name: cf-mysql-route-registrar
   - name: switchboard


### PR DESCRIPTION
This is needed for fissile to correctly construct the links.

This is currently marked WIP because it only becomes useful after SUSE/fissile#288 and SUSE/configgin#59 land, but can be used to test those PRs with.  This is required for the fissile bump (because otherwise fissile will spit out new errors on not having links).