### PR TITLE
Replace `make/uaa-wait` with `make/wait uaa`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ ${FISSILE_BINARY}: bin/dev/install_tools.sh bin/common/versions.sh
 
 run:
 	make/uaa-run
-	make/uaa-wait
+	make/wait uaa
 	make/run
 
 upgrade:
 	make/uaa-upgrade
-	make/uaa-wait
+	make/wait uaa
 	make/upgrade
 
 wait:
@@ -89,7 +89,7 @@ uaa-run:
 	make/uaa-run
 
 uaa-wait:
-	make/uaa-wait
+	make/wait uaa
 
 uaa-stop:
 	make/uaa-stop

--- a/make/uaa-wait
+++ b/make/uaa-wait
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit -o nounset
-
-while ! ( kubectl get pods -n uaa | awk '{ if ((match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) || !match($3, /STATUS|Completed|Running/)) { print ; exit 1 } }' )
-do
-  sleep 10
-done


### PR DESCRIPTION
The scripts are virtually identical, except wait-uaa has the namespace hardcoded in it. The Makefile already uses `make/wait uaa` in other places, so get rid of this duplication.