### PR TITLE
Remove DNS_HEALTH_CHECK_HOST variable

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -579,7 +579,7 @@ instance_groups:
             topologyKey: "beta.kubernetes.io/os"
   configuration:
     templates:
-      properties.dns_health_check_host: '"((DNS_HEALTH_CHECK_HOST))"'
+      properties.dns_health_check_host: '"api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"'
 - name: routing-api
   environment_scripts:
   - scripts/configure-HA-hosts.sh
@@ -627,7 +627,7 @@ instance_groups:
     active-passive-probe: head -c0 </dev/tcp/${HOSTNAME}/3000
   configuration:
     templates:
-      properties.dns_health_check_host: '"((DNS_HEALTH_CHECK_HOST))"'
+      properties.dns_health_check_host: '"api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"'
 - name: api
   environment_scripts:
   - scripts/configure-HA-hosts.sh
@@ -2433,10 +2433,6 @@ configuration:
     default: false
     description: Disable external buildpacks. Only admin buildpacks and system buildpacks will be available to users.
     required: true
-  - name: DNS_HEALTH_CHECK_HOST
-    default: 127.0.0.1
-    description: The host to ping for confirmation of DNS resolution.
-    required: true
   - name: DOMAIN
     example: my-scf-cluster.com
     required: true
@@ -3517,7 +3513,7 @@ configuration:
     properties.opensuse42-rootfs.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))((#ROOTFS_TRUSTED_CERTS))\n((/ROOTFS_TRUSTED_CERTS))((INTERNAL_CA_CERT))"'
     properties.router.balancing_algorithm: '"((ROUTER_BALANCING_ALGORITHM))"'
     properties.router.client_cert_validation: '"((ROUTER_CLIENT_CERT_VALIDATION))"'
-    properties.router.dns_health_check_host: '"((DNS_HEALTH_CHECK_HOST))"'
+    properties.router.dns_health_check_host: '"api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"'
     properties.router.force_forwarded_proto_https: ((FORCE_FORWARDED_PROTO_AS_HTTPS))
     properties.router.forwarded_client_cert: "((ROUTER_FORWARDED_CLIENT_CERT))"
     properties.router.logging_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'


### PR DESCRIPTION
The health check host can be the API role, and it can be automatically determined.
This also fixes issues with Core DNS.