### PR TITLE
Jenkins: Don't quote shell globs when looking for test files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,14 +33,14 @@ void runTest(String testName) {
 EOF
         }
 
-        image=\$(awk '\$1 == "image:" { print \$2 }' "output/unzipped/kube/cf*/bosh-task/${testName}.yaml" | tr -d '"')
+        image=\$(awk '\$1 == "image:" { print \$2 }' output/unzipped/kube/cf*/bosh-task/"${testName}.yaml" | tr -d '"')
 
         kubectl run \
             --namespace=${jobBaseName()}-${BUILD_NUMBER}-scf \
             --attach \
             --restart=Never \
             --image=\${image} \
-            --overrides="\$(kube_overrides "output/unzipped/kube/cf*/bosh-task/${testName}.yaml")" \
+            --overrides="\$(kube_overrides output/unzipped/kube/cf*/bosh-task/"${testName}.yaml")" \
             "${testName}"
     """
 }


### PR DESCRIPTION
We attempt to find test files by shell glob.  When doing so, do not quote the shell glob, as that means it will not be expanded by the shell (causing the files describing the thing we are looking for to not be found).