### PR TITLE
Jenkinsfile: email notification on build failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,6 +207,12 @@ pipeline {
             defaultValue: '',
             description: 'Extra labels for Jenkins slave selection',
         )
+        credentials(
+            name: 'NOTIFICATION_EMAIL',
+            description: 'E-mail address to send failure notifications to; mail will not be sent for PRs',
+            defaultValue: 'cred-scf-email-notification',
+            required: false,
+        )
     }
 
     environment {
@@ -615,6 +621,36 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
                             echo "Create a cap release using this link: https://cap-release-tool.suse.de/?release_archive_url=${encodedCapBundleUri}&SOURCE_BUILD=${encodedBuildUri}"
                             echo "Open a Pull Request for the helm repository using this link: http://jenkins-new.howdoi.website/job/helm-charts/parambuild?CAP_BUNDLE=${encodedCapBundleUri}&SOURCE_BUILD=${encodedBuildUri}"
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        // Send mail, but only if we're develop or master
+        failure {
+            script {
+                if ((params.NOTIFICATION_EMAIL != null) && (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME == 'master')) {
+                    try {
+                        withCredentials([string(credentialsId: params.NOTIFICATION_EMAIL, variable: 'NOTIFICATION_EMAIL')]) {
+                            mail(
+                                subject: "Jenkins failure: ${env.JOB_NAME} #${env.BUILD_ID}",
+                                from: env.NOTIFICATION_EMAIL,
+                                to: env.NOTIFICATION_EMAIL,
+                                body: ("""
+                                Jenkins build failed: ${env.JOB_NAME} on branch ${env.BRANCH_NAME} after ${currentBuild.durationString}
+
+                                See logs on ${currentBuild.absoluteUrl}console
+                                """).toString().replaceAll('\n[ \t]*', '\n'),
+                            )
+                        }
+                        echo 'Build failure notification mail sent'
+                    } catch (e) {
+                        // Jenkins normally doesn't catch any exceptions here; catch it manually so we can see when
+                        // there is an error with the mail queuing.  Note that succeeding past this does not mean
+                        // the mail was successfully delivered.
+                        echo "${e}"
                     }
                 }
             }


### PR DESCRIPTION
Sample message:

```
Return-path: <notifications@example.invalid>
Received: from jenkins.example.invalid (localhost [127.0.0.1])
	by localhost (Postfix) with ESMTP id 675A022A74
	for <notifications@example.invalid>; Tue,  5 Jun 2018 20:39:27 +0000 (UTC)
Date: Tue, 5 Jun 2018 20:39:27 +0000 (UTC)
From: notifications@example.invalid
To: notifications@example.invalid
Message-ID: <1398547267.17.1528231167421.JavaMail.jenkins@ip-192-0-2-55>
Subject: Jenkins failure: scf/PR-1576 #29
MIME-Version: 1.0
Content-Type: multipart/mixed; 
	boundary="----=_Part_16_281734322.1528231167420"

------=_Part_16_281734322.1528231167420
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 7bit


Jenkins build failed: scf/PR-1576 on branch PR-1576 after 4.5 sec and counting

See logs on https://jenkins.example.invalid/job/scf/job/PR-1576/29//console

------=_Part_16_281734322.1528231167420--
```