### PR TITLE
role manifest: Mark rotateable secrets as immutable

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1527,6 +1527,7 @@ configuration:
     required: true
   - name: BBS_ACTIVE_KEY_PASSPHRASE
     secret: true
+    immutable: true
     generator:
       type: Password
     description: The password for access to the diego BBS database.
@@ -1753,6 +1754,7 @@ configuration:
     required: true
   - name: CONSUL_SERVER_ENCRYPT_KEY
     secret: true
+    immutable: true
     generator:
       type: Password
     description: Consul server encryption key


### PR DESCRIPTION
These secrets are things where we need to keep the old value around to decrypt the old data. They need to be kept immutable, until we have a better way of rotating them (plus the CCDB encryption key).

Fixes boo#1092990

Manually checked against the remaining secrets:
```sh
for i in $(
    y2j < container-host-files/etc/scf/config/role-manifest.yml | \
    jq -cSr '
        .configuration.variables[] | 
        select(.secret) | 
        select(.immutable | not) | 
        select(.generator) | 
        select([.generator.type] | inside(["Certificate", "SSH", "CACertificate"]) | not) | 
        .name
    ' )
do
    printf "%b%s%b\n" "\e[0;1;33m" "$i" "\e[0m"
    grep --color=always -w $i container-host-files/etc/scf/config/role-manifest.yml
done | less -R

```