### PR TITLE
Set persistent storage class as default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -429,7 +429,7 @@ pipeline {
                     fi
 
                     kubectl delete storageclass hostpath || /bin/true
-                    kubectl create -f - <<< '{"kind":"StorageClass","apiVersion":"storage.k8s.io/v1","metadata":{"name":"hostpath"},"provisioner":"kubernetes.io/host-path"}'
+                    kubectl create -f - <<< '{"kind":"StorageClass","apiVersion":"storage.k8s.io/v1","metadata":{"name":"hostpath","annotations":{"storageclass.kubernetes.io/is-default-class":"true"}},"provisioner":"kubernetes.io/host-path"}'
 
                     # Unzip the bundle
                     rm -rf output/unzipped


### PR DESCRIPTION
Note that https://github.com/SUSE/uaa-fissile-release/pull/112 is the real PR and this should point to UAA master again after it's merged.