### PR TITLE
Implement a better mechanism for waiting on mysql.

### DIFF
--- a/src/scf-release/packages/acceptance-tests-brain/packaging
+++ b/src/scf-release/packages/acceptance-tests-brain/packaging
@@ -78,3 +78,7 @@ mv "${BOSH_COMPILE_TARGET}/github.com" "${BOSH_COMPILE_TARGET}/src/github.com"
 
 # We currently have no way of getting a valid version number, as we have no git repo
 GOBIN="${BIN_DIR}" go install -ldflags="-X main.version=0.0.0" github.com/SUSE/testbrain
+
+# Install the mysql client into the package
+zypper install -y mariadb-client
+cp /usr/bin/mysql ${BIN_DIR}

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/008_cf_usb_test.sh
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/008_cf_usb_test.sh
@@ -38,17 +38,17 @@ function get_port
     echo "${port}"
 }
 
-function wait_on_port
+function wait_on_database
 {
-    endpoint="${CF_TCP_DOMAIN}:${1}"
+    # args = port user password
     for (( i = 0; i < 60 ; i++ )) ; do
-	if curl --fail -s -o /dev/null "${endpoint}" ; then
+	if mysql -u"${2}" -p"${3}" -P "${1}" -h "${CF_TCP_DOMAIN}" > /dev/null ; then
             break
 	fi
 	sleep 5
     done
     # Last try, any error will abort the test
-    curl "${endpoint}"
+     mysql -u"${2}" -p"${3}" -P "${1}" -h "${CF_TCP_DOMAIN}"
 }
 
 ## # # ## ### Tracing and common configuration ### ## # #
@@ -160,8 +160,7 @@ cf set-env   "${SERVER_APP}" MYSQL_ROOT_HOST '%'
 cf start     "${SERVER_APP}"
 
 MYSQL_PORT="$(get_port mysql)"
-
-wait_on_port "${MYSQL_PORT}"
+wait_on_database "${MYSQL_PORT}" "${MYSQL_USER}" "${MYSQL_PASS}"
 
 ## --(2)-- Create and configure the mysql client sidecar for usb.
 


### PR DESCRIPTION
Ref: https://trello.com/c/nG2H79ig/743-cf-usb-exit-with-panic-during-brain-test-after-upgrade-from-2101-2110

- Installing the mysql client in the testbrain package.
- Using the client to wait for the database to become ready.
- Note, dropped `wait_on_port` using `curl`.
  The new `wait_on_database` using `mysql` is enough.