### PR TITLE
fix base64 option for Darwin

### DIFF
--- a/make/include/secrets
+++ b/make/include/secrets
@@ -16,5 +16,5 @@ get_secret () {
 
     kubectl get secret "${name}" \
 	--namespace "${ns}" \
-	-o jsonpath="{.data['${key}']}" | base64 -d -
+	-o jsonpath="{.data['${key}']}" | base64 --decode
 }


### PR DESCRIPTION
The base64 command on Linux.

```
~# base64 --help
Usage: base64 [OPTION]... [FILE]
Base64 encode or decode FILE, or standard input, to standard output.

Mandatory arguments to long options are mandatory for short options too.
  -d, --decode          decode data
  -i, --ignore-garbage  when decoding, ignore non-alphabet characters
  -w, --wrap=COLS       wrap encoded lines after COLS character (default 76).
                          Use 0 to disable line wrapping

      --help     display this help and exit
      --version  output version information and exit
```

The base64 command on Darwin.
```
$ base64 -h
base64: invalid option -- h
Usage:	base64 [-hvD] [-b num] [-i in_file] [-o out_file]
  -h, --help     display this message
  -D, --decode   decodes input
  -b, --break    break encoded string into num character lines
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
```

Let command works on both systems.