### PR TITLE
Use a single flag in Jenkins for stack and stemcell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -98,10 +98,10 @@ if ! type source_up >/dev/null 2>/dev/null; then
 fi
 
 # Base OS for stemcell and stack
-export USE_SLES_BASE=${USE_SLES_BASE:-false}
+export USE_SLE_BASE=${USE_SLE_BASE:-false}
 
 # The fissile stemcell image that is used as the base
-if [ "${USE_SLES_BASE}" = "false" ]
+if [ "${USE_SLE_BASE}" = "false" ]
 then
     export FISSILE_STEMCELL=${FISSILE_STEMCELL:-${FISSILE_DOCKER_REGISTRY}${FISSILE_DOCKER_ORGANIZATION}/fissile-stemcell-opensuse:$FISSILE_STEMCELL_VERSION}
 else

--- a/.envrc
+++ b/.envrc
@@ -97,8 +97,11 @@ if ! type source_up >/dev/null 2>/dev/null; then
     PWD="$(pwd)"
 fi
 
+# Base OS for stemcell and stack
+export USE_SLES_BASE=${USE_SLES_BASE:-false}
+
 # The fissile stemcell image that is used as the base
-if [ "${USE_SLES_STEMCELL:-false}" == "false" ]
+if [ "${USE_SLES_BASE}" = "false" ]
 then
     export FISSILE_STEMCELL=${FISSILE_STEMCELL:-${FISSILE_DOCKER_REGISTRY}${FISSILE_DOCKER_ORGANIZATION}/fissile-stemcell-opensuse:$FISSILE_STEMCELL_VERSION}
 else

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,7 @@ pipeline {
             description: 'Docker organization to publish to',
         )
         booleanParam(
-            name: 'USE_SLE',
+            name: 'USE_SLES_BASE',
             defaultValue: false,
             description: 'Generates a build with the SLE stemcell and stack',
         )
