### PR TITLE
Adapt create_helm_charts_pr.sh to allow Github tokens

### DIFF
--- a/bin/dev/create_helm_charts_pr.sh
+++ b/bin/dev/create_helm_charts_pr.sh
@@ -12,7 +12,7 @@ if [ -z "$GITHUB_USER"  ]; then
   exit 1
 fi
 
-if [ -z "$GITHUB_PASSWORD" ]; then
+if [ -z "$GITHUB_PASSWORD" ] && [ -z "${GITHUB_TOKEN}" ] ; then
   echo "GITHUB_PASSWORD environment variable not set"
   exit 1
 fi


### PR DESCRIPTION
The problem with the username password combination is that each time a
new access token is created which does not make sense for ci.

Similar to https://raw.githubusercontent.com/SUSE/cf-usb-sidecar/develop/scripts/create_helm_charts_pr.sh .

Maybe we should combine them in the future.