### PR TITLE
role-manifest: allow apps.statefulset/get to configgin roles

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1406,6 +1406,9 @@ configuration:
       - apiGroups: [""]
         resources: [services]
         verbs: [get]
+      - apiGroups: [apps]
+        resources: [statefulsets]
+        verbs: [get]
       secrets-role:
       - apiGroups: [""]
         resources: [secrets]


### PR DESCRIPTION
This is required for HA (for the pods to find the other instances).