### PR TITLE
Merge from master as 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [2.9.0] - 2018-05-07
+
+### Added
+- The previous CF/UAA bumps should be considered minor updates, not patch releases, so we will bump this verison in light of the changes in 2.8.1 and rely on this as part of future semver
+
+### Changed
+- Bump PHP buildpack to v4.3.53.1 to address MS-ISAC ADVISORY NUMBER 2018-046
+
+### Fixed
+- Fixed string interpolation issue
+
 ## [2.8.1] - 2018-05-04
 
 ### Added


### PR DESCRIPTION
Based on discussion, any CF bump should mean a minor release version bump. Thus, the past check-in should've already raised the version up, so this tag is for catching up.