### PR TITLE
With go/ruby buildpcks updated, switch CATs back to upstream.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -75,7 +75,7 @@
 	url = https://github.com/SUSE/cf-java-buildpack-release.git
 [submodule "src/scf-release/src/github.com/cloudfoundry/cf-acceptance-tests"]
 	path = src/scf-release/src/github.com/cloudfoundry/cf-acceptance-tests
-	url = https://github.com/andreas-kupries/cf-acceptance-tests.git
+	url = https://github.com/cloudfoundry/cf-acceptance-tests.git
 [submodule "src/cf-syslog-drain-release"]
 	path = src/cf-syslog-drain-release
 	url = https://github.com/cloudfoundry/cf-syslog-drain-release.git


### PR DESCRIPTION

- Local vagrant had lots of :cat: failures (76)
- While one of them was for the test of interest it looks to be a timeout waiting for things to get ready. Not the actual condition of interest.
- While will redo locally, also made the PR to run :cat: via jenkins.

The redo went down to 3 failures, none of which are about the buildpacks.
So, we can switch back, the updated go/ruby buildpacks pass the new tests now.




