### PR TITLE
Increase default volume size for the blobstore

### DIFF
--- a/container-host-files/etc/hcf/config/role-manifest.yml
+++ b/container-host-files/etc/hcf/config/role-manifest.yml
@@ -787,7 +787,7 @@ roles:
     persistent-volumes:
     - path: /var/vcap/store
       tag: blobstore-data
-      size: 5
+      size: 50
     shared-volumes: []
     memory: 1536
     virtual-cpus: 2


### PR DESCRIPTION
5GB is too little, especially with large buildpacks compiled for multiple stacks