### PR TITLE
Fetch secret name/key from first matched pod

### DIFF
--- a/make/include/secrets
+++ b/make/include/secrets
@@ -8,11 +8,11 @@ get_secret () {
 
     name="$(kubectl get pods \
 	--namespace "${ns}" \
-	-o jsonpath='{.items[*].spec.containers[?(.name=="'${pod}'")].env[?(.name=="'${ev}'")].valueFrom.secretKeyRef.name}')"
+	-o jsonpath='{.items[*].spec.containers[?(.name=="'${pod}'")].env[?(.name=="'${ev}'")].valueFrom.secretKeyRef.name}' | awk '{ print $1 }')"
 
     key="$(kubectl get pods \
 	--namespace "${ns}" \
-	-o jsonpath='{.items[*].spec.containers[?(.name=="'${pod}'")].env[?(.name=="'${ev}'")].valueFrom.secretKeyRef.key}')"
+	-o jsonpath='{.items[*].spec.containers[?(.name=="'${pod}'")].env[?(.name=="'${ev}'")].valueFrom.secretKeyRef.key}' | awk '{ print $1 }')"
 
     kubectl get secret "${name}" \
 	--namespace "${ns}" \


### PR DESCRIPTION
This PR fixed issue [1528](https://github.com/SUSE/scf/issues/1528).