### PR TITLE
CATS pre-start: explicitly add SG for endpoint

### DIFF
--- a/container-host-files/etc/scf/config/scripts/cf_acceptance_tests_suites.sh
+++ b/container-host-files/etc/scf/config/scripts/cf_acceptance_tests_suites.sh
@@ -20,6 +20,14 @@ ALL_SUITES='
     v3
 '
 
+if test -n "$(type -p jq)" ; then
+    ALL_SUITES="$(
+        cat /var/vcap/jobs-src/acceptance-tests/config_spec.json | \
+        jq -r '.properties.acceptance_tests | to_entries | .[].key ' | \
+        perl -n -e ' m/^include_(.*)/ && print $1 . "\n" '
+    )"
+fi
+
 declare -A suites
 mode='invalid'
 CATS_SUITES="${CATS_SUITES}," # Ensure we can always remove something

--- a/src/scf-helper-release/jobs/acceptance-tests/templates/pre-start.erb
+++ b/src/scf-helper-release/jobs/acceptance-tests/templates/pre-start.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /usr/bin/env bash
 
 set -o errexit
 set -o nounset
@@ -8,3 +8,12 @@ PATH=$PATH:/var/vcap/packages/cli/bin
 cf api --skip-ssl-validation "https://api.$DOMAIN"
 cf auth admin "${CLUSTER_ADMIN_PASSWORD}"
 cf enable-feature-flag diego_docker
+
+# Allow connections to ourselves
+IP="$(host "api.${DOMAIN}" | tail -n1 | awk '{ print $NF }')"
+if test -n "${IP}" && test -z "${IP//[0-9.]/}" ; then
+    # We have an address for hairpin to the cluster endpoint
+    cf create-security-group loopback <(echo "[{\"destination\":\"${IP}\",\"protocol\":\"all\"}]")
+    cf bind-staging-security-group loopback
+    cf bind-running-security-group loopback
+fi


### PR DESCRIPTION
The default configuration we use for vagrant boxes uses a private network address (192.168.77.77) for the external endpoint for the CF cluster.  This means that it is not covered by the public networks default security group, and therefore apps won't be allowed to connect to it.  This breaks the route services test where it attempts to connect to an exposed port from within a different application.
