### PR TITLE
Dropped `test-brain` account, and added its `test-role` to the `default` account.

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1251,7 +1251,7 @@ instance_groups:
     flight-stage: manual
     capabilities: []
     exposed-ports: []
-    service-account: test-brain
+    service-account: default
 - name: acceptance-tests
   type: bosh-task
   tags:
@@ -1568,11 +1568,9 @@ configuration:
         verbs: [create, delete, get, list]
     accounts:
       default:
-        roles: [configgin-role]
+        roles: [configgin-role, test-role]
       secret-generator:
         roles: [configgin-role, secrets-role]
-      test-brain:
-        roles: [configgin-role, test-role]
   variables:
   - name: ALLOWED_CORS_DOMAINS
     default: []


### PR DESCRIPTION
Ref: https://trello.com/c/8b8F5QCt/767-serviceaccountname-changes-required-for-brains-to-pass
:construction: Wait for Jenkins to pass.
