### PR TITLE
Jenkins: Cleanup: Removed created, never-run, containers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,7 +256,8 @@ pipeline {
                         sleep 1
                     done
 
-                    docker ps --filter=status=exited --quiet | xargs --no-run-if-empty docker rm
+                    docker ps --filter=status=exited  --quiet | xargs --no-run-if-empty docker rm
+                    docker ps --filter=status=created --quiet | xargs --no-run-if-empty docker rm
 
                     while docker ps -a --format '{{.Names}}' | grep -- '-scf_|-uaa_'; do
                         sleep 1


### PR DESCRIPTION
It looks like we can end up containers that have been created but never actually run.  This is likely due to errors that get kube pods to not run at all (e.g. missing secrets).  We should clean those up too, so that we eventually reclaim the resources.