### PR TITLE
versions: bump fissile stemcell for configgin 0.16.2

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -24,9 +24,9 @@ export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$
 
 if [ "${USE_SLE_BASE:-false}" == "false" ]
 then
-	export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-develop-42.3-6.g1785bff-30.51}
+	export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-6.g1785bff-30.31}
 else
-	export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-12SP3-7.g66370f0-0.116}
+	export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-12SP3-7.g66370f0-0.138}
 fi
 
 # Used in: bin/generate-dev-certs.sh


### PR DESCRIPTION
For some reason the openSUSE one was using `develop` builds instead of `release` builds; moved that back to match the SLE one.