### PR TITLE
pod-status: don't re-column the output

### DIFF
--- a/container-host-files/opt/hcf/bin/pod-status
+++ b/container-host-files/opt/hcf/bin/pod-status
@@ -42,18 +42,5 @@ while true ; do
     esac
 done
 
-kubectl get pods ${NS:+--namespace="${NS}"} ${NS:---all-namespaces} | gawk -f <(cat <<"EOF"
-{
-    if (match($3, /^([0-9]+)\/([0-9]+)$/, capture)) {
-        if (capture[1] == capture[2]) {
-            $3 = "\033[0;32m" $3 "\033[0m"
-        } else {
-            $3 = "\033[0;31m" $3 "\033[0m"
-        }
-    } else {
-        $3 = "\033[0;37m" $3 "\033[0m"
-    }
-    print
-}
-EOF
-) | column -t
+kubectl get pods ${NS:+--namespace="${NS}"} ${NS:---all-namespaces} \
+    | perl -p -e 's@^(\S+\s+\S+\s*)(\d+)/(\d+)@"$1\e[0;" . ($2 == $3 ? "32" : "31;1") . "m$2/$3\e[0m"@e'


### PR DESCRIPTION
We previously used awk to find the right field to check for readiness. Unfortunately, this meant that the columns were all changed, and we had to run `column -t` on it; this doesn't work well if any of the columns had whitespace within it (e.g. when the pod status had a longer explanation on why it wasn't working).

This switches to using a perl one-liner that doesn't affect the column layout, so that issue does not occur.