### PR TITLE
Jenkins: switch to xip.io instead of nip.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ String ipAddress() {
 }
 
 String domain() {
-    return ipAddress() + ".nip.io"
+    return ipAddress() + ".xip.io"
 }
 
 String jobBaseName() {


### PR DESCRIPTION
It appears that nip.io has been down for > 12 hours. Try the fallback service instead.