### PR TITLE
Disable test based on privileged containers.

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -12,7 +12,6 @@ properties:
     include_diego_ssh: true
     include_internet_dependent: true
     include_persistent_app: true
-    include_privileged_container_support: true
     include_route_services: true
     include_routing: true
     include_security_groups: true


### PR DESCRIPTION
https://trello.com/c/MWgYpR8T/523-cats-fuse-endpoint
SCF does not support that, so they should not be run.
Example of a test breaking without privileges is `apps/fuse.go`.