### PR TITLE
Verify pod status in pod waiting pharse

### DIFF
--- a/make/uaa-wait
+++ b/make/uaa-wait
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset
 
-while ! ( kubectl get pods -n uaa | awk '{ if (match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) { print ; exit 1 } }' )
+while ! ( kubectl get pods -n uaa | awk '{ if ((match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) || !match($3, /STATUS|Completed|Running/)) { print ; exit 1 } }' )
 do
   sleep 10
 done

--- a/make/wait
+++ b/make/wait
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset
 
-while ! ( kubectl get pods -n "$1" | awk '{ if (match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) { print ; exit 1 } }' )
+while ! ( kubectl get pods -n "$1" | awk '{ if ((match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) || !match($3, /STATUS|Completed|Running/)) { print ; exit 1 } }' )
 do
   sleep 10
 done


### PR DESCRIPTION
Hi,

Our wait/uaa-wait scripts was still not good for check. 

Sometime, pod status like below would stop waiting and continue to deploy process :
```
NAME                        READY     STATUS      RESTARTS   AGE
diego-cell-0              1/1       Terminating 0          5m
```

So I added a condition `((match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) || !match($3, /STATUS|Completed|Running/))` to verify pod status:

1. Condition 1 `(match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)`: verify pods' containers readiness and exclude job pods.
2. Condition 2 `!match($3, /STATUS|Completed|Running/))`: verify pods' status


Please help to review. Thanks!