### PR TITLE
Scripts and assets to automate the deployment of the mysql sidecar helm chart in a vagrant box.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,11 @@ brain:
 cats:
 	make/tests acceptance-tests
 
+########## SIDECAR SERVICE TARGETS ##########
+
+mysql:
+	make/deploy-mysql
+
 ########## UAA LINK TARGETS ##########
 
 uaa-releases:

--- a/make/asg
+++ b/make/asg
@@ -13,7 +13,7 @@ ports="$3"
 echo > "$$-asg.json" \
     "[{ \"destination\": \"${destination}\", \"protocol\": \"tcp\", \"ports\": \"${ports}\" }]"
 
-if cf security-groups | grep "${name}" > /dev/null
+if cf security-group "${name}" > /dev/null
 then
     cf update-security-group "${name}" "$$-asg.json"
 else

--- a/make/asg
+++ b/make/asg
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o nounset -o errexit
+set -o nounset
 
 # Install a TCP application security group
 #

--- a/make/asg
+++ b/make/asg
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -o nounset
+
+# Install a TCP application security group
+#
+# This script is derived from part of
+#	cf-ci:qa-pipelines/tasks/usb-deploy.sh
+
+name="$1"
+destination="$2"
+ports="$3"
+
+echo > "$$-asg.json" \
+    "[{ \"destination\": \"${destination}\", \"protocol\": \"tcp\", \"ports\": \"${ports}\" }]"
+
+if cf security-groups | grep "${name}" > /dev/null
+then
+    cf update-security-group "${name}" "$$-asg.json"
+else
+    cf create-security-group "${name}" "$$-asg.json"
+fi
+
+cf bind-running-security-group "${name}"
+cf bind-staging-security-group "${name}"
+
+rm "$$-asg.json"
+
+exit

--- a/make/asg
+++ b/make/asg
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o nounset
+set -o nounset -o errexit
 
 # Install a TCP application security group
 #

--- a/make/assets/nfs-provisioner/claim.yaml
+++ b/make/assets/nfs-provisioner/claim.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: nfsclaim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "nfspersist"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Mi

--- a/make/assets/nfs-provisioner/class.yaml
+++ b/make/assets/nfs-provisioner/class.yaml
@@ -1,0 +1,5 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: nfspersist
+provisioner: nfs

--- a/make/assets/nfs-provisioner/clusterrole.yaml
+++ b/make/assets/nfs-provisioner/clusterrole.yaml
@@ -1,0 +1,24 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nfs-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get"]
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["nfs-provisioner"]
+    verbs: ["use"]

--- a/make/assets/nfs-provisioner/clusterrolebinding.yaml
+++ b/make/assets/nfs-provisioner/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: run-nfs-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: nfs-provisioner
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: nfs-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/make/assets/nfs-provisioner/deployment.yaml
+++ b/make/assets/nfs-provisioner/deployment.yaml
@@ -1,0 +1,73 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nfs-provisioner
+  labels:
+    app: nfs-provisioner
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+    - name: mountd
+      port: 20048
+    - name: rpcbind
+      port: 111
+    - name: rpcbind-udp
+      port: 111
+      protocol: UDP
+  selector:
+    app: nfs-provisioner
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: nfs-provisioner
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate 
+  template:
+    metadata:
+      labels:
+        app: nfs-provisioner
+    spec:
+      serviceAccount: nfs-provisioner
+      containers:
+        - name: nfs-provisioner
+          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+          ports:
+            - name: nfs
+              containerPort: 2049
+            - name: mountd
+              containerPort: 20048
+            - name: rpcbind
+              containerPort: 111
+            - name: rpcbind-udp
+              containerPort: 111
+              protocol: UDP
+          securityContext:
+            capabilities:
+              add:
+                - DAC_READ_SEARCH
+                - SYS_RESOURCE
+          args:
+            - "-provisioner=nfs"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SERVICE_NAME
+              value: nfs-provisioner
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: export-volume
+              mountPath: /export
+      volumes:
+        - name: export-volume
+          hostPath:
+            path: /var/lib/docker/tmp/nfs

