### PR TITLE
Fix internal ca key exposed

### DIFF
--- a/bin/config-validator.rb
+++ b/bin/config-validator.rb
@@ -340,7 +340,8 @@ def check_rm_variables(manifest)
   end
 
   manifest['configuration']['variables'].each do |variable|
-    next if Common.special_use(variable['name'])
+    # "internal" variables are defined but not used in the role manifest. They are referenced directly in scripts.
+    next if variable['internal']
     found = templates.any? do |template|
       Common.parameters_in_template(template).include?(variable['name'])
     end

--- a/bin/vagrant-setup/common.rb
+++ b/bin/vagrant-setup/common.rb
@@ -209,16 +209,6 @@ class Common
     ).include? key
   end
 
-  def self.special_use(key)
-    # Detect env var keys that are special (they are defined, but not
-    # used in the role-manifest. They are needed and used in scripts).
-    %w(
-      SCF_LOG_HOST
-      SCF_LOG_PORT
-      SCF_LOG_PROTOCOL
-    ).include? key
-  end
-
   def product_version
     return @product_version if @product_version
     product_version = open("#{@scf_root_dir}/VERSION").read.strip

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -3267,7 +3267,9 @@ configuration:
     ip: '"((IP_ADDRESS))"'
     networks.default.dns_record_name: '"((#KUBE_COMPONENT_NAME))((KUBE_COMPONENT_NAME))((/KUBE_COMPONENT_NAME))((^KUBE_COMPONENT_NAME))((DNS_RECORD_NAME))((/KUBE_COMPONENT_NAME))"'
     networks.default.ip: '"((IP_ADDRESS))"'
-    properties.acceptance_tests.admin_password: '"((CLUSTER_ADMIN_PASSWORD))"'
+    # We include INTERNAL_CA_KEY here so validation doesn't complain that it's not being used.
+    # we can't make it internal, as that exposes it everywhere. The acceptance tests are not used at runtime so it's safe.
+    properties.acceptance_tests.admin_password: '"((CLUSTER_ADMIN_PASSWORD))"((#INTERNAL_CA_KEY))((/INTERNAL_CA_KEY))'
     properties.acceptance_tests.api: '"api.((DOMAIN))"'
     properties.acceptance_tests.apps_domain: '"((DOMAIN))"'
     properties.acceptance_tests_brain.domain: '"((DOMAIN))"'
@@ -3725,7 +3727,7 @@ configuration:
     properties.scalablesyslog.scheduler.tls.client.ca: '"((INTERNAL_CA_CERT))"'
     properties.scalablesyslog.scheduler.tls.client.cert: '"((SYSLOG_SCHED_CERT))"'
     properties.scalablesyslog.scheduler.tls.client.key: '"((SYSLOG_SCHED_KEY))"'
-    properties.scf.internal-ca-cert: '"((INTERNAL_CA_CERT))((#INTERNAL_CA_KEY))((/INTERNAL_CA_KEY))"'
+    properties.scf.internal-ca-cert: '"((INTERNAL_CA_CERT))"'
     properties.scf.uaa.internal-url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
     properties.scf.uaa.root-zone.url: https://((UAA_HOST)):((UAA_PORT))
     properties.scf_set_proxy.running_http_proxy: '"((HTTP_PROXY))"'


### PR DESCRIPTION
`env | grep CA_KEY` doesn't return the key in the pods anymore. My `api-0` didn't come up when testing this because monit wasn't running in the container but it could be a random (irrelevant) issue. Let's wait for CI to see if it is all green.