### PR TITLE
Create separate submit request for each package

### DIFF
--- a/bin/dev/legalscan.sh
+++ b/bin/dev/legalscan.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 PROJECTS="Cloud:Platform:sources:scf Cloud:Platform:sources:buildpacks"
-TMPPATH=TMPOSC
-rm -r "${TMPPATH}"
-mkdir -p "${TMPPATH}" 
-pushd "${TMPPATH}" > /dev/null
 for PROJECT in ${PROJECTS}; do
-  osc checkout -M "${PROJECT}"
-  pushd "${PROJECT}" > /dev/null
-  osc submitrequest ${PROJECT}:reviewed
-  popd > /dev/null
+  for PACKAGE in $(osc ls $PROJECT); do
+    osc submitrequest --yes $PROJECT $PACKAGE ${PROJECT}:reviewed
+  done
 done

--- a/bin/dev/legalscan.sh
+++ b/bin/dev/legalscan.sh
@@ -2,6 +2,6 @@
 PROJECTS="Cloud:Platform:sources:scf Cloud:Platform:sources:buildpacks"
 for PROJECT in ${PROJECTS}; do
   for PACKAGE in $(osc ls $PROJECT); do
-    osc submitrequest --yes $PROJECT $PACKAGE ${PROJECT}:reviewed
+    osc submitrequest --yes --message=legal-review $PROJECT $PACKAGE ${PROJECT}:reviewed
   done
 done


### PR DESCRIPTION
Hi,

this change creates for each package it's own submit request. It automatically supersedes the old SR when needed :) There is no need to checkout the project, the script can be executed anywhere.

For unknown reasons the approach with `osc submitrequest --seperate-requests $PROJECT:reviewed` doesn't work.

Jonathan 