### PR TITLE
Jenkins: Don't run `make clean` when tarring up sources

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -530,7 +530,7 @@ pipeline {
                 sh '''
                     set -e +x
                     source ${PWD}/.envrc
-                    make compile-clean
+                    make tar-sources
                 '''
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,9 @@ compile: ${FISSILE_BINARY}
 	make/compile cache
 
 compile-clean: clean ${FISSILE_BINARY} vagrant-prep
+	${MAKE} tar-sources
+
+tar-sources:
 	make/tar-sources
 
 osc-commit-sources:


### PR DESCRIPTION
That kinda kills the output