### PR TITLE
CATS: Show the log as it happens, instead of after the run

### DIFF
--- a/src/scf-helper-release/jobs/acceptance-tests/templates/run.erb
+++ b/src/scf-helper-release/jobs/acceptance-tests/templates/run.erb
@@ -45,11 +45,10 @@ noColorFlag=<%= properties.acceptance_tests.enable_color ? "" : "-noColor" %>
 set +e
 bin/test -r $noColorFlag -slowSpecThreshold=120 -randomizeAllSpecs $verbose \
   -nodes=$nodes -skipPackage=helpers $skips -keepGoing \
-  > /var/vcap/sys/log/acceptance_tests.log \
+  > >( tee /var/vcap/sys/log/acceptance_tests.log ) \
   2> /var/vcap/sys/log/acceptance_tests.err.log
 EXITSTATUS=$?
 set -e
-tail -c 905696 /var/vcap/sys/log/acceptance_tests.log
 
 echo "Acceptance Tests Complete; exit status: $EXITSTATUS"
 


### PR DESCRIPTION
This lets people peek in on an in-progress run (e.g. on Jenkins) to let them know that things are still going and aren't stuck.