### PR TITLE
Make mysql-proxy healthcheck timeout configurable

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -176,7 +176,6 @@ properties:
     proxy:
       api_force_https: false
       api_username: 'mysql_proxy'
-      healthcheck_timeout_millis: 30000
   diego:
     auctioneer:
       rep:

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -272,6 +272,7 @@ roles:
       properties.cf_mysql.mysql.admin_password: ((MYSQL_ADMIN_PASSWORD))
       properties.cf_mysql.mysql.galera_healthcheck.endpoint_password: ((MYSQL_GALERA_HEALTHCHECK_ENDPOINT_PASSWORD))
       properties.cf_mysql.proxy.api_password: ((MYSQL_PROXY_ADMIN_PASSWORD))
+      properties.cf_mysql.proxy.healthcheck_timeout_millis: ((MYSQL_PROXY_HEALTHCHECK_TIMEOUT))
 - name: cf-usb
   environment_scripts:
   - scripts/configure-HA-hosts.sh
@@ -1907,6 +1908,10 @@ configuration:
     generator:
       type: Password
     description: The password for Basic Auth used to secure the MySQL proxy API.
+    required: true
+  - name: MYSQL_PROXY_HEALTHCHECK_TIMEOUT
+    default: 30000
+    description: The time allowed for the MySQL server to respond to healthcheck queries, in milliseconds.
     required: true
   - name: MYSQL_ROUTING_API_PASSWORD
     secret: true


### PR DESCRIPTION
HA configurations of MySQL can take a long time to respond when starting
up on slower hardware, so allow users to increase this timeout if
needed.