### PR TITLE
Move ports around to avoid privileged ports

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -263,6 +263,7 @@ properties:
   router:
     enable_ssl: true
     extra_headers_to_log: null
+    port: 8000
     requested_route_registration_interval_in_seconds: null
     route_services_timeout: null
     secure_cookies: null
@@ -305,6 +306,8 @@ properties:
     skip_cert_verify: false
   tcp:
     enabled: true
+  tcp_router:
+    health_check_port: 8080
   traffic_controller:
     locked_memory_limit: kernel
   uaa:

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -256,9 +256,9 @@ instance_groups:
     - name: mysql-proxy
       protocol: TCP
       internal: 3306
-    - name: api
+    - name: api-proxy
       protocol: TCP
-      internal: 80
+      internal: 8080
     - name: healthck-proxy
       protocol: TCP
       internal: 1936
@@ -485,13 +485,14 @@ instance_groups:
     exposed-ports:
     - name: router
       protocol: TCP
-      internal: 80
+      external: 80
+      internal: 8000
       public: true
-    - name: router2
+    - name: router-ssl
       protocol: TCP
       internal: 443
       public: true
-    - name: router3
+    - name: doppler-ssl
       protocol: TCP
       external: 4443
       internal: 443
@@ -554,7 +555,7 @@ instance_groups:
     - name: healthcheck
       protocol: TCP
       external: 2341
-      internal: 80
+      internal: 8080
     - name: tcp-route
       protocol: TCP
       internal: 20000-20008
@@ -564,7 +565,7 @@ instance_groups:
     healthcheck:
       readiness:
         command:
-        - curl --silent --fail http://${HOSTNAME}/health
+        - curl --silent --fail http://${HOSTNAME}:8080/health
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This moves various ports around to avoid privileged ports, so that _most_ containers can avoid using privileged containers.  That is still needed for diego-cell and nfs-broker for non-port-related reasons.

Router SSL ports are not changed here pending upstream PR https://github.com/cloudfoundry/routing-release/pull/119

UAA does not appear to require PSP changes in my testing.