### PR TITLE
Make the cc-clock role wait until the api is ready

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -830,6 +830,7 @@ roles:
   - scripts/configure-HA-hosts.sh
   scripts:
   - scripts/forward_logfiles.sh
+  - scripts/patches/cc_clock_wait_for_api_ready.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper

--- a/container-host-files/etc/scf/config/scripts/patches/cc_clock_wait_for_api_ready.sh
+++ b/container-host-files/etc/scf/config/scripts/patches/cc_clock_wait_for_api_ready.sh
@@ -1,0 +1,46 @@
+#! /usr/bin/env bash
+
+set -e
+
+PATCH_DIR=/var/vcap/jobs-src/cloud_controller_clock/templates
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+patch -d "$PATCH_DIR" --force -p0 <<'PATCH'
+--- cloud_controller_clock_ctl.erb	2018-02-22 18:03:26.188000000 +0000
++++ cloud_controller_clock_ctl.erb	2018-02-22 18:03:12.932000000 +0000
+@@ -21,6 +21,17 @@
+   mkdir -p "${RUN_DIR}"
+ }
+ 
++function wait_for_api_ready() {
++  echo "Waiting for api to be ready"
++
++  api_url="<%= p("cc.external_protocol") %>://<%= p("cc.internal_service_hostname") %>:<%= p("cc.external_port") %>/v2/info"
++
++  while ! curl --silent --connect-timeout 5 --fail --header "Accept:application/json" ${api_url} > /dev/null
++  do
++    sleep 60
++  done
++}
++
+ case $1 in
+ start)
+   setup_environment
+@@ -29,6 +40,8 @@
+ 
+   echo $$ > "$PIDFILE"
+ 
++  wait_for_api_ready
++
+   exec /var/vcap/jobs/cloud_controller_clock/bin/cloud_controller_clock
+   ;;
+ 
+PATCH
+
+touch "${SENTINEL}"
+
+exit 0


### PR DESCRIPTION
This prevents the cc-clock role from creating the schema_migrations
table when it tries to check for the existence of this table. Under
heavy load, it can be deadlocked trying to access this table, and fail
to find it. Afterwards, it will try to create the table, and could
deadlock the migration happening in the api role.

https://github.com/jeremyevans/sequel/blob/7995642c7fccdf1d8a8516cdf3d51db2859bb27e/lib/sequel/extensions/migration.rb#L768