### PR TITLE
Remove architecture tag from release archive

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -377,7 +377,7 @@ pipeline {
                     source ${PWD}/.envrc
                     set -x
                     unset SCF_PACKAGE_COMPILATION_CACHE
-                    rm -f output/scf-*amd64*.zip
+                    rm -f output/scf-*.zip
                     make helm bundle-dist
                 '''
             }

--- a/make/bundle-dist
+++ b/make/bundle-dist
@@ -19,7 +19,7 @@ else
     echo "Unkown stemcell operating system: ${FISSILE_STEMCELL}"
     exit 1
 fi
-ARCHIVE="${GIT_ROOT}/output/scf-${stemcell_os}-${APP_VERSION}-amd64.zip"
+ARCHIVE="${GIT_ROOT}/output/scf-${stemcell_os}-${APP_VERSION}.zip"
 
 echo Packaging, taking $APP_VERSION ...
 


### PR DESCRIPTION
because it only provides helm charts which are hardware independent.