### PR TITLE
Bump the CF version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,9 @@ bump instructions in the [UAA README](src/uaa-fissile-release/README.md).
 
 1. Test the release by running the `make <release-name>-release compile images run` command.
 
+1. Before committing the tested release update the line
+   `export CF_VERSION=...` in `bin/common/version.sh` to the new CF version.
+
 ### Can I suspend or resume my vagrant VM?
 
 1. Run the `vagrant reload` command.

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -35,7 +35,7 @@ export GOLANG_VERSION=1.7
 
 # Used in: make/include/versioning
 
-export CF_VERSION=1.15.0
+export CF_VERSION=1.36.0
 
 # Show versions, if called on its own.
 # # ## ### ##### ######## ############# #####################


### PR DESCRIPTION
Forgotten during the actual bump of the sources. 
Updated instructions in the README.md
