### PR TITLE
Update vagrant box to kube 1.9

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure(2) do |config|
 
   vm_memory = ENV.fetch('SCF_VM_MEMORY', ENV.fetch('VM_MEMORY', 10 * 1024)).to_i
   vm_cpus = ENV.fetch('SCF_VM_CPUS', ENV.fetch('VM_CPUS', 4)).to_i
-  vm_box_version = ENV.fetch('SCF_VM_BOX_VERSION', ENV.fetch('VM_BOX_VERSION', '2.0.12'))
+  vm_box_version = ENV.fetch('SCF_VM_BOX_VERSION', ENV.fetch('VM_BOX_VERSION', '2.0.13'))
   vm_registry_mirror = ENV.fetch('SCF_VM_REGISTRY_MIRROR', ENV.fetch('VM_REGISTRY_MIRROR', ''))
 
   # Create a private network, which allows host-only access to the machine

--- a/bin/common/install_tools.sh
+++ b/bin/common/install_tools.sh
@@ -41,12 +41,17 @@ chmod a+x "${SCF_BIN_DIR}/kk"
 chmod a+x "${SCF_BIN_DIR}/helm"
 
 # The vagrant deployment runs this script privileged, so init helm as vagrant user if they exist.
-if systemctl is-active kube-apiserver.service ; then
+if systemctl list-unit-files kube-apiserver.service | grep --quiet enabled ; then
   if [[ $(id -u) -eq 0 ]] && id -u vagrant &>/dev/null; then
     do_as_vagrant="sudo -iu vagrant"
   else
     do_as_vagrant=""
   fi
+
+  # Wait for kube-apiserver to actually be ready
+  while ! systemctl is-active kube-apiserver.service ; do
+    sleep 1
+  done
 
   echo "Installing tiller for helm ..."
   ${do_as_vagrant} helm init

--- a/bin/common/install_tools.sh
+++ b/bin/common/install_tools.sh
@@ -48,26 +48,6 @@ if systemctl is-active kube-apiserver.service ; then
     do_as_vagrant=""
   fi
 
-  echo "Setting up RBAC permissions for tiller ..."
-  ${do_as_vagrant} kubectl create -f - <<EOF
-  { "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-    "kind": "ClusterRoleBinding",
-    "metadata": { "name": "permissive-system-accounts" },
-    "roleRef":{
-      "apiGroup": "rbac.authorization.k8s.io",
-      "kind": "ClusterRole",
-      "name": "cluster-admin"
-    },
-    "subjects": [
-      { "apiGroup": "rbac.authorization.k8s.io",
-        "kind": "Group",
-        "name": "system:serviceaccounts:kube-system" },
-      { "kind": "ServiceAccount",
-        "name": "default",
-        "namespace":"kube-system" }
-    ]
-  }
-EOF
   echo "Installing tiller for helm ..."
   ${do_as_vagrant} helm init
 else

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -23,3 +23,15 @@ http/vagrant-autoyast.xml: http/autoyast.xml.tpl
 	txtplate --input http/autoyast.xml.tpl \
 	         --output http/vagrant-autoyast.xml \
 	         vagrant-templating.json
+
+# Install locally-built vagrant images
+vagrant-install-libvirt:
+	FILE="scf-libvirt-v$$(jq -r .variables.version vagrant-box.json).box" && \
+	URL="https://cf-opensusefs2.s3.amazonaws.com/vagrant/$${FILE}" && \
+	vagrant box add --force --provider libvirt --name "$${URL}" "$${FILE}" && \
+	virsh vol-delete --pool default "$${URL//\//-VAGRANTSLASH-}_vagrant_box_image_0.img"
+
+vagrant-install-virtualbox:
+	FILE="scf-virtualbox-v$$(jq -r .variables.version vagrant-box.json).box" && \
+	URL="https://cf-opensusefs2.s3.amazonaws.com/vagrant/$${FILE}" && \
+	vagrant box add --force --provider virtualbox --name "$${URL}" "$${FILE}"

--- a/packer/scripts/create-kubedns.sh
+++ b/packer/scripts/create-kubedns.sh
@@ -2,19 +2,6 @@
 
 set -o errexit -o xtrace
 
