### PR TITLE
make/clean: Use fissile before we delete it

### DIFF
--- a/make/clean
+++ b/make/clean
@@ -4,7 +4,8 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
+${GIT_ROOT}/make/images clean
+
 rm -rf ${FISSILE_WORK_DIR}
 rm -rf ${GIT_ROOT}/output
 
-${GIT_ROOT}/make/images clean


### PR DESCRIPTION
When deleting obsolete images, we will ask fissile for images it does still care about.  But since we just deleted fissile, that will (probably) fall over.