### PR TITLE
autoscaler: Always use client_credentials

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -40,6 +40,12 @@ properties:
     user: admin
     org: test-brain-org
     space: test-brain-space
+  autoscaler:
+    cf:
+      client_id: app_autoscaler
+      grant_type: client_credentials
+      password: "" # unused
+      username: "" # unused
   capi:
     tps:
       watcher:
@@ -306,6 +312,10 @@ properties:
       # Note that these clients are overridden in the dev-only UAA role; that is
       # instead used to bootstrap the default zone, whereas all of these clients
       # go into the SCF zone.
+      app_autoscaler:
+        # Requires read-only admin to look up stats, and write admin to do scaling
+        authorities: cloud_controller.read,cloud_controller.write,cloud_controller.admin
+        authorized-grant-types: client_credentials
       cc_routing:
         authorities: routing.router_groups.read
         authorized-grant-types: client_credentials

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1445,6 +1445,8 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release: scf-helper
+  - name: authorize-internal-ca
+    release: scf
   - name: metricscollector
     release: app-autoscaler
   - name: eventgenerator
@@ -1478,6 +1480,8 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release: scf-helper
+  - name: authorize-internal-ca
+    release: scf
   - name: scalingengine
     release: app-autoscaler
   - name: scheduler
@@ -1822,17 +1826,6 @@ configuration:
     default: "postgres"
     description: ""
 
-  - name: AUTOSCALER_CF_GRANT_TYPE
-    default: "password"
-    description: "password or client_credentials"
-
-  - name: AUTOSCALER_CF_SKIP_SSL_VALIDATION
-    default: true
-    description: ""
-  - name: AUTOSCALER_CF_USERNAME
-    default: "admin"
-    description: ""
-
   - name: AUTOSCALER_DATABASE_MAX_CONNECTIONS
     default: 1000
     description: ""
@@ -2119,9 +2112,6 @@ configuration:
     default: "username"
     description: ""
 
-  - name: AUTOSCALER_UAA_CLIENT_ID
-    default: "autoscaler_client_id"
-    description: "the uaa client id used by autoscaler"
   - name: AUTOSCALER_UAA_CLIENT_SECRET
     default: "autoscaler_client_secret"
     description: "the uaa client secret used by autoscaler"
@@ -3165,12 +3155,7 @@ configuration:
     properties.autoscaler.binding_db.port: '"((AUTOSCALER_BINDING_DB_PORT))"'
     properties.autoscaler.binding_db.roles: '[{"name": "((AUTOSCALER_DB_ROLE_NAME))", "password": "((AUTOSCALER_DB_ROLE_PASSWORD))", "tag": "((AUTOSCALER_DB_ROLE_TAG))"}]'
     properties.autoscaler.cf.api: '"https://api.((DOMAIN))"'
-    properties.autoscaler.cf.client_id: '"((AUTOSCALER_UAA_CLIENT_ID))"'
-    properties.autoscaler.cf.grant_type: '"((AUTOSCALER_CF_GRANT_TYPE))"'
-    properties.autoscaler.cf.password: '"((CLUSTER_ADMIN_PASSWORD))"'
     properties.autoscaler.cf.secret: '"((AUTOSCALER_UAA_CLIENT_SECRET))"'
-    properties.autoscaler.cf.skip_ssl_validation: '((AUTOSCALER_CF_SKIP_SSL_VALIDATION))'
-    properties.autoscaler.cf.username: '"((AUTOSCALER_CF_USERNAME))"'
     properties.autoscaler.eventgenerator.aggregator.aggregator_execute_interval: '"((AUTOSCALER_EVENT_GENERATOR_AGGREGATOR_EXECUTE_INTERVAL))"'
     properties.autoscaler.eventgenerator.aggregator.app_metric_channel_size: '"((AUTOSCALER_EVENT_GENERATOR_AGGREGATOR_APP_METRIC_CHANNEL_SIZE))"'
     properties.autoscaler.eventgenerator.aggregator.app_monitor_channel_size: '((AUTOSCALER_EVENT_GENERATOR_AGGREGATOR_APP_MONITOR_CHANNEL_SIZE))'
@@ -3586,6 +3571,7 @@ configuration:
     properties.uaa.admin.client_secret: '"((UAA_ADMIN_CLIENT_SECRET))"'
     properties.uaa.ca_cert: '"((UAA_CA_CERT))((^UAA_CA_CERT))((INTERNAL_CA_CERT))((/UAA_CA_CERT))"'
     properties.uaa.client_secret: '"((UAA_CLIENTS_TCP_EMITTER_SECRET))"'
+    properties.uaa.clients.app_autoscaler.secret: ((AUTOSCALER_UAA_CLIENT_SECRET))
     properties.uaa.clients.cc-service-dashboards.secret: '"((UAA_CLIENTS_CC_SERVICE_DASHBOARDS_CLIENT_SECRET))"'
     properties.uaa.clients.cc_routing.secret: '"((UAA_CLIENTS_CC_ROUTING_SECRET))"'
     properties.uaa.clients.cc_service_key_client.secret: '"((UAA_CLIENTS_CC_SERVICE_KEY_CLIENT_SECRET))"'

--- a/src/scf-release/jobs/autoscaler-smoke/templates/run.erb
+++ b/src/scf-release/jobs/autoscaler-smoke/templates/run.erb
@@ -81,7 +81,7 @@ fi
 
 cf app "${APP}"
 printf "Causing memory stress...\n"
-curl -X POST "${URL}/stress_testers?vm=10"
+curl -X POST "${URL}/stress_testers?vm=10&vm-bytes=100M"
 printf "Waiting for new instances to start..."
 for (( i = 0 ; i < $(( 60 * 2 / 5)) ; i ++ )) ; do
     if test "$(get_count)" -gt 1 ; then
@@ -90,5 +90,11 @@ for (( i = 0 ; i < $(( 60 * 2 / 5)) ; i ++ )) ; do
     printf "."
     sleep 5
 done
-printf "\nInstances increased.\n"
+printf "\n"
 cf app "${APP}"
+if test "$(get_count)" -gt 1 ; then
+    printf "%bInstances increased.%b\n" "\e[0;32m" "\e[0m"
+else
+    printf "%bFailed to increase instances.%b\n" "\e[0;31m" "\e[0m" >&2
+    exit 1
+fi


### PR DESCRIPTION
In the context of SCF (/other fissilized CF deployment), it is possible for the administrator to change the administrator password and then do something that requires the autoscaler to be restarted.  In that case the password embedded in the helm release will no longer be correct, which will cause the autoscaler to cease working.

Instead, use client credentials for the autoscaler (which would be generated anyway).  This ensures that we always have an auth method that will work even when the secrets are rotated.

This is independent of the autoscaler being used outside of SCF (where it might still be a good idea to use username / password authentication).

/cc @qibobo Could you see if this would make sense?  Longer term, we are planning on moving fissile to use BOSH ops files instead, in which case none of this matters (since the operator would then be able to change any BOSH property they please).