### PR TITLE
Remove option to configure UAA_HOST

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -444,7 +444,6 @@ pipeline {
                         --name ${jobBaseName()}-${BUILD_NUMBER}-uaa \
                         --namespace ${jobBaseName()}-${BUILD_NUMBER}-uaa \
                         --set env.DOMAIN=${domain()} \
-                        --set env.UAA_HOST=uaa.${domain()} \
                         --set env.UAA_PORT=2793 \
                         --set secrets.CLUSTER_ADMIN_PASSWORD=changeme \
                         --set secrets.UAA_ADMIN_CLIENT_SECRET=uaa-admin-client-secret \
@@ -476,7 +475,6 @@ pipeline {
                         --name ${jobBaseName()}-${BUILD_NUMBER}-scf \
                         --namespace ${jobBaseName()}-${BUILD_NUMBER}-scf \
                         --set env.DOMAIN=${domain()} \
-                        --set env.UAA_HOST=uaa.${domain()} \
                         --set env.UAA_PORT=2793 \
                         --set secrets.CLUSTER_ADMIN_PASSWORD=changeme \
                         --set secrets.UAA_ADMIN_CLIENT_SECRET=uaa-admin-client-secret \

--- a/bin/settings/network.env
+++ b/bin/settings/network.env
@@ -1,5 +1,4 @@
 DOMAIN=cf-dev.io
 GARDEN_LINUX_DNS_SERVER=8.8.8.8
 TCP_DOMAIN=tcp.cf-dev.io
-UAA_HOST=uaa.cf-dev.io
 UAA_PORT=2793

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2274,9 +2274,6 @@ configuration:
       type: Password
     description: The password for UAA access by the TCP router.
     required: true
-  - name: UAA_HOST
-    description: The host name of the UAA server (root zone)
-    required: true
   - name: UAA_PORT
     default: 2793
     description: The tcp port the UAA server (root zone) listens on for requests.
@@ -2382,7 +2379,7 @@ configuration:
     properties.cc.stacks: '[{"name": "cflinuxfs2", "description": "Cloud Foundry Linux-based filesystem"},{"name": "((SUSE_STACK))", "description": "((SUSE_STACK_DESCRIPTION))"}]'
     properties.cc.staging_timeout_in_seconds: ((STAGING_TIMEOUT))
     properties.cc.staging_upload_password: '"((STAGING_UPLOAD_PASSWORD))"'
-    properties.cc.uaa.internal_url: ((KUBERNETES_NAMESPACE)).((UAA_HOST))
+    properties.cc.uaa.internal_url: ((KUBERNETES_NAMESPACE)).uaa.((DOMAIN))
     properties.ccdb.address: mysql-proxy.((KUBE_SERVICE_DOMAIN_SUFFIX))
     properties.ccdb.roles: '[{"name": "ccadmin", "password": "((MYSQL_CCDB_ROLE_PASSWORD))", "tag": "admin"}]'
     properties.cf-sle12.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))"'
@@ -2462,7 +2459,7 @@ configuration:
     properties.diego.ssh_proxy.host_key: '"((APP_SSH_KEY))"'
     properties.diego.ssh_proxy.log_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
     properties.diego.ssh_proxy.uaa_secret: '"((UAA_CLIENTS_DIEGO_SSH_PROXY_SECRET))"'
-    properties.diego.ssh_proxy.uaa_token_url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))/oauth/token
+    properties.diego.ssh_proxy.uaa_token_url: https://((KUBERNETES_NAMESPACE)).uaa.((DOMAIN)):((UAA_PORT))/oauth/token
     properties.domain: '"((DOMAIN))"'
     properties.doppler.addr: '"doppler-set.((KUBE_SERVICE_DOMAIN_SUFFIX))"'
     properties.fissile.monit.password: '"((MONIT_PASSWORD))"'
@@ -2494,7 +2491,7 @@ configuration:
     properties.loggregator.tls.trafficcontroller.cert: '"((TRAFFICCONTROLLER_CERT))"'
     properties.loggregator.tls.trafficcontroller.key: '"((TRAFFICCONTROLLER_KEY))"'
     properties.loggregator.uaa.client_secret: '"((UAA_CLIENTS_DOPPLER_SECRET))"'
