### PR TITLE
Expose property `router.forwarded_client_cert` as parameter `ROUTER_FORWARDED_CLIENT_CERT`.

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2011,6 +2011,9 @@ configuration:
   - name: ROUTER_BALANCING_ALGORITHM
     default: 'round-robin'
     description: The algorithm used by the router to distribute requests for a route across backends. Supported values are round-robin and least-connection.
+  - name: ROUTER_FORWARDED_CLIENT_CERT
+    default: 'always_forward'
+    description: How to handle the x-forwarded-client-cert (XFCC) HTTP header. Supported values are always_forward, forward, and sanitize_set. See https://docs.cloudfoundry.org/concepts/http-routing.html for more information.
   - name: ROUTER_SERVICES_SECRET
     secret: true
     immutable: true
@@ -2520,6 +2523,7 @@ configuration:
     properties.router.balancing_algorithm: '"((ROUTER_BALANCING_ALGORITHM))"'
     properties.router.dns_health_check_host: '"((DNS_HEALTH_CHECK_HOST))"'
     properties.router.force_forwarded_proto_https: ((FORCE_FORWARDED_PROTO_AS_HTTPS))
+    properties.router.forwarded_client_cert: "((ROUTER_FORWARDED_CLIENT_CERT))"
     properties.router.logging_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
     properties.router.route_services_secret: '"((ROUTER_SERVICES_SECRET))"'
     properties.router.status.password: '"((ROUTER_STATUS_PASSWORD))"'


### PR DESCRIPTION
Ref: https://trello.com/c/jnGQ3xAo/610-2-make-gorouter-configurable-for-routerforwardedclientcert

Vagrant: Builds ok, passes :smoking:, brain, and :cat: