### PR TITLE
update cached libvirt box

### DIFF
--- a/packer/Makefile
+++ b/packer/Makefile
@@ -2,7 +2,10 @@
 .INTERMEDIATE: http/scf-autoyast.xml http/vagrant-autoyast.xml
 
 scf-cached-libvirt: http/scf-autoyast.xml
-	packer build -only scf-cached-libvirt vagrant-box.json
+	packer build -only scf-cached-libvirt \
+		-var ssh_username=scf \
+		-var ssh_password=changeme \
+		vagrant-box.json
 vagrant-libvirt: http/vagrant-autoyast.xml
 	packer build -only vagrant-libvirt vagrant-box.json
 vagrant-virtualbox: http/vagrant-autoyast.xml

--- a/packer/http/autoyast.xml.tpl
+++ b/packer/http/autoyast.xml.tpl
@@ -141,7 +141,6 @@
         <service>kube-proxy</service>
         <service>kube-scheduler</service>
         <service>kubelet</service>
-        <service>sshd</service>
       </enable>
     </services>
   </services-manager>
@@ -160,6 +159,16 @@
         <chrooted config:type="boolean">true</chrooted>
       </script>
     </chroot-scripts>
+    <init-scripts config:type="list">
+      <script>
+        <filename>enable-sshd.sh</filename>
+        <source><![CDATA[#!/bin/bash
+          # Delay sshd startup to after the reboot, to ensure that packer does
+          # not attempt to connect before everything is ready
+          systemctl enable --now sshd.service
+        ]]></source>
+      </script>
+    </init-scripts>
   </scripts>
 
   <groups config:type="list">

--- a/packer/http/kubelet-vagrant-overrides.env
+++ b/packer/http/kubelet-vagrant-overrides.env
@@ -1,2 +1,4 @@
 KUBE_ALLOW_PRIV="--allow-privileged"
 KUBELET_API_SERVER=""
+# --network-plugin-dir was renamed to --cni-bin-dir
+KUBELET_ARGS="--pod-manifest-path=/etc/kubernetes/manifests --cluster-dns=10.254.0.254 --cluster-domain=cluster.local --cgroups-per-qos=false --enforce-node-allocatable='' --network-plugin='kubenet' --non-masquerade-cidr=172.16.0.0/16 --pod-cidr=172.16.0.0/16 --cni-bin-dir=/usr/lib/cni/ --feature-gates KubeletConfigFile=true --kubeconfig /etc/kubernetes/kubelet-config"

--- a/packer/scripts/create-kube-certs.sh
+++ b/packer/scripts/create-kube-certs.sh
@@ -26,4 +26,5 @@ perl -p -i -e 's@^(KUBELET_ARGS=)"(.*)"@\1"\2 --cluster-dns=10.254.0.254 --clust
 # Enable RBAC for kubernetes
 perl -p -i -e 's@^(KUBE_API_ARGS=)"(.*)"@\1"\2 --authorization-mode=RBAC"@' /etc/kubernetes/apiserver
 
+systemctl daemon-reload
 systemctl restart etcd.service kube-apiserver.service kube-controller-manager.service kube-proxy.service kube-scheduler.service kubelet.service

--- a/packer/scripts/install-cap-archives.sh
+++ b/packer/scripts/install-cap-archives.sh
@@ -4,13 +4,13 @@ set -o errexit
 set -o verbose
 
 # Fetch predetermined version of scf
-SCF_URL=https://github.com/SUSE/scf/releases/download/2.7.0/scf-opensuse-2.7.0.cf1.9.0.0.g2d95fcb5.linux-amd64.zip
+SCF_URL=https://github.com/SUSE/scf/releases/download/2.8.0/scf-opensuse-2.8.0.cf1.15.0.0.g5aa8b036-amd64.zip
 SCF_ARCHIVE="$(basename "${SCF_URL}")"
 wget "${SCF_URL}"
 unzip "${SCF_ARCHIVE}"
 
 # Fetch predetermined version of the ui
