### PR TITLE
fissile: bump version

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -9,7 +9,7 @@ set -o errexit -o nounset
 
 export BOSH_CLI_VERSION="39747e9d1fbc1d32af3672f903b6c4b73e1e1a9e"
 export CFCLI_VERSION="6.21.1"
-export FISSILE_VERSION="5.1.0+15.g08de800"
+export FISSILE_VERSION="5.1.0+16.g4a2a4f8"
 export HELM_VERSION="2.6.2"
 export HELM_CERTGEN_VERSION="master"
 export CERTSTRAP_VERSION="v1.0.1-11-g0e00d5c"


### PR DESCRIPTION
Pulls in change to use rolling update in helm charts

I'm sad because we're using fissile that's not off the master branch.