### PR TITLE
Update repository links in gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/diego-release"]
 	path = src/diego-release
-	url = https://github.com/cloudfoundry-incubator/diego-release.git
+	url = https://github.com/cloudfoundry/diego-release.git
 [submodule "src/cf-mysql-release"]
 	path = src/cf-mysql-release
 	url = https://github.com/cloudfoundry/cf-mysql-release.git
@@ -9,7 +9,7 @@
 	url = https://github.com/cloudfoundry/cflinuxfs2-release.git
 [submodule "src/routing-release"]
 	path = src/routing-release
-	url = https://github.com/cloudfoundry-incubator/routing-release.git
+	url = https://github.com/cloudfoundry/routing-release.git
 [submodule "src/garden-runc-release"]
 	path = src/garden-runc-release
 	url = https://github.com/cloudfoundry/garden-runc-release.git


### PR DESCRIPTION
Hi,

diego-release and routing-release moved from the cloudfoundry-incubator to the cloudfoundry project. We didn't  noticed that because they redirect to the new place.

Jonathan