### PR TITLE
Fix new UAA release 3 migration issues

### DIFF
--- a/container-host-files/etc/hcf/config/opinions.yml
+++ b/container-host-files/etc/hcf/config/opinions.yml
@@ -392,3 +392,14 @@ properties:
       - roles
       - user_attributes
       - routing.router_groups.read
+      default_groups:
+      - openid
+      - cloud_controller.read
+      - cloud_controller.write
+      - password.write
+      - uaa.user
+      - approvals.me
+      - profile
+      - roles
+      - user_attributes
+      - uaa.offline_token

--- a/src/hcf-release/jobs/uaa-create-user/spec
+++ b/src/hcf-release/jobs/uaa-create-user/spec
@@ -31,3 +31,5 @@ properties:
     description: The base url of the UAA with the correct zone id
   uaa.user.authorities:
     description: List of user authorities to create in the HCF zone
+  uaa.user.default_groups:
+    description: The list of default user groups for new users

--- a/src/hcf-release/jobs/uaa-create-user/templates/run.erb
+++ b/src/hcf-release/jobs/uaa-create-user/templates/run.erb
@@ -77,12 +77,28 @@ status "Checking for UAA zone ${UAA_ZONE_ID}..."
 uaac target <%= uaac_ssl %> '<%= p("scf.uaa.root-zone.url") %>'
 uaac token client get default_zone_admin --secret '<%= p("uaa.admin.client_secret") %>'
 
-if uaac curl <%= curl_ssl %> "/identity-zones/${UAA_ZONE_ID}" | grep --quiet '404 Not Found' ; then
+if uaac curl <%= curl_ssl %> "/identity-zones/${UAA_ZONE_ID}" | grep --quiet '404' ; then
     status "Creating UAA zone ${UAA_ZONE_ID}"
     uaac curl <%= curl_ssl %> -X POST /identity-zones -H 'Content-Type: application/json' -d '{
         "id": "'"${UAA_ZONE_ID}"'",
         "subdomain": "'"${UAA_ZONE_ID}"'",
-        "name": "'"${UAA_ZONE_ID}"'"
+        "name": "'"${UAA_ZONE_ID}"'",
+        "config": {
+          "userConfig": {
+            "defaultGroups": [
+                "openid",
+                "cloud_controller.read",
+                "cloud_controller.write",
+                "password.write",
+                "uaa.user",
+                "approvals.me",
+                "profile",
+                "roles",
+                "user_attributes",
+                "uaa.offline_token"
+            ]
+          }
+        }
     }'
 fi
 
@@ -161,7 +177,14 @@ if uaac group get '<%= authority %>' | grep -q '  displayname: <%= username %>' 
     status "User %s already in %s" <%= username %> '<%= authority %>'
 elif ! uaac group get '<%= authority %>' | grep -q "    value: ${user_id}" ; then
     status "+ %s" <%= username %>
+    set +e
     uaac member add '<%= authority %>' <%= username %>
+    if [ $? -eq 0 ]; then
+    	status "Add %s to %s successfully" <%= username %> '<%= authority %>'
+    else
+        status "Add %s to %s failed but ignore the error first" <%= username %> '<%= authority %>'
+    fi
+    set -e
 fi
 <% end %>
 

--- a/src/hcf-release/jobs/uaa-create-user/templates/run.erb
+++ b/src/hcf-release/jobs/uaa-create-user/templates/run.erb
@@ -85,18 +85,7 @@ if uaac curl <%= curl_ssl %> "/identity-zones/${UAA_ZONE_ID}" | grep --quiet '40
         "name": "'"${UAA_ZONE_ID}"'",
         "config": {
           "userConfig": {
-            "defaultGroups": [
-                "openid",
-                "cloud_controller.read",
-                "cloud_controller.write",
-                "password.write",
-                "uaa.user",
-                "approvals.me",
-                "profile",
-                "roles",
-                "user_attributes",
-                "uaa.offline_token"
-            ]
+            "defaultGroups": <%= p("uaa.user.default_groups").to_json %>
           }
         }
     }'
