### PR TITLE
role-manifest: add `syslog_adapter` to syslog adapter cert

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2907,6 +2907,7 @@ configuration:
       value_type: certificate
       subject_names:
       - adapter
+      - syslog_adapter
     description: PEM-encoded certificate
     required: true
   - name: SYSLOG_ADAPT_KEY


### PR DESCRIPTION
Because it's missing in that for some reason