### PR TITLE
role manifest: postgres: use new volume syntax

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -383,8 +383,9 @@ roles:
       min: 1
       max: 3
       ha: 2
-    persistent-volumes:
+    volumes:
     - path: /var/vcap/store
+      type: persistent
       tag: postgres-data
       size: 20
     memory: 3072


### PR DESCRIPTION
For consistency, and so we can deprecate the old syntax.