### PR TITLE
Changes to make it easier to run a subset of 🐱

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,14 +380,19 @@ To exclude the bundled tests match against names starting with 3 digits followed
 
 #### How do I run a subset of Cloud Foundry acceptance tests?
 
-Deploy `acceptance-tests` after modifying the environment block to include `CATS_SUITES=-suite,+suite`.    Each suite is
-separated by a comma.    The modifiers apply until the next modifier is seen, and have the following meanings:
+Run `make/tests acceptance-tests env.CATS_SUITES="-suite,+suite" env.CATS_FOCUS="regular expression"`
+directly.  Each suite is separated by a comma.  The modifiers apply until the next modifier is seen,
+and have the following meanings:
 
 Modifier | Meaning
 --- | ---
 `+` | Enable the following suites
 `-` | Disable the following suites
 `=` | Disable all suites, and enable the following suites
+
+The `CATS_FOCUS` parameter is passed to [ginkgo] as a `-focus` parameter.
+
+[ginkgo]: http://onsi.github.io/ginkgo/#the-ginkgo-cli
 
 ### `fissile` refuses to create images that already exist. How do I recreate images?
 

--- a/bin/kube_overrides.rb
+++ b/bin/kube_overrides.rb
@@ -1,7 +1,7 @@
 require 'yaml'
 require 'json'
 
-namespace, domain, kube_config = ARGV
+namespace, domain, kube_config = ARGV.shift(3)
 
 configmap = %x(kubectl get configmap secrets-config --namespace #{namespace} -o json)
 configmap = JSON.parse(configmap)['data']
@@ -12,6 +12,12 @@ secrets = JSON.parse(secrets)['data']
 
 generated = %x(kubectl get secret #{current_secrets_name} --namespace #{namespace} -o json)
 generated = JSON.parse(generated)['data']
+
+overrides = Hash.new
+ARGV.each do |arg|
+  k, v = arg.split('=', 2)
+  overrides[k.split('.')] = v
+end
 
 obj = YAML.load_file(kube_config)
 obj['spec']['containers'].each do |container|
@@ -35,6 +41,28 @@ obj['spec']['containers'].each do |container|
       name = env['name'].downcase.gsub('_', '-')
       if generated.has_key?(name) && (secrets[name].nil? || secrets[name].empty?)
         env['valueFrom']['secretKeyRef']['name'] = current_secrets_name
+      end
+    end
+    overrides.each do |k, v|
+      child = container
+      k[0...-1].each do |elem|
+        child[elem] ||= {}
+        child = child[elem]
+      end
+      case child
+      when Array
+        # Deal with the environment list specially
+        child.reject! do |elem|
+          elem['name'] == k.last
+        end
+        child << {
+          'name'  => k.last,
+          'value' => v,
+        }
+      when Hash
+        child[k.last] = v
+      else
+        raise ArgumentError, "Don't know how to deal with a #{child.class} from #{k}"
       end
     end
   end

--- a/make/tests
+++ b/make/tests
@@ -8,6 +8,7 @@ if [ ! -f "output/kube/bosh-task/${POD_NAME}.yaml" ]; then
     echo 1>&2 There is no bosh-task for "${POD_NAME}".
     exit 1
 fi
+shift
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 METRICS="${GIT_ROOT}/scf_metrics.csv"
@@ -51,7 +52,7 @@ done
 # actual name as pulled from the cluster under test.
 
 CONFIG=$(mktemp)
-ruby bin/kube_overrides.rb "${NAMESPACE}" "${DOMAIN:-}" "output/kube/bosh-task/${POD_NAME}.yaml" > "${CONFIG}"
+ruby bin/kube_overrides.rb "${NAMESPACE}" "${DOMAIN:-}" "output/kube/bosh-task/${POD_NAME}.yaml" "$@" > "${CONFIG}"
 
 remove_test_config () { rm "${CONFIG}" ; }
 trap remove_test_config EXIT

--- a/src/scf-release/jobs/acceptance-tests/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests/templates/run.erb
@@ -41,10 +41,14 @@ skips=
 
 verbose=<%= properties.acceptance_tests.verbose ? "-v" : "" %>
 noColorFlag=<%= properties.acceptance_tests.enable_color ? "" : "-noColor" %>
+focus=()
+if test -n "${CATS_FOCUS:-}" ; then
+  focus=( -focus "${CATS_FOCUS}" )
+fi
 
 set +e
 bin/test -r $noColorFlag -slowSpecThreshold=120 -randomizeAllSpecs $verbose \
-  -nodes=$nodes -skipPackage=helpers $skips -keepGoing \
+  -nodes=$nodes -skipPackage=helpers $skips -keepGoing "${focus[@]}" \
   > >( tee /var/vcap/sys/log/acceptance_tests.log ) \
   2> /var/vcap/sys/log/acceptance_tests.err.log
 EXITSTATUS=$?


### PR DESCRIPTION
These changes make it easier to run a subset of :cat: in order to attempt to reproduce failures.

Usage:
`make/tests acceptance-tests env.CATS_SUITES="=v3" env.CATS_FOCUS="health"`