@@ -133,9 +122,13 @@ status "Populating clients..."
                 end
             %>
     fi
-    status "- Client <%= client_id %> set secret"
-    uaac --zone "${UAA_ZONE_ID}" secret set '<%= client_id %>' --secret '<%= client_data['secret'] %>'
-    status "- Client <%= client_id %> /done"
+    if test -n '<%= client_data['secret'] %>' ; then
+        status "- Client <%= client_id %> set secret"
+        uaac --zone "${UAA_ZONE_ID}" secret set '<%= client_id %>' --secret '<%= client_data['secret'] %>'
+        status "- Client <%= client_id %> /done"
+    else
+        status "- Client <%= client_id %> no secret, skipped"
+    fi
 <% end %>
 
 status "Waiting for UAA zone to be available ..."
@@ -169,23 +162,19 @@ fi
 user_id=$(uaac user get <%= username %> | awk '/^  id:/ { print $2 }')
 
 <% authorities.each do |authority| %>
-status "Adding users to authority %s" '<%= authority %>'
-if ! uaac group get '<%= authority %>' 2>/dev/null >/dev/null ; then
-    uaac group add '<%= authority %>'
-fi
-if uaac group get '<%= authority %>' | grep -q '  displayname: <%= username %>' ; then
-    status "User %s already in %s" <%= username %> '<%= authority %>'
-elif ! uaac group get '<%= authority %>' | grep -q "    value: ${user_id}" ; then
-    status "+ %s" <%= username %>
-    set +e
-    uaac member add '<%= authority %>' <%= username %>
-    if [ $? -eq 0 ]; then
-    	status "Add %s to %s successfully" <%= username %> '<%= authority %>'
+    if uaac curl -k "/Users/${user_id}" | grep -A999 '{' | jq -r '.groups[].display' | grep --quiet '<%= authority %>' ; then
+        status "User already in group %s, skipping" '<%= authority %>'
     else
-        status "Add %s to %s failed but ignore the error first" <%= username %> '<%= authority %>'
+        status "Adding users to authority %s" '<%= authority %>'
+        if ! uaac group get '<%= authority %>' 2>/dev/null >/dev/null ; then
+            uaac group add '<%= authority %>'
+        fi
+        if uaac group get '<%= authority %>' | grep -q '  displayname: <%= username %>' ; then
+            status "User %s already in %s" <%= username %> '<%= authority %>'
+        elif ! uaac group get '<%= authority %>' | grep -q "    value: ${user_id}" ; then
+            uaac member add '<%= authority %>' <%= username %>
+        fi
     fi
-    set -e
-fi
 <% end %>
 
 status "UAA initialization successful"


### PR DESCRIPTION
Fix 3 issues for new UAA release:
1,  use `404` instead of `404 not found` to check if identity-zone exists, or will report error because UAA message change.

2, Add cloud_controller.read and cloud_controller.write groups for new identity-zone, because new UAA release remove them that new user cannot use CC (Report Invaild Token Error):
https://github.com/cloudfoundry/uaa-release/releases/tag/v43

3, We need to discuss the third change, because I change it in run.erb to use `set +e` and `set -e` to ignore the error, because `openid` is the default group, when you add admin to group openid, the process of post-deployment-setup will report and fail in the end:
```
api/0:/# uaac member add 'openid' admin

error response:
{
  "error_description": "Trying to add member to default group",
  "error": "member_already_exists",
  "message": "Trying to add member to default group"
}
```

Pls refer:
https://github.com/cloudfoundry/uaa/blob/master/docs/Sysadmin-Guide.rst
```
some default groups are always available and do not need to be explicitly populated: openid, password.write, cloud_controller.read, cloud_controller.write, tokens.read, tokens.write
```

But I suggest remove `openid` from `CLUSTER_ADMIN_AUTHORITIES` property directly if no any other component use it.

Pls let me know if you have any suggestion. Thanks!