### PR TITLE
Jenkinsfile: don't source .envrc when deploying

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -340,9 +340,7 @@ pipeline {
             }
             steps {
                 sh """
-                    set -e +x
-                    source \${PWD}/.envrc
-                    set -x
+                    set -e
 
                     kubectl delete storageclass hostpath || /bin/true
                     kubectl create -f - <<< '{"kind":"StorageClass","apiVersion":"storage.k8s.io/v1","metadata":{"name":"hostpath"},"provisioner":"kubernetes.io/host-path"}'


### PR DESCRIPTION
That's not necessary, since we only need it to get the stemcell to check if we're doing SLE builds... and we can get that by asking Jenkins instead

Addresses https://github.com/SUSE/scf/pull/1204/files#r152733706