### PR TITLE
Cleanup klog.sh debugging script

### DIFF
--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -29,8 +29,8 @@ if [ "${FORCE}" == "1" ] ; then
 fi
 
 if [ ! -f "${DONE}" ]; then
+    rm -rf "${KLOG:?}/${NS:?}"
     mkdir -p "${KLOG}/${NS}"
-    rm -rf "${KLOG:?}/${NS:?}/"*
 
     PODS=$(kubectl get pods --namespace "${NS}" --output name --show-all=true | sed 's/pods\///')
 

--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -40,9 +40,9 @@ if [ ! -f "${DONE}" ]; then
     rm -rf "${KLOG:?}/${NS:?}"
     mkdir -p "${KLOG}/${NS}"
 
-    PODS=$(kubectl get pods --namespace "${NS}" --output name --show-all=true | sed 's/pods\///')
+    PODS=($(kubectl get pods --namespace "${NS}" --output name --show-all=true | sed 's/pods\///'))
 
-    for POD in ${PODS}; do
+    for POD in "${PODS[@]}"; do
         DIR=${KLOG}/${NS}/${POD}
 
         mkdir -p "${DIR}"

--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -50,7 +50,7 @@ if [ ! -f "${DONE}" ]; then
         # Unfortunately we can't get anything past the previous one
         kubectl logs "${POD}" --namespace "${NS}" > "${DIR}/kube.log"
         kubectl logs "${POD}" --namespace "${NS}" --previous > "${DIR}/kube-previous.log" 2> /dev/null || true
-        kubectl describe pods "${POD}" --namespace "${NS}" > "${DIR}/describe-pod"
+        kubectl describe pods "${POD}" --namespace "${NS}" > "${DIR}/describe-pod.txt"
     done
     gunzip -r "${KLOG}"
 

--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -34,7 +34,7 @@ if [ ! -f ${DONE} ]; then
 
     for POD in ${PODS}; do
         if $(kubectl exec ${POD} --namespace ${NS} -- bash -c "[ -d /var/vcap/sys/log ]"); then
-            DIR=${KLOG}/${NS}/${POD%-*-*}
+            DIR=${KLOG}/${NS}/${POD}
             mkdir -p ${DIR}
             cd ${DIR}
             echo Fetching logs for ${POD}

--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -58,6 +58,8 @@ if [ ! -f "${DONE}" ]; then
         kubectl logs "${POD}" --namespace "${NS}" --previous > "${DIR}/kube-previous.log" 2> /dev/null || true
         kubectl describe pods "${POD}" --namespace "${NS}" > "${DIR}/describe-pod.txt"
     done
+
+    # Unzip any logrotated files so the lookup can read them
     gunzip -r "${KLOG}"
 
     kubectl get all --export=true --namespace "${NS}" -o yaml > "${KLOG}/${NS}/resources.yaml"

--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -49,8 +49,7 @@ if [ ! -f "${DONE}" ]; then
 
         # Get the CF logs inside the pod if there are any
         if [ "$(get_phase)" != 'Succeeded' ] && check_for_log_dir; then
-            # Mask the exit status of tar because it complains if files were written while it was reading them
-            kubectl exec "${POD}" --namespace "${NS}" -- bash -c "cd /var/vcap/sys/log && (tar --warning=no-file-changed -cf - * || true)" | ( cd "${DIR}" && tar xf -)
+            kubectl cp --namespace "${NS}" "${POD}":/var/vcap/sys/log/ "${DIR}/" 2> /dev/null
         fi
 
         # Get the pod logs - previous may not be there if it was successful on the first run.

--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -43,7 +43,7 @@ if [ ! -f "${DONE}" ]; then
     PODS=($(kubectl get pods --namespace "${NS}" --output name --show-all=true | sed 's/pods\///'))
 
     for POD in "${PODS[@]}"; do
-        DIR=${KLOG}/${NS}/${POD}
+        DIR="${KLOG}/${NS}/${POD}"
 
         mkdir -p "${DIR}"
 
@@ -70,7 +70,7 @@ NEWLINE=0
 function lookfor {
     read PATTERN
 
-    cd ${KLOG}
+    cd "${KLOG}"
     if grep -c -r -F "${PATTERN}" > .grep; then
         [ "${NEWLINE}" == "1" ] && echo
         NEWLINE=1
@@ -80,7 +80,7 @@ function lookfor {
         grep -v :0$ .grep
 
         while read INFO; do
-            echo ${INFO}
+            echo "${INFO}"
         done
     fi
 }


### PR DESCRIPTION
* shellcheck linting
* Simplify klog by removing error checks. This will be handled by another tool in the future.
* Don't remove this pod suffix - this was overwriting log files if there was more than one pod.
* Get some extra kube logs related to each pod and the overall namespace