-echo "Waiting for kube-apiserver to be active..."
-while ! systemctl is-active kube-apiserver.service 2>/dev/null >/dev/null; do
-  sleep 10
-done
-echo "Waiting for kubectl to respond..."
-while ! kubectl get pods --all-namespaces; do
-  sleep 2
-done
-# Due to timing, kube-system may not exist immediately
-while ! kubectl get ns kube-system >& /dev/null; do
-  sleep .1
-done
-
 curl -s https://raw.githubusercontent.com/SUSE/caasp-services/b0cf20ca424c/contrib/addons/kubedns/dns.yaml | \
   perl -p -e '
     s@clusterIP:.*@clusterIP: 10.254.0.254@ ;

--- a/packer/scripts/install-helm.sh
+++ b/packer/scripts/install-helm.sh
@@ -6,25 +6,4 @@ set -o verbose
 wget -O - https://kubernetes-helm.storage.googleapis.com/helm-v2.6.2-linux-amd64.tar.gz \
     | tar xz -C /usr/local/bin --no-same-owner --strip-components=1 linux-amd64/helm
 
-# Set up RBAC permissions for tiller
-kubectl create -f - <<EOF
-{ "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-  "kind": "ClusterRoleBinding",
-  "metadata": { "name": "permissive-system-accounts" },
-  "roleRef":{
-    "apiGroup": "rbac.authorization.k8s.io",
-    "kind": "ClusterRole",
-    "name": "cluster-admin"
-  },
-  "subjects": [
-    { "apiGroup": "rbac.authorization.k8s.io",
-      "kind": "Group",
-      "name": "system:serviceaccounts:kube-system" },
-    { "kind": "ServiceAccount",
-      "name": "default",
-      "namespace":"kube-system" }
-  ]
-}
-EOF
-
 /usr/local/bin/helm init

--- a/packer/scripts/setup-service-account.sh
+++ b/packer/scripts/setup-service-account.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o errexit -o xtrace
+
+# Set up RBAC permissions for kubedns/tiller
+kubectl create -f - <<EOF
+{ "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+  "kind": "ClusterRoleBinding",
+  "metadata": { "name": "permissive-system-accounts" },
+  "roleRef":{
+    "apiGroup": "rbac.authorization.k8s.io",
+    "kind": "ClusterRole",
+    "name": "cluster-admin"
+  },
+  "subjects": [
+    { "apiGroup": "rbac.authorization.k8s.io",
+      "kind": "Group",
+      "name": "system:serviceaccounts:kube-system" },
+    { "kind": "ServiceAccount",
+      "name": "default",
+      "namespace":"kube-system" }
+  ]
+}
+EOF

--- a/packer/scripts/wait-for-kube.sh
+++ b/packer/scripts/wait-for-kube.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit -o xtrace
+
+echo "Waiting for kube-apiserver to be active..."
+while ! systemctl is-active kube-apiserver.service 2>/dev/null >/dev/null; do
+  sleep 10
+done
+echo "Waiting for kubectl to respond..."
+while ! kubectl get pods --all-namespaces; do
+  sleep 2
+done
+# Due to timing, kube-system may not exist immediately
+while ! kubectl get ns kube-system >& /dev/null; do
+  sleep .1
+done

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -65,7 +65,7 @@
             "ssh_wait_timeout": "{{user `ssh_wait_timeout`}}",
             "shutdown_command": "{{user `shutdown_command`}}",
             "vboxmanage": [
-                [ "modifyvm", "{{.Name}}", "--memory", "1024" ]
+                [ "modifyvm", "{{.Name}}", "--memory", "2048" ]
             ],
             "boot_command": [
                 "<esc><enter><wait>",

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -284,6 +284,8 @@
                 "scripts/install-certstrap.sh",
                 "scripts/usr-local-bin-to-path.sh",
                 "scripts/create-kube-certs.sh",
+                "scripts/wait-for-kube.sh",
+                "scripts/setup-service-account.sh",
                 "scripts/create-kubedns.sh"
             ],
             "start_retry_timeout": "7m"


### PR DESCRIPTION
This just rebuilds the vagrant box, because I already had kube `1.9.6+9f8ebd17` for the cached vagrant box work.  Of course, that comes with issues with actually building the things…

Relevant boxes already uploaded to S3.