### PR TITLE
acceptance-tests-brain: don't move things in ${BOSH_COMPILE_TARGET}

### DIFF
--- a/src/scf-release/packages/acceptance-tests-brain/packaging
+++ b/src/scf-release/packages/acceptance-tests-brain/packaging
@@ -68,14 +68,15 @@ rm \
 # # ## ### ##### ######## test brain itself
 
 export GOROOT=$(readlink -nf /var/vcap/packages/golang1.10)
-export GOPATH=${BOSH_COMPILE_TARGET}
 export PATH=$GOROOT/bin:$PATH
+GOPATH="$(mktemp -d)"
+export GOPATH
 
 # BOSH copies files in without the `src` directory; put it back.
 # We can't use a symlink because go doesn't like those
-mkdir -p "${BOSH_COMPILE_TARGET}/src"
-mv "${BOSH_COMPILE_TARGET}/github.com" "${BOSH_COMPILE_TARGET}/src/github.com"
-mv test-resources "${BOSH_COMPILE_TARGET}/src/test-resources"
+mkdir -p "${GOPATH}/src"
+cp -r "${BOSH_COMPILE_TARGET}/github.com" "${GOPATH}/src/github.com"
+cp -r test-resources "${GOPATH}/src/test-resources"
 
 # We currently have no way of getting a valid version number, as we have no git repo
 export GOBIN="${BIN_DIR}"
@@ -87,4 +88,4 @@ test -x "${GOBIN}/docker-uploader"
 
 # Install the mysql client into the package
 zypper install -y mariadb-client
-cp /usr/bin/mysql ${BIN_DIR}
+cp /usr/bin/mysql "${BIN_DIR}"


### PR DESCRIPTION
Moving things around in the source directory can end up with files owned by root in unexpected places, causing issues when the user tries to delete those files later.  Instead, copy them to a temporary directory that is automatically deleted on container shutdown instead.