### PR TITLE
Jenkinsfile: Try to track down cleanup errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,6 +224,15 @@ pipeline {
             }
             steps {
                 sh '''
+                    #!/bin/bash
+                    dump_info() {
+                        kubectl get namespace
+                        helm list --all
+                        docker ps -a
+                        docker images
+                    }
+                    trap dump_info EXIT
+
                     kubectl get namespace | awk '/-scf|-uaa/ {print $1}' | xargs --no-run-if-empty kubectl delete ns
                     while kubectl get namespace | grep -- '-scf|-uaa'; do
                         sleep 1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,6 +256,8 @@ pipeline {
                         sleep 1
                     done
 
+                    docker ps --filter=status=exited --quiet | xargs --no-run-if-empty docker rm
+
                     while docker ps -a --format '{{.Names}}' | grep -- '-scf_|-uaa_'; do
                         sleep 1
                     done


### PR DESCRIPTION
This dumps out the docker/kube/helm state on cleanup exit (success or failure), to try to figure out what state things are in and why our current attempts to catch problems aren't working