-CONSOLE_URL=https://github.com/cloudfoundry-incubator/stratos/releases/download/1.0.0/console-helm-chart-1.0.0.tgz
+CONSOLE_URL=https://github.com/cloudfoundry-incubator/stratos/releases/download/1.1.0/console-helm-chart-1.1.0.tgz
 CONSOLE_ARCHIVE="$(basename "${CONSOLE_URL}")"
 wget "${CONSOLE_URL}"
 tar xzf "${CONSOLE_ARCHIVE}"

--- a/packer/scripts/install-kubernetes.sh
+++ b/packer/scripts/install-kubernetes.sh
@@ -7,29 +7,21 @@ set -o errexit -o xtrace
 # Kube doesn't like swap: https://github.com/kubernetes/kubernetes/blob/e4551d50e57c089aab6f67333412d3ca64bc09ae/pkg/kubelet/cm/container_manager_linux.go#L207-L209
 swapoff -a
 
-zypper --non-interactive addrepo --gpgcheck --refresh --priority 130 --check \
-    obs://devel:CaaSP:Head:ControllerNode devel:CaaSP
 zypper --non-interactive addrepo --gpgcheck --refresh --priority 120 --check \
-    obs://home:aarondl:branches:devel:CaaSP:Head:ControllerNode aaron:CaaSP
-zypper --non-interactive addrepo --gpgcheck --refresh --priority 110 --check \
-    obs://Virtualization:containers Virtualization:containers
+    obs://home:mook_work:branches:devel:CaaSP:Head:ControllerNode mook_work:CaaSP
 
 zypper --non-interactive --gpg-auto-import-keys refresh
-zypper --non-interactive repos --uri # for troubleshooting
+zypper --non-interactive repos --uri --priority # for troubleshooting
 
-zypper --non-interactive install --no-confirm --from=Virtualization:containers \
-    'docker = 17.09.1_ce'
-
-zypper --non-interactive install --no-confirm --from=devel:CaaSP \
+zypper --non-interactive install --no-confirm --from=mook_work:CaaSP \
     etcd \
     cni-plugins \
-    kubernetes-node-image-pause
-
-zypper --non-interactive install --no-confirm --from=aaron:CaaSP \
     kubernetes-client \
     kubernetes-kubelet \
     kubernetes-master \
-    kubernetes-node
+    kubernetes-node \
+    kubernetes-node-image-pause
+# kubernetes-kubelet pulls in docker-kubic automatically
 
 usermod --append --groups docker vagrant || usermod --append --groups docker scf
 systemctl enable etcd.service

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -93,7 +93,7 @@
             "http_directory": "{{user `http_directory`}}",
             "shutdown_command": "{{user `shutdown_command`}}",
             "qemuargs": [
-                [ "-m", "1024M" ]
+                [ "-m", "2048M" ]
             ],
             "boot_command": [
                 "<esc><enter><wait>",
@@ -108,9 +108,9 @@
             "type": "qemu",
 
             "vm_name": "scf-vm+{{isotime \"20060102-1504\"}}",
-            "ssh_username": "scf",
-            "ssh_password": "changeme",
-            "shutdown_command": "echo changeme | sudo -S shutdown -P now",
+            "ssh_username": "{{user `ssh_username`}}",
+            "ssh_password": "{{user `ssh_password`}}",
+            "shutdown_command": "echo {{user `ssh_password`}} | sudo -S shutdown -P now",
 
             "headless": true,
             "disk_size": 120480,
@@ -123,7 +123,7 @@
             "iso_checksum_type": "{{user `iso_checksum_type`}}",
             "http_directory": "{{user `http_directory`}}",
             "qemuargs": [
-                [ "-m", "1024M" ]
+                [ "-m", "2048M" ]
             ],
             "boot_command": [
                 "<esc><enter><wait>",

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "2.0.12",
+        "version": "2.0.13",
         "vm_name": "scf-vagrant",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",


### PR DESCRIPTION
The cached libvirt box no longer builds, because we now need more RAM to install `kernel-default`. Not sure why; guessing it downloads the RPM to a ramdisk?

Of course, this leads to Fun like discovering that the repo we used no longer exists… so I had to upgrade kubernetes to get it to build.