### PR TITLE
Fix an issue where helm could not be found

### DIFF
--- a/bin/common/install_tools.sh
+++ b/bin/common/install_tools.sh
@@ -44,7 +44,7 @@ chmod a+x "${SCF_BIN_DIR}/helm"
 if systemctl is-active kube-apiserver.service ; then
   echo "Installing tiller for helm ..."
   if [[ $(id -u) -eq 0 ]] && id -u vagrant &>/dev/null; then
-    sudo -u vagrant helm init
+    sudo -iu vagrant helm init
   else
     helm init
   fi


### PR DESCRIPTION
- Something happens in OpenSUSE 42.3 where sudo'd things are not having
  their $PATH set to the correct thing leading to a missing 'helm' binary.
  This will be useful later when we upgrade the vagrant box to 42.3.