### PR TITLE
Enable operator overrides for role capabilities

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -9,7 +9,7 @@ set -o errexit -o nounset
 
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.21.1"
-export FISSILE_VERSION="5.2.0+32.g4c79a2b"
+export FISSILE_VERSION="5.2.0+68.gb06a43d"
 export HELM_VERSION="2.6.2"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"
 export KUBECTL_VERSION="1.8.2"


### PR DESCRIPTION
Ref https://trello.com/c/BxUbBojW/642-5-eks-label-for-specific-pods-that-require-more-privileges-than-default

Ref https://github.com/SUSE/fissile/wiki/Operator-overrides-of-role-capabilities

Controlling fissile PR https://github.com/SUSE/fissile/pull/351
