### PR TITLE
Jenkins: make grep not confuse pattern with options

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -225,7 +225,7 @@ pipeline {
             steps {
                 sh '''
                     kubectl get namespace | awk '/-scf|-uaa/ {print $1}' | xargs --no-run-if-empty kubectl delete ns
-                    while kubectl get namespace | grep '-scf|-uaa'; do
+                    while kubectl get namespace | grep -- '-scf|-uaa'; do
                         sleep 1
                     done
 


### PR DESCRIPTION
`grep '-scf|-uaa'` looks too much like a grep option; prefix -- to make sure it gets treated as a pattern so we actually do useful things there