--- a/make/assets/nfs-provisioner/psp.yaml
+++ b/make/assets/nfs-provisioner/psp.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: nfs-provisioner
+spec:
+  fsGroup:
+    rule: RunAsAny
+  allowedCapabilities:
+  - DAC_READ_SEARCH
+  - SYS_RESOURCE
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - secret
+  - hostPath

--- a/make/assets/nfs-provisioner/serviceaccount.yaml
+++ b/make/assets/nfs-provisioner/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfs-provisioner

--- a/make/deploy-mysql
+++ b/make/deploy-mysql
@@ -7,8 +7,8 @@ set -o nounset
 # # ## ### ##### ######## ############# #####################
 ## configuration
 
-NAMESPACE="cf"
-UAA_NAMESPACE="uaa"
+NAMESPACE="${NAMESPACE:-cf}"
+UAA_NAMESPACE="${UAA_NAMESPACE:-uaa}"
 
 USB_PLUGIN_LOCATION="https://github.com/SUSE/cf-usb-plugin/releases/download/1.0.0/cf-usb-plugin-1.0.0.0.g47b49cd-linux-amd64"
 
@@ -21,6 +21,7 @@ DB_EXTERNAL_IP=192.168.77.77
 
 NFS_SCLASS="nfspersist"
 
+PASS="$(kubectl -n scf get secrets secrets -o jsonpath='{.data.cluster-admin-password}' | base64 -d)"
 DOMAIN=$(kubectl get pods -o json --namespace "${NAMESPACE}" api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
 
 # # ## ### ##### ######## ############# #####################
@@ -31,7 +32,7 @@ DOMAIN=$(kubectl get pods -o json --namespace "${NAMESPACE}" api-0 | jq -r '.spe
 # - Need an app security group so that apps using the new service can talk with its instances.
 
 cf api --skip-ssl-validation "https://api.${DOMAIN}"
-cf auth admin changeme
+cf auth admin "${PASS}"
 
 $(dirname $0)/nfs-storageclass
 $(dirname $0)/usb-plugin
@@ -82,7 +83,7 @@ $(dirname $0)/wait mysql
 
 COMMON_SIDECAR_PARAMS=(
   --set "env.CF_ADMIN_USER=admin"
-  --set "env.CF_ADMIN_PASSWORD=changeme"
+  --set "env.CF_ADMIN_PASSWORD=${PASS}"
   --set "env.CF_DOMAIN=${DOMAIN}"
   --set "env.CF_CA_CERT=${CF_CERT}"
   --set "env.UAA_CA_CERT=${UAA_CERT}"

--- a/make/deploy-mysql
+++ b/make/deploy-mysql
@@ -21,7 +21,7 @@ DB_EXTERNAL_IP=192.168.77.77
 
 NFS_SCLASS="nfspersist"
 
-PASS="$(kubectl -n scf get secrets secrets -o jsonpath='{.data.cluster-admin-password}' | base64 -d)"
+PASS="$(kubectl --namespace "${NAMESPACE}" get secrets secrets -o jsonpath='{.data.cluster-admin-password}' | base64 -d)"
 DOMAIN=$(kubectl get pods -o json --namespace "${NAMESPACE}" api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
 
 # # ## ### ##### ######## ############# #####################

--- a/make/deploy-mysql
+++ b/make/deploy-mysql
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -o nounset
+
+# This script is derived from
+#	cf-ci:qa-pipelines/tasks/usb-deploy.sh
+
+# # ## ### ##### ######## ############# #####################
+## configuration
+
+NAMESPACE="cf"
+UAA_NAMESPACE="uaa"
+
+USB_PLUGIN_LOCATION="https://github.com/SUSE/cf-usb-plugin/releases/download/1.0.0/cf-usb-plugin-1.0.0.0.g47b49cd-linux-amd64"
+
+SUSE_REPO="https://kubernetes-charts.suse.com"
+MYSQL_CHART="suse/cf-usb-sidecar-mysql"
+
+# For vagrant the external IP is a fixed value.
+# dig cf-dev.io (We need IP for the ASG later)
+DB_EXTERNAL_IP=192.168.77.77
+
+NFS_SCLASS="nfspersist"
+
+DOMAIN=$(kubectl get pods -o json --namespace "${NAMESPACE}" api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
+
+# # ## ### ##### ######## ############# #####################
+## Preparations
+# - Need a persistent NFS storage class (mysql backend data storage)
+# - Need the cf usb plugin (usb inspection)
+# - Need the SUSE helm repository (mysql sidecar chart)
+# - Need an app security group so that apps using the new service can talk with its instances.
+
+cf api --skip-ssl-validation "https://api.${DOMAIN}"
+cf auth admin changeme
+
+$(dirname $0)/nfs-storageclass
+$(dirname $0)/usb-plugin
+$(dirname $0)/helm-suse-repository
+$(dirname $0)/asg                  k8s-mysql-sidecar-net "${DB_EXTERNAL_IP}/32" "5432,30306"
+
+if ! helm search  "${MYSQL_CHART}" ; then
+    prtinf "%sThe required sidecar chart ${MYSQL_CHART} is missing%s" "\033\[0;31;1m" "\033\[0m"
+    # Should have been in the suse repository, see above.
+    exit 1
+fi
+
+# # ## ### ##### ######## ############# #####################
+
+get_internal_ca_cert() {
+  local generated_secrets_secret=$(kubectl get --namespace ${1} deploy -o json | jq -r '[.items[].spec.template.spec.containers[].env[] | select(.name == "INTERNAL_CA_CERT").valueFrom.secretKeyRef.name] | unique[]')
+  if [[ $(echo $generated_secrets_secret | wc -w) -ne 1 ]]; then
+    echo "Internal cert or secret problem in ${1} namespace"
+    return 1
+  fi
+  kubectl get secret ${generated_secrets_secret} \
+    --namespace "${1}" \
+    -o jsonpath="{.data['internal-ca-cert']}" \
+    | base64 -d
+}
+
+UAA_CERT=$(get_internal_ca_cert "${UAA_NAMESPACE}")
+CF_CERT=$(get_internal_ca_cert "${NAMESPACE}")
+
+# # ## ### ##### ######## ############# #####################
+## mysql database
+
+helm install stable/mysql                   \
+  --name mysql                              \
+  --namespace mysql                         \
+  --set imageTag=5.7.22                     \
+  --set mysqlRootPassword=password          \
+  --set persistence.storageClass="${NFS_SCLASS}" \
+  --set persistence.size=4Gi                \
+  --set service.type=NodePort               \
+  --set service.nodePort=30306              \
+  --set service.port=3306
+
+$(dirname $0)/wait mysql
+
+# # ## ### ##### ######## ############# #####################
+## mysql usb sidecar
+
+COMMON_SIDECAR_PARAMS=(
+  --set "env.CF_ADMIN_USER=admin"
+  --set "env.CF_ADMIN_PASSWORD=changeme"
+  --set "env.CF_DOMAIN=${DOMAIN}"
+  --set "env.CF_CA_CERT=${CF_CERT}"
+  --set "env.UAA_CA_CERT=${UAA_CERT}"
+  --set "kube.registry.hostname=registry.suse.com"
+  --set "kube.organization=cap"
+)
+
+MYSQL_SIDECAR_PARAMS=(
+  --set "env.SERVICE_TYPE=mysql"
+  --set "env.SERVICE_LOCATION=http://cf-usb-sidecar-mysql.mysql-sidecar:8081"
+  --set "env.SERVICE_MYSQL_HOST=${DB_EXTERNAL_IP}"
+  --set "env.SERVICE_MYSQL_PORT=30306"
+  --set "env.SERVICE_MYSQL_USER=root"
+  --set "env.SERVICE_MYSQL_PASS=password"
+)
+
+helm install "${MYSQL_CHART}"  \
+  --name mysql-sidecar         \
+  --namespace mysql-sidecar    \
+  "${MYSQL_SIDECAR_PARAMS[@]}" \
+  "${COMMON_SIDECAR_PARAMS[@]}"
+
+$(dirname $0)/wait mysql-sidecar
+
+# Note: While the driver endpoint should be registered when the
+# sidecar namespace is fully up (indicating that the setup task has
+# completed) it may still take some time before this has passed
+# through all the pieces of CF to become fully known. So, wait a bit
+# more.
+while ! cf usb-driver-endpoints | grep mysql ; do
+    echo "Waiting for driver setup ..."
+    sleep 10
+done
+
+# # ## ### ##### ######## ############# #####################
+## Quick test that the new mysql service is ok.
+
+$(dirname $0)/test-service mysql
+
+exit

--- a/make/deploy-mysql
+++ b/make/deploy-mysql
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o nounset
+set -o nounset -o errexit
 
 # This script is derived from
 #	cf-ci:qa-pipelines/tasks/usb-deploy.sh

--- a/make/helm-suse-repository
+++ b/make/helm-suse-repository
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o nounset
+set -o nounset -o errexit
 
 # This script is derived from part of
 #	cf-ci:qa-pipelines/tasks/usb-deploy.sh

--- a/make/helm-suse-repository
+++ b/make/helm-suse-repository
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o nounset -o errexit
+set -o nounset
 
 # This script is derived from part of
 #	cf-ci:qa-pipelines/tasks/usb-deploy.sh

--- a/make/helm-suse-repository
+++ b/make/helm-suse-repository
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -o nounset
+
+# This script is derived from part of
+#	cf-ci:qa-pipelines/tasks/usb-deploy.sh
+
+# # ## ### ##### ######## ############# #####################
+## configuration
+
+SUSE_REPO="https://kubernetes-charts.suse.com"
+PATTERN="kubernetes-charts\\.suse\\.com"
+
+# # ## ### ##### ######## ############# #####################
+
+# Repository holding the charts for the sidecars
+
+if [ $(helm repo list|grep -c "${PATTERN}") -gt 0 ] ; then
+    printf "%bSUSE helm repository is installed already%b\n" "\033[0;32m" "\033[0m"
+    exit 0
+fi
+
+printf "%bSUSE helm repository required, missing, starting installation ...%b\n" "\033[0;31;1m" "\033[0m"
+
+helm repo add suse "${SUSE_REPO}"
+
+# Check that the repo is now present
+if [ $(helm repo list|grep -c "${PATTERN}") -lt 1 ] ; then
+    printf "%bInstallation of SUSE helm repository failed%b\n" "\033[0;31;1m" "\033[0m"
+    exit 1
+fi
+
+helm repo update
+printf "%bUSE helm repository is now installed%b\n" "\033[0;32m" "\033[0m"
+exit 0

--- a/make/nfs-storageclass
+++ b/make/nfs-storageclass
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o nounset -o errexit
+set -o nounset
 
 # Install the nfs-provisioner and adjunct definitions for persistent
 # nfs storage class.

--- a/make/nfs-storageclass
+++ b/make/nfs-storageclass
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -o nounset
+
+# Install the nfs-provisioner and adjunct definitions for persistent
+# nfs storage class.
+#
+# This script is derived from part of
+#	cf-ci:qa-pipelines/tasks/usb-deploy.sh
+
+# # ## ### ##### ######## ############# #####################
+## configuration
+
+NFS_SCLASS="nfspersist"
+
+# # ## ### ##### ######## ############# #####################
+
+PROVISIONER=$(kubectl get storageclasses "${NFS_SCLASS}" -o "jsonpath={.provisioner}")
+
+if [[ ${PROVISIONER} == "nfs" ]]; then
+    printf "%bNFS provisioner and storage class are installed already%b\n" "\033[0;32m" "\033[0m"
+    exit 0
+fi
+
+printf "%bNFS provisioner and storage class required, missing, starting installation%b\n" "\033[0;31;1m" "\033[0m"
+
+SC="$(dirname $0)/assets/nfs-provisioner"
+kubectl create -f "${SC}"
+
+printf "%bWaiting for the NFS provisioner to be online...%b\n" "\033[0;32m" "\033[0m"
+sleep 10
+# Wait for default:nfs-provisioner to run properly
+$(dirname $0)/wait default
+
+# Check that the class is now present
+PROVISIONER=$(kubectl get storageclasses "${NFS_SCLASS}" -o "jsonpath={.provisioner}")
+
+if [[ ${PROVISIONER} != "nfs" ]]; then
+    printf "%bInstallation of NFS storageclass failed%b\n" "\033[0;31;1m" "\033[0m"
+    exit 1
+fi
+
+# Ensure "${NFS_SCLASS}" is the only default storageclass
+for sc in $(kubectl get storageclass | tail -n+2 | cut -f1 -d ' '); do
+  kubectl patch storageclass ${sc} -p '
+    {
+      "metadata": {
+        "annotations": {
+          "storageclass.kubernetes.io/is-default-class":
+            "'$([[ $sc == "${NFS_SCLASS}" ]] && echo true || echo false)'"
+        }
+      }
+    }
+  '
+done
+
+printf "%bNFS provisioner and storage class are now installed%b\n" "\033[0;32m" "\033[0m"
+exit

--- a/make/nfs-storageclass
+++ b/make/nfs-storageclass
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o nounset
+set -o nounset -o errexit
 
 # Install the nfs-provisioner and adjunct definitions for persistent
 # nfs storage class.

--- a/make/test-service
+++ b/make/test-service
@@ -9,14 +9,15 @@ service="$1"
 # This script is derived from part of
 #	cf-ci:qa-pipelines/tasks/usb-deploy.sh
 
-NAMESPACE="cf"
+NAMESPACE="${NAMESPACE:-cf}"
 
+PASS="$(kubectl -n scf get secrets secrets -o jsonpath='{.data.cluster-admin-password}' | base64 -d)"
 DOMAIN=$(kubectl get pods -o json --namespace "${NAMESPACE}" api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
 
 # # ## ### ##### ######## ############# #####################
 
 cf api --skip-ssl-validation "https://api.${DOMAIN}"
-cf auth admin changeme
+cf auth admin "${PASS}"
 
 ## Note: We need a targeted space for marketplace and the other
 ## service operations to work.

--- a/make/test-service
+++ b/make/test-service
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o nounset -o errexit
+set -o nounset
 
 service="$1"
 
@@ -11,7 +11,7 @@ service="$1"
 
 NAMESPACE="${NAMESPACE:-cf}"
 
-PASS="$(kubectl -n scf get secrets secrets -o jsonpath='{.data.cluster-admin-password}' | base64 -d)"
+PASS="$(kubectl --namespace "${NAMESPACE}" get secrets secrets -o jsonpath='{.data.cluster-admin-password}' | base64 -d)"
 DOMAIN=$(kubectl get pods -o json --namespace "${NAMESPACE}" api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
 
 # # ## ### ##### ######## ############# #####################

--- a/make/test-service
+++ b/make/test-service
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -o nounset
+
+service="$1"
+
+# Test that a named service is visible and that we can create
+# instances for it.
+#
+# This script is derived from part of
+#	cf-ci:qa-pipelines/tasks/usb-deploy.sh
+
+NAMESPACE="cf"
+
+DOMAIN=$(kubectl get pods -o json --namespace "${NAMESPACE}" api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
+
+# # ## ### ##### ######## ############# #####################
+
+cf api --skip-ssl-validation "https://api.${DOMAIN}"
+cf auth admin changeme
+
+## Note: We need a targeted space for marketplace and the other
+## service operations to work.
+
+cf create-org      "${service}-test-org"
+cf create-space -o "${service}-test-org"    "${service}-test-space"
+cf target       -o "${service}-test-org" -s "${service}-test-space"
+
+echo
+printf "%bChecking marketplace for '$service'%b\n" "\033[0;32m" "\033[0m"
+cf marketplace | grep "${service}"
+sleep 1
+echo
+
+cf create-service "${service}" default "${service}-test"
+sleep 1
+
+echo
+printf "%bChecking services for '${service}-test'%b\n" "\033[0;32m" "\033[0m"
+cf services | grep "${service}-test"
+sleep 1
+echo
+
+cf delete-service -f "${service}-test"
+cf delete-space   -f "${service}-test-space"
+cf delete-org     -f "${service}-test-org"
+
+exit

--- a/make/test-service
+++ b/make/test-service
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o nounset
+set -o nounset -o errexit
 
 service="$1"
 

--- a/make/usb-plugin
+++ b/make/usb-plugin
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -o nounset
+
+# Install the suse usb plugin, if needed.
+#
+# This script is derived from part of
+#	cf-ci:qa-pipelines/tasks/usb-deploy.sh
+
+# # ## ### ##### ######## ############# #####################
+## configuration
+
+NAMESPACE="cf"
+
+USB_PLUGIN_LOCATION="https://github.com/SUSE/cf-usb-plugin/releases/download/1.0.0/cf-usb-plugin-1.0.0.0.g47b49cd-linux-amd64"
+
+# # ## ### ##### ######## ############# #####################
+## Install usb plugin, we will need it when remvoing the sidecar again.
+
+if [ $(cf plugins|grep -c usb-info) -gt 0 ] ; then
+    printf "%bCF usb plugin is installed already%b\n" "\033[0;32m" "\033[0m"
+    exit 0
+fi
+
+printf "%bCF usb plugin required, missing, starting installation ...%b\n" "\033[0;31;1m" "\033[0m"
+
+DOMAIN=$(kubectl get pods -o json --namespace "${NAMESPACE}" api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
+
+cf api --skip-ssl-validation "https://api.${DOMAIN}"
+cf auth admin changeme
+
+wget -O cf-usb-plugin "${USB_PLUGIN_LOCATION}"
+
+chmod u+x            ./cf-usb-plugin
+cf install-plugin -f ./cf-usb-plugin
+rm -f                ./cf-usb-plugin
+
+# Check that the plugin is now present
+if [ $(cf plugins|grep -c usb-info) -lt 1 ] ; then
+    printf "%bInstallation of CF usb plugin failed%b\n" "\033[0;31;1m" "\033[0m"
+    exit 1
+fi
+
+cf usb-target
+cf usb-info
+
+printf "%bCF usb plugin is now installed%b\n" "\033[0;32m" "\033[0m"
+exit

--- a/make/usb-plugin
+++ b/make/usb-plugin
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o nounset -o errexit
+set -o nounset
 
 # Install the suse usb plugin, if needed.
 #
@@ -23,7 +23,7 @@ fi
 
 printf "%bCF usb plugin required, missing, starting installation ...%b\n" "\033[0;31;1m" "\033[0m"
 
-PASS="$(kubectl -n scf get secrets secrets -o jsonpath='{.data.cluster-admin-password}' | base64 -d)"
+PASS="$(kubectl --namespace "${NAMESPACE}" get secrets secrets -o jsonpath='{.data.cluster-admin-password}' | base64 -d)"
 DOMAIN=$(kubectl get pods -o json --namespace "${NAMESPACE}" api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
 
 cf api --skip-ssl-validation "https://api.${DOMAIN}"

--- a/make/usb-plugin
+++ b/make/usb-plugin
@@ -9,7 +9,7 @@ set -o nounset
 # # ## ### ##### ######## ############# #####################
 ## configuration
 
-NAMESPACE="cf"
+NAMESPACE="${NAMESPACE:-cf}"
 
 USB_PLUGIN_LOCATION="https://github.com/SUSE/cf-usb-plugin/releases/download/1.0.0/cf-usb-plugin-1.0.0.0.g47b49cd-linux-amd64"
 
@@ -23,10 +23,11 @@ fi
 
 printf "%bCF usb plugin required, missing, starting installation ...%b\n" "\033[0;31;1m" "\033[0m"
 
+PASS="$(kubectl -n scf get secrets secrets -o jsonpath='{.data.cluster-admin-password}' | base64 -d)"
 DOMAIN=$(kubectl get pods -o json --namespace "${NAMESPACE}" api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
 
 cf api --skip-ssl-validation "https://api.${DOMAIN}"
-cf auth admin changeme
+cf auth admin "${PASS}"
 
 wget -O cf-usb-plugin "${USB_PLUGIN_LOCATION}"
 

--- a/make/usb-plugin
+++ b/make/usb-plugin
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o nounset
+set -o nounset -o errexit
 
 # Install the suse usb plugin, if needed.
 #


### PR DESCRIPTION
Ref https://trello.com/c/UMCUmJUf/700-vagrant-service-automation-mysql

Similar to usb-deploy.sh in the qa-pipelines of cf-ci.
Differences:
- mysql only
- Various pre/post tasks factored into their own scripts.
