### PR TITLE
Allow HA (2 default/3 max) for roles cc-clock and syslog-scheduler.

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -18,8 +18,8 @@ roles:
   run:
     scaling:
       min: 1
-      max: 1
-      ha: 1
+      max: 3
+      ha: 2
     capabilities: []
     memory: 69
     virtual-cpus: 2
@@ -808,7 +808,8 @@ roles:
   run:
     scaling:
       min: 1
-      max: 1 # Max is 1 per the description of the clock job
+      max: 3
+      ha: 2
     capabilities: []
     memory: 789
     virtual-cpus: 2


### PR DESCRIPTION
Ref https://trello.com/c/8Af9uLyM/757-3-implement-ha-for-cc-clock-and-syslog-scheduler

:cat: results under vagrant:

1. 3x SA, both roles at count 1, as before the change. 3 fails.
1. 3x HA, both roles at count 2, now possible with the change. 4 fails.

SA:
```
3x  [Fail] [apps] Logging Syslog drains [It] forwards app messages to registered syslog drains 
1x  [Fail] [v3] v3 buildpack app lifecycle with a java_buildpack [It] can run spring apps 
```

HA:
```
3x  [Fail] [apps] Logging Syslog drains [It] forwards app messages to registered syslog drains 
1x  [Fail] [route_services] Route Services when a route binds to a service when service broker does not return a route service url [AfterEach] routes to an app 
2x  [Fail] [routing] Multiple App Ports [BeforeEach] when app has multiple ports mapped should listen on multiple ports 
1x  [Fail] [services] SSO Lifecycle [BeforeEach] When a service broker is created with a dashboard client can perform an operation on a user's behalf using sso 
1x  [Fail] [services] Service Broker Lifecycle public brokers [BeforeEach] service access disabling is not visible to a regular user 
```

The syslog failure is across the board, so not an issue with the change.

The other issues ... While they look to be random they are persistently cropping up in larger numbers than under SA mode. That does not make me happy.

