### PR TITLE
Exclude completed jobs when waiting pods ready in kube 1.9

### DIFF
--- a/make/uaa-wait
+++ b/make/uaa-wait
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset
 
-while ! ( kubectl get pods -n uaa | awk '{ if (match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2]) { print ; exit 1 } }' )
+while ! ( kubectl get pods -n uaa | awk '{ if (match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) { print ; exit 1 } }' )
 do
   sleep 10
 done

--- a/make/wait
+++ b/make/wait
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset
 
-while ! ( kubectl get pods -n "$1" | awk '{ if (match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2]) { print ; exit 1 } }' )
+while ! ( kubectl get pods -n "$1" | awk '{ if (match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) { print ; exit 1 } }' )
 do
   sleep 10
 done


### PR DESCRIPTION
Hi,

This PR fixes [issue 1522](https://github.com/SUSE/scf/issues/1522). 