### PR TITLE
Add a patch to remove timestamp check for rsyslog

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -5,6 +5,7 @@ roles:
   - scripts/configure-HA-hosts.sh
   scripts:
   - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper
@@ -37,6 +38,7 @@ roles:
   - scripts/configure-HA-hosts.sh
   scripts:
   - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper
@@ -65,6 +67,7 @@ roles:
   - scripts/configure-HA-hosts.sh
   scripts:
   - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper
@@ -100,6 +103,7 @@ roles:
   - scripts/configure-HA-hosts.sh
   scripts:
   - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper
@@ -151,6 +155,7 @@ roles:
   - scripts/patches/fix_mysql_advertise_ip.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/enable_mysql_galera_bootstrap.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper
@@ -225,6 +230,7 @@ roles:
   - scripts/configure-HA-hosts.sh
   scripts:
   - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper
@@ -322,6 +328,7 @@ roles:
   - scripts/go_log_level.sh
   scripts:
   - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper
@@ -490,6 +497,7 @@ roles:
   scripts:
   - scripts/patches/fix_haproxy_fd_requirements.sh
   - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper
@@ -818,6 +826,7 @@ roles:
   - scripts/configure-HA-hosts.sh
   scripts:
   - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper
@@ -931,6 +940,7 @@ roles:
   - scripts/go_log_level.sh
   scripts:
   - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper
@@ -975,6 +985,7 @@ roles:
   - scripts/go_log_level.sh
   scripts:
   - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper
@@ -1026,6 +1037,7 @@ roles:
   - scripts/go_log_level.sh
   scripts:
   - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: scf-helper

--- a/container-host-files/etc/scf/config/scripts/patches/fix_monit_rsyslog.sh
+++ b/container-host-files/etc/scf/config/scripts/patches/fix_monit_rsyslog.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# This patch removes a timestamp check for /var/log/messages.
+# For e.g., in nats or doppler, only limited logs will be recorded to /var/log/messages, and then this file is
+# no longer updated. If /var/log/messages is outdated for more than 65 mins, there will be an alert
+# named "timestamp failed".
+
+
+PATCH_DIR="/etc/monit/monitrc.d"
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+cd "$PATCH_DIR"
+cat <<'EOF' | patch
+--- rsyslog.ori	2018-01-29 14:23:21.000000000 +0000
++++ rsyslog	2018-03-29 05:59:56.945312289 +0000
+@@ -16,7 +16,6 @@
+
+ check file rsyslog_file with path /var/log/messages
+    group rsyslogd
+-   if timestamp > 65 minutes then alert
+    if failed permission 640  then unmonitor
+    if failed uid "syslog"    then unmonitor
+    if failed gid "syslog"    then unmonitor
+EOF
+
+echo "${PATCH_DIR}/${0##*/}" >> "${SENTINEL}"
+exit 0


### PR DESCRIPTION
Hi,
In nats or doppler, only limited logs will be recorded to /var/log/messages, then this file is no longer updated. If /var/log/messages is outdated for more than 65 mins, there will be an alert named "timestamp failed". So add a patch for these component to remove the check.

[issue 1433](https://github.com/SUSE/scf/issues/1433)
Thanks!