### PR TITLE
role-manifest: consul: set min to 0

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -149,7 +149,7 @@ roles:
   tags: [clustered]
   run:
     scaling:
-      min: 1
+      min: 0
       max: 1
       ha: 1
       must_be_odd: true


### PR DESCRIPTION
We don't actually _need_ consul right now, so it should have a minimum of zero.