### PR TITLE
More sightly helm version

### DIFF
--- a/make/include/versioning
+++ b/make/include/versioning
@@ -19,3 +19,4 @@ GIT_SHA=${GIT_SHA:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $NF }' )}
 export ARTIFACT_NAME=${ARTIFACT_NAME:-$(basename $(git config --get remote.origin.url) .git | sed s/^scf-//)}
 export APP_VERSION=${GIT_TAG}+cf${CF_VERSION}.${GIT_COMMITS}.${GIT_SHA}
 export DOCKER_APP_VERSION=$(echo ${APP_VERSION} | tr + -)
+export GIT_TAG

--- a/make/kube
+++ b/make/kube
@@ -45,10 +45,10 @@ if [ "${BUILD_TARGET}" = "helm" ]; then
     fi
 
     cat > "${FISSILE_OUTPUT_DIR}/Chart.yaml" << EOF
-apiVersion: v1
+apiVersion: ${APP_VERSION}
 description: A Helm chart for SUSE Cloud Foundry
 name: cf${chart_name_suffix:-}
-version: ${APP_VERSION}
+version: ${GIT_TAG}
 EOF
     cp NOTES.txt  "${FISSILE_OUTPUT_DIR}/templates/"
 elif [ "${BUILD_TARGET}" = "kube" ]; then


### PR DESCRIPTION
https://trello.com/c/hu6x06Qz/507-helm-unsightly-versions

Move the extended version information to the `apiVersion` key, and show only the `GIT_TAG` in the `version` key, to make the version information shown by the helm tools more sightly.

Ditto for UAA chart = https://github.com/SUSE/uaa-fissile-release/pull/70
  