-    properties.login.url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
+    properties.login.url: https://((KUBERNETES_NAMESPACE)).uaa.((DOMAIN)):((UAA_PORT))
     properties.metron_agent.zone: '"((KUBE_AZ))"'
     # CLUSTER_NAME is not wrapped in quotes because it has quotes in the dev env file.
     properties.name: ((CLUSTER_NAME))
@@ -2551,8 +2548,8 @@ configuration:
     properties.scalablesyslog.scheduler.tls.client.cert: '"((SYSLOG_SCHED_CERT))"'
     properties.scalablesyslog.scheduler.tls.client.key: '"((SYSLOG_SCHED_KEY))"'
     properties.scf.internal-ca-cert: '"((INTERNAL_CA_CERT))((#INTERNAL_CA_KEY))((/INTERNAL_CA_KEY))"'
-    properties.scf.uaa.internal-url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
-    properties.scf.uaa.root-zone.url: https://((UAA_HOST)):((UAA_PORT))
+    properties.scf.uaa.internal-url: https://((KUBERNETES_NAMESPACE)).uaa.((DOMAIN)):((UAA_PORT))
+    properties.scf.uaa.root-zone.url: https://uaa.((DOMAIN)):((UAA_PORT))
     properties.scf_set_proxy.running_http_proxy: '"((HTTP_PROXY))"'
     properties.scf_set_proxy.running_https_proxy: '"((HTTPS_PROXY))"'
     properties.scf_set_proxy.running_no_proxy: '"((NO_PROXY))"'
@@ -2577,25 +2574,25 @@ configuration:
     properties.uaa.clients.cc_routing.secret: '"((UAA_CLIENTS_CC_ROUTING_SECRET))"'
     properties.uaa.clients.cc_service_key_client.secret: '"((UAA_CLIENTS_CC_SERVICE_KEY_CLIENT_SECRET))"'
     properties.uaa.clients.cf-usb.secret: '"((UAA_CLIENTS_CF_USB_SECRET))"'
-    properties.uaa.clients.cf.redirect-uri: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))/login
+    properties.uaa.clients.cf.redirect-uri: https://((KUBERNETES_NAMESPACE)).uaa.((DOMAIN)):((UAA_PORT))/login
     properties.uaa.clients.cloud_controller.secret: ((UAA_CC_CLIENT_SECRET))
     properties.uaa.clients.cloud_controller_username_lookup.secret: '"((UAA_CLIENTS_CLOUD_CONTROLLER_USERNAME_LOOKUP_SECRET))"'
-    properties.uaa.clients.doppler.redirect-uri: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
+    properties.uaa.clients.doppler.redirect-uri: https://((KUBERNETES_NAMESPACE)).uaa.((DOMAIN)):((UAA_PORT))
     properties.uaa.clients.doppler.secret: '"((UAA_CLIENTS_DOPPLER_SECRET))"'
     properties.uaa.clients.gorouter.secret: '"((UAA_CLIENTS_GOROUTER_SECRET))"'
-    properties.uaa.clients.login.redirect-uri: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
+    properties.uaa.clients.login.redirect-uri: https://((KUBERNETES_NAMESPACE)).uaa.((DOMAIN)):((UAA_PORT))
     properties.uaa.clients.login.secret: '"((UAA_CLIENTS_LOGIN_SECRET))"'
     properties.uaa.clients.scf_auto_config.secret: '"((UAA_CLIENTS_SCF_AUTO_CONFIG_SECRET))"'
-    properties.uaa.clients.ssh-proxy.redirect-uri: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))/login
+    properties.uaa.clients.ssh-proxy.redirect-uri: https://((KUBERNETES_NAMESPACE)).uaa.((DOMAIN)):((UAA_PORT))/login
     properties.uaa.clients.ssh-proxy.secret: '"((UAA_CLIENTS_DIEGO_SSH_PROXY_SECRET))"'
     properties.uaa.clients.tcp_emitter.secret: '"((UAA_CLIENTS_TCP_EMITTER_SECRET))"'
     properties.uaa.clients.tcp_router.secret: '"((UAA_CLIENTS_TCP_ROUTER_SECRET))"'
