### PR TITLE
Fix get_package_version_list for Final releases

### DIFF
--- a/make/compile
+++ b/make/compile
@@ -9,7 +9,7 @@ STEMCELL_HASH="$(echo -n "${FISSILE_STEMCELL}" | sha1sum | awk '{ print $1 }')"
 
 # Return a list of desired packages with their versions, as in package/00000000
 _get_package_version_list() {
-    fissile show release | grep -v 'Dev release' | grep -F '(' | cut -d: -f1 | sort -u | while read package hash ; do
+    fissile show release | grep -vE '(Dev|Final) release' | grep -F '(' | cut -d: -f1 | sort -u | while read package hash ; do
         hash=$(echo "${hash}" | tr -c -d 0-9a-f)
         echo "${package}/${hash}"
     done


### PR DESCRIPTION
Extend `grep` in `get_package_version_list` function of `make/compile` to exclude heading lines for Final and Dev releases. The change of the output was introduced by https://github.com/SUSE/fissile/pull/339.

Trying to keep the change as compact as possible, only the `grep` was modified. However, based on the output `fissile` generates, it could very well be that the `cut -d: -f1` part became obsolete.