### PR TITLE
Fix string interpolation in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -595,7 +595,7 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
                         passwordVariable: 'AWS_SECRET_ACCESS_KEY',
                     )]) {
                         script {
-                            def files = findFiles(glob: 'output/scf-${params.USE_SLE_BASE ? "sle" : "opensuse"}-*.zip')
+                            def files = findFiles(glob: "output/scf-${params.USE_SLE_BASE ? "sle" : "opensuse"}-*.zip")
                             def subdir = "${params.S3_PREFIX}${distSubDir()}"
                             def prefix = distPrefix()
 


### PR DESCRIPTION
With single quotes the os part of the glob is not interpolated resulting
in an empty file array and a subsequent build failure.