### PR TITLE
Move the SLE trigger to the end of the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,14 +153,6 @@ pipeline {
     }
 
     stages {
-        stage('trigger_sles_build') {
-          when {
-                expression { return params.TRIGGER_SLES_BUILD }
-          }
-          steps {
-            build job: 'scf-sles-trigger', wait: false, parameters: [string(name: 'JOB_NAME', value: env.JOB_NAME)]
-          }
-        }
         stage('wipe') {
             when {
                 expression { return params.WIPE }
@@ -343,6 +335,14 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
                     )
                 }
             }
+        }
+        stage('trigger_sles_build') {
+          when {
+                expression { return params.TRIGGER_SLES_BUILD }
+          }
+          steps {
+            build job: 'scf-sles-trigger', wait: false, parameters: [string(name: 'JOB_NAME', value: env.JOB_NAME)]
+          }
         }
     }
 }


### PR DESCRIPTION
We have some build failures in Jenkins since a few days where docker images
can't be cleaned up because they are still referenced by running containers.
I think this might be related to the concurrent builds that were re-enabled
recently.

This commit moves the SLES trigger to the very end of the build, so although
we have concurrent builds in Jenkins the openSUSE and the SLES builds will be
practically sequential which hopefully fixes these issues.