### PR TITLE
Fix make kube source env file issue for helm

### DIFF
--- a/make/kube
+++ b/make/kube
@@ -37,9 +37,9 @@ fi
 if [ "${BUILD_TARGET}" = "kube" ]; then
     # Overrides when generating kube config files instead of helm charts.
     FISSILE_OUTPUT_DIR="${PWD}/output/kube"
-    FISSILE_DEFAULTS_FILE="${FISSILE_DEFAULTS_FILE},bin/settings/settings.env,${NETWORK_ENV}"
     USE_SECRETS_GENERATOR=
 fi
+FISSILE_DEFAULTS_FILE="${FISSILE_DEFAULTS_FILE},bin/settings/settings.env,${NETWORK_ENV}"
 
 rm -rf "${FISSILE_OUTPUT_DIR}"
 


### PR DESCRIPTION
Right now, `make kube` only source FISSILE_DEFAULTS_FILE for kube, but when we use `make kube helm`, there is no any source file. 

So I move `FISSILE_DEFAULTS_FILE="${FISSILE_DEFAULTS_FILE},bin/settings/settings.env,${NETWORK_ENV}"`
out of `if [ "${BUILD_TARGET}" = "kube" ]; then`