### PR TITLE
Refactor diego-api HA rules, odd value not required:

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -417,8 +417,7 @@ instance_groups:
     scaling:
       min: 1
       max: 3
-      ha: 3
-      must_be_odd: true
+      ha: 2
     capabilities: []
     memory: 310
     virtual-cpus: 2


### PR DESCRIPTION
This should be related to the fact that BBS move to postgres
instead of etcd. Therefore the `must_be_odd` flag should not
longer apply to the `diego-api` role.

See https://docs.cloudfoundry.org/concepts/high-availability.html

