### PR TITLE
role-manifest/opinions: Drop the syslog_adapter name again

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -291,7 +291,7 @@ properties:
         api:
           cn: 'api'
         client:
-          adapter_cn: 'syslog_adapter'
+          adapter_cn: adapter
   scf:
     skip_cert_verify_external: false
   smoke_tests:

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2907,7 +2907,8 @@ configuration:
       value_type: certificate
       subject_names:
       - adapter
-      - syslog_adapter
+      # The CN must be listed in the BOSH property
+      # scalablesyslog.scheduler.tls.client.adapter_cn
     description: PEM-encoded certificate
     required: true
   - name: SYSLOG_ADAPT_KEY


### PR DESCRIPTION
We just forgot to update the hard-coded BOSH property in the opinions that needs to list the CN of the cert