### PR TITLE
Bump stemcell version for configgin 0.14.0

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -24,7 +24,7 @@ export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$
 
 # Used in: .envrc
 
-export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.2-15.g38c573e-29.44}
+export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.2-15.g38c573e-29.48}
 
 # Used in: bin/generate-dev-certs.sh
 


### PR DESCRIPTION
This changes behaviour such that we will run bootstrap on any pod where it is the only pod with a given image version.  This is to support upgrades and similar scenarios where the image versions will change, but not necessarily starting from the lowest-numbered pod.