### PR TITLE
Fix passing regex parameters for INCLUDE/EXCLUDE brain test options

### DIFF
--- a/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
@@ -16,6 +16,7 @@ for i in "${ASSETS}/plugins/"*; do
     cf install-plugin -f "$i" > /dev/null
     # -f forces install without requiring confirmation.
 done
+shopt -u nullglob
 
 PARAM="--timeout 600 --verbose"
 


### PR DESCRIPTION
This is required to avoid shell expansion of glob patterns, that would then collapse to nothing, for example in:

    make/tests acceptance-tests-brain "env.INCLUDE=00[12]"