### PR TITLE
Revert "Jenkins: switch to xip.io instead of nip.io"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ String ipAddress() {
 }
 
 String domain() {
-    return ipAddress() + ".xip.io"
+    return ipAddress() + ".nip.io"
 }
 
 String jobBaseName() {


### PR DESCRIPTION
This reverts commit 298b44ef40813f78b8d4121f8d0283d2fdc24d6c.