-    properties.uaa.hostname: '((KUBERNETES_NAMESPACE)).((UAA_HOST))'
-    properties.uaa.internal_url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT)) # For loggregator
+    properties.uaa.hostname: '((KUBERNETES_NAMESPACE)).uaa.((DOMAIN))'
+    properties.uaa.internal_url: https://((KUBERNETES_NAMESPACE)).uaa.((DOMAIN)):((UAA_PORT)) # For loggregator
     properties.uaa.port: ((UAA_PORT))
     properties.uaa.scim.users: '[{name: admin, password: ((CLUSTER_ADMIN_PASSWORD)), groups: [((CLUSTER_ADMIN_AUTHORITIES))]}]'
     properties.uaa.ssl.port: ((UAA_PORT))
     properties.uaa.tls_port: ((UAA_PORT))
-    properties.uaa.token_endpoint: ((KUBERNETES_NAMESPACE)).((UAA_HOST))
-    properties.uaa.url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
+    properties.uaa.token_endpoint: ((KUBERNETES_NAMESPACE)).uaa.((DOMAIN))
+    properties.uaa.url: https://((KUBERNETES_NAMESPACE)).uaa.((DOMAIN)):((UAA_PORT))
     properties.version: '"((CLUSTER_VERSION))"'

--- a/make/kube
+++ b/make/kube
@@ -22,7 +22,6 @@ if test -n "${DOMAIN}"; then
     trap "rm -rf ${TMP}" EXIT
     NETWORK_ENV="${TMP}/$(basename "${NETWORK_ENV}")"
     sed -e "s/^DOMAIN=.*/DOMAIN=${DOMAIN}/" \
-        -e "s/^UAA_HOST=.*/UAA_HOST=uaa.${DOMAIN}/" \
         -e "s/^TCP_DOMAIN=.*/TCP_DOMAIN=tcp.${DOMAIN}/" \
         -i "${NETWORK_ENV}"
 fi

--- a/make/run
+++ b/make/run
@@ -67,7 +67,6 @@ if test -n "${DOMAIN}"; then
     trap "rm -rf ${TMP}" EXIT
     NETWORK_ENV="${TMP}/$(basename "${NETWORK_ENV}")"
     sed -e "s/^DOMAIN=.*/DOMAIN=${DOMAIN}/" \
-        -e "s/^UAA_HOST=.*/UAA_HOST=uaa.${DOMAIN}/" \
         -e "s/^TCP_DOMAIN=.*/TCP_DOMAIN=tcp.${DOMAIN}/" \
         -i "${NETWORK_ENV}"
 fi
@@ -81,7 +80,6 @@ helm install output/helm \
      --namespace ${NAMESPACE} \
      --set "env.DOMAIN=${DOMAIN}" \
      --set "env.TCP_DOMAIN=${TCP_DOMAIN}" \
-     --set "env.UAA_HOST=${UAA_HOST}" \
      --set "env.UAA_PORT=${UAA_PORT}" \
      --set "secrets.CLUSTER_ADMIN_PASSWORD=$CLUSTER_ADMIN_PASSWORD" \
      --set "secrets.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}" \

--- a/make/upgrade
+++ b/make/upgrade
@@ -37,7 +37,6 @@ if test -n "${DOMAIN}"; then
     trap "rm -rf ${TMP}" EXIT
     NETWORK_ENV="${TMP}/$(basename "${NETWORK_ENV}")"
     sed -e "s/^DOMAIN=.*/DOMAIN=${DOMAIN}/" \
-        -e "s/^UAA_HOST=.*/UAA_HOST=uaa.${DOMAIN}/" \
         -e "s/^TCP_DOMAIN=.*/TCP_DOMAIN=tcp.${DOMAIN}/" \
         -i "${NETWORK_ENV}"
 fi
@@ -52,7 +51,6 @@ helm upgrade ${RELEASE} output/helm \
     --set "env.DOMAIN=${DOMAIN}" \
     --set "env.TCP_DOMAIN=${TCP_DOMAIN}" \
     --set "env.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}" \
-    --set "env.UAA_HOST=${UAA_HOST}" \
     --set "env.UAA_PORT=${UAA_PORT}" \
     --set "env.UAA_CA_CERT=${UAA_CA_CERT}" \
     --set "kube.external_ip=$(dig +short ${DOMAIN})" \


### PR DESCRIPTION
The UAA cert is hardcoded to uaa.$DOMAIN, so it can't be changed.