### PR TITLE
Don't set stemcell via jenkins environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -98,7 +98,12 @@ if ! type source_up >/dev/null 2>/dev/null; then
 fi
 
 # The fissile stemcell image that is used as the base
-export FISSILE_STEMCELL=${FISSILE_STEMCELL:-splatform/fissile-stemcell-opensuse:$FISSILE_STEMCELL_VERSION}
+if [ "${USE_SLES_STEMCELL:-false}" == "false" ]
+then
+    export FISSILE_STEMCELL=${FISSILE_STEMCELL:-splatform/fissile-stemcell-opensuse:$FISSILE_STEMCELL_VERSION}
+else
+    export FISSILE_STEMCELL=${FISSILE_STEMCELL:-splatform/fissile-stemcell-sle12:$FISSILE_STEMCELL_VERSION}
+fi
 
 # fissile build kube|helm (memory limits, output, env)
 # TODO: We currently skip memory limits for development purposes

--- a/.envrc
+++ b/.envrc
@@ -12,7 +12,7 @@ fi
 export FISSILE_GIT_ROOT=$PWD
 
 # Get version information
-. ${PWD}/bin/common/versions.sh
+. "${PWD}/bin/common/versions.sh"
 
 # The Docker repository name used for images, the registry itself, and the org to use.
 # Note, this replaces "make/include/registry" and its IMAGE_* variables
@@ -100,9 +100,9 @@ fi
 # The fissile stemcell image that is used as the base
 if [ "${USE_SLES_STEMCELL:-false}" == "false" ]
 then
-    export FISSILE_STEMCELL=${FISSILE_STEMCELL:-splatform/fissile-stemcell-opensuse:$FISSILE_STEMCELL_VERSION}
+    export FISSILE_STEMCELL=${FISSILE_STEMCELL:-${FISSILE_DOCKER_REGISTRY}${FISSILE_DOCKER_ORGANIZATION}/fissile-stemcell-opensuse:$FISSILE_STEMCELL_VERSION}
 else
-    export FISSILE_STEMCELL=${FISSILE_STEMCELL:-splatform/fissile-stemcell-sle12:$FISSILE_STEMCELL_VERSION}
+    export FISSILE_STEMCELL=${FISSILE_STEMCELL:-${FISSILE_DOCKER_REGISTRY}${FISSILE_DOCKER_ORGANIZATION}/fissile-stemcell-sle12:$FISSILE_STEMCELL_VERSION}
 fi
 
 # fissile build kube|helm (memory limits, output, env)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,15 +172,10 @@ pipeline {
             defaultValue: 'splatform',
             description: 'Docker organization to publish to',
         )
-        string(
-            name: 'FISSILE_STEMCELL',
-            defaultValue: '',
-            description: 'Override the .envrc configured stemcell. .envrc is used if left blank.',
-        )
-        string(
-            name: 'FISSILE_STEMCELL_VERSION',
-            defaultValue: '',
-            description: 'Override the .envrc configured stemcell version. .envrc is used if left blank.',
+        booleanParam(
+            name: 'USE_SLES_STEMCELL',
+            defaultValue: false,
+            description: 'Generates a build with the SLES stemcell',
         )
         booleanParam(
             name: 'TRIGGER_SLES_BUILD',
@@ -197,8 +192,7 @@ pipeline {
     environment {
         FISSILE_DOCKER_REGISTRY = "${params.FISSILE_DOCKER_REGISTRY}"
         FISSILE_DOCKER_ORGANIZATION = "${params.FISSILE_DOCKER_ORGANIZATION}"
-        FISSILE_STEMCELL = "${params.FISSILE_STEMCELL}"
-        FISSILE_STEMCELL_VERSION = "${params.FISSILE_STEMCELL_VERSION}"
+        USE_SLES_STEMCELL = "${params.USE_SLES_STEMCELL}"
     }
 
     stages {
@@ -356,7 +350,7 @@ pipeline {
                     ./output/unzipped/kube-ready-state-check.sh || /bin/true
 
                     suffix=""
-                    if echo "${params.FISSILE_STEMCELL}" | grep -qv "fissile-stemcell-sle"; then
+                    if [ "${params.USE_SLES_STEMCELL}" == "false" ]; then
                         suffix="-opensuse"
                     fi
 

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -22,7 +22,12 @@ export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$
 
 # Used in: .envrc
 
-export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.2-21.g0757523-29.55}
+if [ "${USE_SLES_STEMCELL:-false}" == "false" ]
+then
+	export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.2-21.g0757523-29.55}
+else
+	export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-12SP3-5.g5fc0351-0.56}
+fi
 
 # Used in: bin/generate-dev-certs.sh
 


### PR DESCRIPTION
This PR removes the text fields from the Jenkinsfile, instead using a flag to switch between OpenSUSE and SLES.

It retains the environment variable overrides so a dev can still easily switch stemcells without changing files in the repo.

Note that you need to provide a valid Docker repository and credentials for SLES builds as it's not on Docker Hub.