### PR TITLE
vagrant: libvirt: suspend to disk

### DIFF
--- a/packer/Vagrantfile.template
+++ b/packer/Vagrantfile.template
@@ -9,6 +9,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.provider :libvirt do |libvirt|
     libvirt.disk_bus = 'virtio'
+    libvirt.suspend_mode = 'managedsave'
     if ENV['VAGRANT_LIBVIRT_URI']
       require 'uri'
       uri = URI.parse(ENV['VAGRANT_LIBVIRT_URI'])


### PR DESCRIPTION
When running `vagrant suspend`, it is much more useful to suspend to disk than suspend to RAM (because the latter doesn't free up any resources at all, making it kind of pointless).

This should be in vagrant-libvirt 0.0.32 and newer.