### PR TITLE
`make kube` / `make helm` / `make dist` should output into output/

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -106,5 +106,5 @@ export FISSILE_STEMCELL=${FISSILE_STEMCELL:-splatform/fissile-stemcell-opensuse:
 # The defaults are all for helm.
 # The make/kube script performs overrides for kube output.
 export FISSILE_USE_MEMORY_LIMITS=false
-export FISSILE_OUTPUT_DIR="${FISSILE_OUTPUT_DIR:-${PWD}/helm}"
+export FISSILE_OUTPUT_DIR="${FISSILE_OUTPUT_DIR:-${PWD}/output/helm}"
 export FISSILE_DEFAULTS_FILE="bin/settings/certs.env,bin/settings/kube/ca.env"

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,4 @@ password
 /bin/settings/kube/ca.env
 # `make dist` output of various forms
 /output/
-/scf-kube-*.zip
-/scf-helm-*.zip
-/helm/
-/kube/
 personal-setup

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ and execute the following commands:
 ```bash
 make smoke
 make cats
-kubectl create -n cf -f kube/bosh-task/acceptance-tests-brain.yaml
+make brain
 ```
 
 #### How do I run a subset of SCF acceptance tests?

--- a/make/bundle-dist
+++ b/make/bundle-dist
@@ -22,7 +22,7 @@ do
         echo "Unkown stemcell operating system: ${FISSILE_STEMCELL}"
         exit 1
     fi
-    ARCHIVE="${GIT_ROOT}/scf-${stemcell_os}-${APP_VERSION}.${OS}-amd64.zip"
+    ARCHIVE="${GIT_ROOT}/output/scf-${stemcell_os}-${APP_VERSION}.${OS}-amd64.zip"
 
     echo Packaging for $OS, taking $APP_VERSION ...
 
@@ -30,9 +30,9 @@ do
     mkdir -p ${tmp_dir}/${OS}/kube ${tmp_dir}/${OS}/helm
 
     # kube configs
-    unzip ${GIT_ROOT}/${ARTIFACT_NAME}-kube-${APP_VERSION}.zip -d ${tmp_dir}/${OS}/kube
+    unzip ${GIT_ROOT}/output/${ARTIFACT_NAME}-kube-${APP_VERSION}.zip -d ${tmp_dir}/${OS}/kube
     # helm charts
-    unzip ${GIT_ROOT}/${ARTIFACT_NAME}-helm-${APP_VERSION}.zip -d ${tmp_dir}/${OS}/helm
+    unzip ${GIT_ROOT}/output/${ARTIFACT_NAME}-helm-${APP_VERSION}.zip -d ${tmp_dir}/${OS}/helm
 
     # "Am I Ok" for kube
     cp ${GIT_ROOT}/bin/dev/kube-ready-state-check.sh ${tmp_dir}/${OS}/

--- a/make/kube
+++ b/make/kube
@@ -31,7 +31,7 @@ fi
 
 if [ "${BUILD_TARGET}" = "kube" ]; then
     # Overrides when generating kube config files instead of helm charts.
-    FISSILE_OUTPUT_DIR="${PWD}/kube"
+    FISSILE_OUTPUT_DIR="${PWD}/output/kube"
     FISSILE_DEFAULTS_FILE="bin/settings/settings.env,bin/settings/certs.env,${NETWORK_ENV},bin/settings/kube/ca.env"
 fi
 
@@ -53,5 +53,5 @@ EOF
     cp NOTES.txt  "${FISSILE_OUTPUT_DIR}/templates/"
 elif [ "${BUILD_TARGET}" = "kube" ]; then
     # This is a small hack to make the output of make kube be compatible with K8s 1.6
-    perl -p -i -e 's@extensions/v1beta1@batch/v1@' $(grep -rl 'kind: "Job"' "${BUILD_TARGET}")
+    perl -p -i -e 's@extensions/v1beta1@batch/v1@' $(grep -rl 'kind: "Job"' "${FISSILE_OUTPUT_DIR}")
 fi

--- a/make/kube-dist
+++ b/make/kube-dist
@@ -10,7 +10,7 @@ artifacts=("")
 for variant in kube helm ; do
     tmp_dir=$(mktemp -d)
     trap "rm -rf '${tmp_dir}'" EXIT
-    artifact="${ARTIFACT_NAME}-${variant}-${APP_VERSION}.zip"
+    artifact="output/${ARTIFACT_NAME}-${variant}-${APP_VERSION}.zip"
 
     rm -f "${GIT_ROOT}/${artifact}"
 
@@ -22,7 +22,7 @@ for variant in kube helm ; do
 
     mkdir -p "${tmp_dir}"/{cf,uaa}${suffix:-}
 
-    cp -r "${GIT_ROOT}/${variant}/"* "${tmp_dir}/cf${suffix:-}"
+    cp -r "${GIT_ROOT}/output/${variant}/"* "${tmp_dir}/cf${suffix:-}"
     cp -r "${GIT_ROOT}/src/uaa-fissile-release/${variant}/"* "${tmp_dir}/uaa${suffix:-}"
 
     (

--- a/make/run
+++ b/make/run
@@ -48,7 +48,7 @@ fi
 source bin/settings/settings.env
 source "${NETWORK_ENV}"
 
-helm install helm \
+helm install output/helm \
      --namespace ${NAMESPACE} \
      --set "env.CLUSTER_ADMIN_PASSWORD=$CLUSTER_ADMIN_PASSWORD" \
      --set "env.DOMAIN=${DOMAIN}" \

--- a/make/tests
+++ b/make/tests
@@ -4,7 +4,7 @@ set -o errexit -o nounset
 
 NAMESPACE="cf"
 POD_NAME=$1
-if [ ! -f "kube/bosh-task/${POD_NAME}.yaml" ]; then
+if [ ! -f "output/kube/bosh-task/${POD_NAME}.yaml" ]; then
     echo 1>&2 There is no bosh-task for ${POD_NAME}.
     exit 1
 fi
@@ -39,7 +39,7 @@ stampy "${METRICS}" "$0" "make-tests::${POD_NAME}::setup" end
 stampy "${METRICS}" "$0" "make-tests::${POD_NAME}::create" start
 
 # Delete left-over pod/definition from previous runs, then create/run
-kubectl delete --namespace="${NAMESPACE}" --filename="kube/bosh-task/${POD_NAME}.yaml" \
+kubectl delete --namespace="${NAMESPACE}" --filename="output/kube/bosh-task/${POD_NAME}.yaml" \
     2> /dev/null || /bin/true
 
 echo "Waiting for pod ${POD_NAME} to be deleted..."
@@ -47,7 +47,7 @@ while has_pod ; do
     sleep 1
 done
 
-kubectl create --namespace="${NAMESPACE}" --filename="kube/bosh-task/${POD_NAME}.yaml"
+kubectl create --namespace="${NAMESPACE}" --filename="output/kube/bosh-task/${POD_NAME}.yaml"
 
 stampy "${METRICS}" "$0" "make-tests::${POD_NAME}::create" end
 


### PR DESCRIPTION
This moves all the generated files into `output/` instead of being at the top level. This makes it easier to check in files that we want to include verbatim inside the helm chart dist bundles later.