### PR TITLE
Add link to cap release tool to the build output.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -613,6 +613,7 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
                             def encodedCapBundleUri = java.net.URLEncoder.encode("https://s3.amazonaws.com/${params.S3_BUCKET}/${params.S3_PREFIX}${distSubDir()}${distPrefix()}${encodedFileName}", "UTF-8")
                             def encodedBuildUri = java.net.URLEncoder.encode(BUILD_URL, "UTF-8")
 
+                            echo "Create a cap release using this link: https://cap-release-tool.suse.de/?release_archive_url=${encodedCapBundleUri}&SOURCE_BUILD=${encodedBuildUri}"
                             echo "Open a Pull Request for the helm repository using this link: http://jenkins-new.howdoi.website/job/helm-charts/parambuild?CAP_BUNDLE=${encodedCapBundleUri}&SOURCE_BUILD=${encodedBuildUri}"
                         }
                     }


### PR DESCRIPTION
This PR adds a link to the cap-release-tool to the output of the scf build on Jenkins.
Which will allow for publishing signed docker images to the public registry.