@@ -201,8 +201,7 @@ pipeline {
     environment {
         FISSILE_DOCKER_REGISTRY = "${params.FISSILE_DOCKER_REGISTRY}"
         FISSILE_DOCKER_ORGANIZATION = "${params.FISSILE_DOCKER_ORGANIZATION}"
-        USE_SLES_STEMCELL = "${params.USE_SLE}"
-        SUSE_STACK = "${params.USE_SLE ? "sle12" : "opensuse42"}"
+        USE_SLES_BASE = "${params.USE_SLES_BASE}"
     }
 
     stages {
@@ -322,7 +321,7 @@ pipeline {
                             }
                             echo "Found expected version: ${expectedVersion}"
 
-                            def glob = "*scf-${params.USE_SLE ? "sle" : "opensuse"}-${expectedVersion}.*-amd64.zip"
+                            def glob = "*scf-${params.USE_SLES_BASE ? "sle" : "opensuse"}-${expectedVersion}.*-amd64.zip"
                             def files = s3FindFiles(bucket: params.S3_BUCKET, path: "${params.S3_PREFIX}${distSubDir()}", glob: glob)
                             if (files.size() > 0) {
                                 error "found a file that matches our current version: ${files[0].name}"
@@ -392,7 +391,7 @@ pipeline {
                     ./output/unzipped/kube-ready-state-check.sh || /bin/true
 
                     suffix=""
-                    if [ "${params.USE_SLE}" == "false" ]; then
+                    if [ "${params.USE_SLES_BASE}" == "false" ]; then
                         suffix="-opensuse"
                     fi
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,9 +182,9 @@ pipeline {
             description: 'Docker organization to publish to',
         )
         booleanParam(
-            name: 'USE_SLES_STEMCELL',
+            name: 'USE_SLE',
             defaultValue: false,
-            description: 'Generates a build with the SLES stemcell',
+            description: 'Generates a build with the SLE stemcell and stack',
         )
         booleanParam(
             name: 'TRIGGER_SLES_BUILD',
@@ -201,7 +201,8 @@ pipeline {
     environment {
         FISSILE_DOCKER_REGISTRY = "${params.FISSILE_DOCKER_REGISTRY}"
         FISSILE_DOCKER_ORGANIZATION = "${params.FISSILE_DOCKER_ORGANIZATION}"
-        USE_SLES_STEMCELL = "${params.USE_SLES_STEMCELL}"
+        USE_SLES_STEMCELL = "${params.USE_SLE}"
+        SUSE_STACK = "${params.USE_SLE ? "sle12" : "opensuse42"}"
     }
 
     stages {
@@ -321,7 +322,7 @@ pipeline {
                             }
                             echo "Found expected version: ${expectedVersion}"
 
-                            def glob = "*scf-${params.USE_SLES_STEMCELL ? "sle" : "opensuse"}-${expectedVersion}.*-amd64.zip"
+                            def glob = "*scf-${params.USE_SLE ? "sle" : "opensuse"}-${expectedVersion}.*-amd64.zip"
                             def files = s3FindFiles(bucket: params.S3_BUCKET, path: "${params.S3_PREFIX}${distSubDir()}", glob: glob)
                             if (files.size() > 0) {
                                 error "found a file that matches our current version: ${files[0].name}"
@@ -391,7 +392,7 @@ pipeline {
                     ./output/unzipped/kube-ready-state-check.sh || /bin/true
 
                     suffix=""
-                    if [ "${params.USE_SLES_STEMCELL}" == "false" ]; then
+                    if [ "${params.USE_SLE}" == "false" ]; then
                         suffix="-opensuse"
                     fi
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,7 @@ pipeline {
             description: 'Docker organization to publish to',
         )
         booleanParam(
-            name: 'USE_SLES_BASE',
+            name: 'USE_SLE_BASE',
             defaultValue: false,
             description: 'Generates a build with the SLE stemcell and stack',
         )
@@ -201,7 +201,7 @@ pipeline {
     environment {
         FISSILE_DOCKER_REGISTRY = "${params.FISSILE_DOCKER_REGISTRY}"
         FISSILE_DOCKER_ORGANIZATION = "${params.FISSILE_DOCKER_ORGANIZATION}"
-        USE_SLES_BASE = "${params.USE_SLES_BASE}"
+        USE_SLE_BASE = "${params.USE_SLE_BASE}"
     }
 
     stages {
@@ -321,7 +321,7 @@ pipeline {
                             }
                             echo "Found expected version: ${expectedVersion}"
 
-                            def glob = "*scf-${params.USE_SLES_BASE ? "sle" : "opensuse"}-${expectedVersion}.*-amd64.zip"
+                            def glob = "*scf-${params.USE_SLE_BASE ? "sle" : "opensuse"}-${expectedVersion}.*-amd64.zip"
                             def files = s3FindFiles(bucket: params.S3_BUCKET, path: "${params.S3_PREFIX}${distSubDir()}", glob: glob)
                             if (files.size() > 0) {
                                 error "found a file that matches our current version: ${files[0].name}"
@@ -391,7 +391,7 @@ pipeline {
                     ./output/unzipped/kube-ready-state-check.sh || /bin/true
 
                     suffix=""
-                    if [ "${params.USE_SLES_BASE}" == "false" ]; then
+                    if [ "${params.USE_SLE_BASE}" == "false" ]; then
                         suffix="-opensuse"
                     fi
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ distribution based on the open source version but with several very key
 differences:
 
 * Uses [fissile](https://github.com/suse/fissile) to containerize the CF components, for running on top of Kubernetes (and Docker)
-* CF Components run on an OpenSUSE Stemcell
+* CF Components run on an openSUSE Stemcell
 * CF Apps optionally can run on a preview of the OpenSUSE Stack (rootfs + buildpacks)
 
 # Disclaimer

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ a working system.
     cd scf
 
     # This runs a combination of bosh & fissile in order to create the docker
-    # images and helm charts you'll need. Once this step is done you can see 
+    # images and helm charts you'll need. Once this step is done you can see
     # images available via "docker images"
     make vagrant-prep
     # This is the final step, where it will install the uaa helm chart into the 'uaa' namespace
@@ -124,8 +124,8 @@ a working system.
    The default stemcell and stack are set to OpenSUSE. The versions are defined
    in `bin/common/versions.sh`.
 
-   To build with the SLES stemcell and stack, the environment variable
-   `USE_SLES_BASE` must be set to `true` before you enter the `scf` directory.
+   To build with the SLE stemcell and stack, the environment variable
+   `USE_SLE_BASE` must be set to `true` before you enter the `scf` directory.
    This allows direnv to configure the various stemcell and stack env vars. The
    `FISSILE_DOCKER_REPOSITORY` env var will need to be set, and Docker configured
    to login to the repository.
@@ -139,7 +139,7 @@ a working system.
 
    ```
    $ cd ~
-   $ export USE_SLES_BASE=true
+   $ export USE_SLE_BASE=true
    $ export FISSILE_DOCKER_REPOSITORY=registry.example.com
    $ docker login ${FISSILE_DOCKER_REPOSITORY} -u username -p password
    $ cd scf
@@ -180,8 +180,8 @@ a working system.
       `wicked ifreload all` and wait for wicked to apply the changes.
     - `VAGRANT_DHCP`: Set this to any value when using virtual networking (as opposed to bridged networking)
       in order to let your VM receive an IP via DHCP in the virtual network. If this environment variable is
-      unset, the VM will instead obtain the IP 192.168.77.77. 
-   
+      unset, the VM will instead obtain the IP 192.168.77.77.
+
 
 **Note:** If every role does not go green in `pod-status --watch` refer to [Troubleshooting](#troubleshooting)
 

--- a/README.md
+++ b/README.md
@@ -119,17 +119,30 @@ a working system.
     # see the Troubleshooting guide.
     k logs -f cf:^api-[0-9]
     ```
-3. Changing the default STEMCELL
+3. Changing the default STEMCELL and STACK
 
-   The default stemcell is set to opensuse.
-   To build with an alternative stemcell the environment variables `FISSILE_STEMCELL` and FISSILE_STEMCELL_VERSION need to be set manually.
-   After changing the stemcell you have to remove the contents of `~vagrant/.fissile/compilation` and `~vagrant/sfc/.fissile/compilation` inside the vagrant box. Afterwards recompile scf (for details see section "2. Building the system").
-   
+   The default stemcell and stack are set to OpenSUSE. The versions are defined
+   in `bin/common/versions.sh`.
+
+   To build with the SLES stemcell and stack, the environment variable
+   `USE_SLES_BASE` must be set to `true` before you enter the `scf` directory.
+   This allows direnv to configure the various stemcell and stack env vars. The
+   `FISSILE_DOCKER_REPOSITORY` env var will need to be set, and Docker configured
+   to login to the repository.
+
+   After changing the stemcell you have to remove the contents of
+   `~vagrant/.fissile/compilation` and `~vagrant/scf/.fissile/compilation` inside
+   the vagrant box. Afterwards recompile scf (for details see section "2. Building
+   the system").
+
    **Example:**
 
    ```
-   $ export FISSILE_STEMCELL_VERSION=42.2-6.ga651b2d-28.31
-   $ export FISSILE_STEMCELL=splatform/fissile-stemcell-opensuse:$FISSILE_STEMCELL_VERSION
+   $ cd ~
+   $ export USE_SLES_BASE=true
+   $ export FISSILE_DOCKER_REPOSITORY=registry.example.com
+   $ docker login ${FISSILE_DOCKER_REPOSITORY} -u username -p password
+   $ cd scf
    ```
 
 3. Environment variables to configure `vagrant up` (optional)

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -22,7 +22,7 @@ export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$
 
 # Used in: .envrc
 
-if [ "${USE_SLES_STEMCELL:-false}" == "false" ]
+if [ "${USE_SLES_BASE:-false}" == "false" ]
 then
 	export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.2-21.g0757523-29.55}
 else

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -22,7 +22,7 @@ export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$
 
 # Used in: .envrc
 
-if [ "${USE_SLES_BASE:-false}" == "false" ]
+if [ "${USE_SLE_BASE:-false}" == "false" ]
 then
 	export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.2-21.g0757523-29.55}
 else

--- a/make/kube
+++ b/make/kube
@@ -7,7 +7,7 @@ cd "${GIT_ROOT}"
 source .envrc
 source ${GIT_ROOT}/make/include/versioning
 
-if [ "${USE_SLES_BASE}" = "false" ]; then
+if [ "${USE_SLE_BASE}" = "false" ]; then
     FISSILE_DEFAULTS_FILE="bin/settings/opensuse42.env"
 else
     FISSILE_DEFAULTS_FILE="bin/settings/sle12.env"

--- a/make/kube
+++ b/make/kube
@@ -7,8 +7,11 @@ cd "${GIT_ROOT}"
 source .envrc
 source ${GIT_ROOT}/make/include/versioning
 
-SUSE_STACK=${SUSE_STACK:-opensuse42}
-FISSILE_DEFAULTS_FILE="bin/settings/${SUSE_STACK}.env"
+if [ "${USE_SLES_BASE}" = "false" ]; then
+    FISSILE_DEFAULTS_FILE="bin/settings/opensuse42.env"
+else
+    FISSILE_DEFAULTS_FILE="bin/settings/sle12.env"
+fi
 
 DOMAIN=${DOMAIN:-}
 


### PR DESCRIPTION
Generating a build with a different base for the stack and stemcell
doesn't make sense.