### PR TITLE
Move `broker_client_timeout_seconds` setting out of opinions into an scf parameter.

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -45,7 +45,6 @@ properties:
       watcher:
         skip_consul_lock: true
   cc:
-    broker_client_timeout_seconds: 70
     buildpacks:
       blobstore_type: webdav
       webdav_config:

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2235,6 +2235,11 @@ configuration:
       value_type: private_key
     description: The PEM-encoded private key for signing TLS/SSL traffic.
     required: true
+
+  - name: BROKER_CLIENT_TIMEOUT_SECONDS
+    default: "70"
+    description: "For requests to service brokers, this is the HTTP (open and read) timeout setting, in seconds."
+
   - name: BULK_API_PASSWORD
     secret: true
     generator:
@@ -3335,6 +3340,7 @@ configuration:
     properties.cc.allowed_cors_domains: ((ALLOWED_CORS_DOMAINS))
     properties.cc.app_bits_max_body_size: ((NGINX_MAX_REQUEST_BODY_SIZE))M
     properties.cc.app_bits_upload_grace_period_in_seconds: ((APP_TOKEN_UPLOAD_GRACE_PERIOD))
+    properties.cc.broker_client_timeout_seconds: '"((BROKER_CLIENT_TIMEOUT_SECONDS))"'
     properties.cc.buildpacks.cdn.uri: '"((CDN_URI))"'
     properties.cc.buildpacks.webdav_config.password: '"((BLOBSTORE_PASSWORD))"'
     properties.cc.buildpacks.webdav_config.private_endpoint: https://blobstore.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):4443

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2235,11 +2235,9 @@ configuration:
       value_type: private_key
     description: The PEM-encoded private key for signing TLS/SSL traffic.
     required: true
-
   - name: BROKER_CLIENT_TIMEOUT_SECONDS
     default: "70"
     description: "For requests to service brokers, this is the HTTP (open and read) timeout setting, in seconds."
-
   - name: BULK_API_PASSWORD
     secret: true
     generator:


### PR DESCRIPTION
Ref: https://trello.com/c/idEoO8TD/765-expose-brokerclienttimeoutseconds

Ran tests under vagrant
- :green_heart: cluster build
- :green_heart: cluster start
- :green_heart: :smoking: 
- :green_heart: brain
- :boom: :cat: - Known thing for dev: `[Fail] [apps] Logging Syslog drains [It] forwards app messages to registered syslog drains`.
