### PR TITLE
Don't specify limits for tests

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1436,8 +1436,6 @@ roles:
       max: 1
     flight-stage: manual
     capabilities: []
-    memory: 144
-    virtual-cpus: 2
     exposed-ports: []
 - name: acceptance-tests
   type: bosh-task
@@ -1458,8 +1456,6 @@ roles:
       max: 1
     flight-stage: manual
     capabilities: []
-    memory: 876
-    virtual-cpus: 2
     exposed-ports: []
   configuration:
     templates:
@@ -1481,8 +1477,6 @@ roles:
       max: 1
     flight-stage: manual
     capabilities: []
-    memory: 1024
-    virtual-cpus: 2
     exposed-ports: []
 - name: secret-generation
   type: bosh-task


### PR DESCRIPTION
This ends up generating resource requests for the static kube files,
which prevents them from running on Azure, etc. They can't be disabled
from a command line option like the helm charts can.