### PR TITLE
RVRbC8mE Avoid race condition while adding admin buildpacks

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -635,6 +635,7 @@ roles:
   - scripts/nginx_log_level.sh
   scripts:
   - scripts/patches/fix_blobstore_send_timeout.sh
+  - scripts/patches/fix_duplicate_buildpack_positions.sh
   - scripts/patches/fix_nodejs_buildpack.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/use_routing_api_private_endpoint.sh

--- a/container-host-files/etc/scf/config/scripts/patches/fix_duplicate_buildpack_positions.sh
+++ b/container-host-files/etc/scf/config/scripts/patches/fix_duplicate_buildpack_positions.sh
@@ -1,0 +1,31 @@
+set -e
+
+PATCH_DIR=/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/app/jobs/runtime
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+patch -d "$PATCH_DIR" --force -p3 <<'PATCH'
+diff --git app/jobs/runtime/buildpack_installer.rb app/jobs/runtime/buildpack_installer.rb
+index cfac8f1c6..9432ad95f 100644
+--- app/jobs/runtime/buildpack_installer.rb
++++ app/jobs/runtime/buildpack_installer.rb
+@@ -16,7 +16,11 @@ module VCAP::CloudController
+
+           buildpack = Buildpack.find(name: name)
+           if buildpack.nil?
+-            buildpack = Buildpack.create(name: name)
++            buildpacks_lock = Locking[name: 'buildpacks']
++            buildpacks_lock.db.transaction do
++              buildpacks_lock.lock!
++              buildpack = Buildpack.create(name: name)
++            end
+             created = true
+           elsif buildpack.locked
+             logger.info "Buildpack #{name} locked, not updated"PATCH
+
+touch "${SENTINEL}"
+
+exit 0


### PR DESCRIPTION
There are 2 local worker processes adding buildpacks and Sequel::Plugins::List is not concurrency-safe, so add a lock for updating the `position` value when the new record is created.