### PR TITLE
Disable container networking tests

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -6,7 +6,6 @@ properties:
     backend: diego
     include_apps: true
     include_backend_compatibility: true
-    include_container_networking: true
     include_detect: true
     include_diego_docker: true
     include_diego_ssh: true


### PR DESCRIPTION
We don't have the cf-networking release, so these tests shouldn't run.