### PR TITLE
Add ROUTER_TLS_PEM structured property

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -9,7 +9,7 @@ set -o errexit -o nounset
 
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.21.1"
-export FISSILE_VERSION="5.3.0+3.g2deff2f"
+export FISSILE_VERSION="5.3.0+12.g64ec547"
 export HELM_VERSION="2.9.1"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"
 export KUBECTL_VERSION="1.9.6"

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2319,7 +2319,7 @@ configuration:
       value_type: certificate
       subject_names:
       - "*.{{.DOMAIN}}"
-    description: The public ssl cert for ssl termination.
+    description: The public ssl cert for ssl termination. Will be ignored if ROUTER_TLS_PEM is set.
     required: true
   - name: ROUTER_SSL_KEY
     secret: true
@@ -2327,7 +2327,7 @@ configuration:
       id: router_cert
       type: Certificate
       value_type: private_key
-    description: The private ssl key for ssl termination.
+    description: The private ssl key for ssl termination. Will be ignored if ROUTER_TLS_PEM is set.
     required: true
   - name: ROUTER_STATUS_PASSWORD
     secret: true
@@ -2336,6 +2336,18 @@ configuration:
       type: Password
     description: Password for HTTP basic auth to the varz/status endpoint.
     required: true
+  - name: ROUTER_TLS_PEM
+    description: Array of private keys and certificates used for TLS handshakes with downstream clients. Each element in the array is an object containing fields 'private_key' and 'cert_chain', each of which supports a PEM block. This setting overrides ROUTER_SSL_CERT and ROUTER_SSL_KEY.
+    example: |
+      - cert_chain: |
+          -----BEGIN CERTIFICATE-----
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----
+          -----END CERTIFICATE-----
+        private_key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          -----END RSA PRIVATE KEY-----
+    secret: true
   - name: SCF_LOG_HOST
     internal: true
     description: The log destination to talk to. This has to point to a syslog server.
@@ -2808,7 +2820,7 @@ configuration:
     properties.router.logging_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
     properties.router.route_services_secret: '"((ROUTER_SERVICES_SECRET))"'
     properties.router.status.password: '"((ROUTER_STATUS_PASSWORD))"'
-    properties.router.tls_pem: '[{cert_chain: "((ROUTER_SSL_CERT))", private_key: "((ROUTER_SSL_KEY))"}]'
+    properties.router.tls_pem: '((#ROUTER_TLS_PEM))((ROUTER_TLS_PEM))((/ROUTER_TLS_PEM))((^ROUTER_TLS_PEM))[{cert_chain: "((ROUTER_SSL_CERT))", private_key: "((ROUTER_SSL_KEY))"}]((/ROUTER_TLS_PEM))'
     properties.routing_api.locket.api_location: '"diego-locket.((KUBERNETES_NAMESPACE)):8891"'
     properties.routing_api.locket.ca_cert: '"((INTERNAL_CA_CERT))"'
     properties.routing_api.locket.client_cert: '"((DIEGO_CLIENT_CERT))"'

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2299,6 +2299,9 @@ configuration:
   - name: ROUTER_BALANCING_ALGORITHM
     default: 'round-robin'
     description: The algorithm used by the router to distribute requests for a route across backends. Supported values are round-robin and least-connection.
+  - name: ROUTER_CLIENT_CERT_VALIDATION
+    description: How to handle client certificates. Supported values are none, request, or require. See https://docs.cloudfoundry.org/adminguide/securing-traffic.html#gorouter_mutual_auth for more information.
+    default: request
   - name: ROUTER_FORWARDED_CLIENT_CERT
     default: 'always_forward'
     description: How to handle the x-forwarded-client-cert (XFCC) HTTP header. Supported values are always_forward, forward, and sanitize_set. See https://docs.cloudfoundry.org/concepts/http-routing.html for more information.
@@ -2798,6 +2801,7 @@ configuration:
     properties.nfsv3driver.log_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
     properties.opensuse42-rootfs.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))"'
     properties.router.balancing_algorithm: '"((ROUTER_BALANCING_ALGORITHM))"'
+    properties.router.client_cert_validation: '"((ROUTER_CLIENT_CERT_VALIDATION))"'
     properties.router.dns_health_check_host: '"((DNS_HEALTH_CHECK_HOST))"'
     properties.router.force_forwarded_proto_https: ((FORCE_FORWARDED_PROTO_AS_HTTPS))
     properties.router.forwarded_client_cert: "((ROUTER_FORWARDED_CLIENT_CERT))"


### PR DESCRIPTION
It is an alternative (and overrides) ROUTER_SSL_CERT (and KEY) and allows specification of multiple cert/key pairs.