### PR TITLE
Alternative to `serviceAccountName changes required for brains to pass`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ void runTestBrain(String testName) {
 
 	sed < "bin/dev/psp-rbac-testbrain.yaml" \
 	    -e "s|namespace: scf|namespace: \${namespace}|" | \
-	    kubectl apply -f -
+	    kubectl apply --namespace="\${namespace}" -f -
 
         kubectl run \
             --namespace=${jobBaseName()}-${BUILD_NUMBER}-scf \

--- a/bin/dev/psp-rbac-testbrain.yaml
+++ b/bin/dev/psp-rbac-testbrain.yaml
@@ -1,0 +1,227 @@
+# # ##
+## Objects specified in this file
+#
+# 1. ServiceAccount     "suse.cap.test-brain.account"
+# 2. Role               "suse:cap:test-brain:base-role"
+# 3. Role               "suse:cap:test-brain:nfs-role"
+# 4. RoleBinding        "suse:cap:test-brain:bind:base-role"  -- 2 <~> 1
+# 5. RoleBinding        "suse:cap:test-brain:bind:nfs-role"   -- 3 <~> 1
+# 6. PodSecurityPolicy  "suse.cap.test-brain.psp"
+# 7. ClusterRole        "suse:cap:test-brain:psp"             -- ^6
+# 8. ClusterRoleBinding "suse:cap:test-brain:psp:clusterrole" -- 7 <~> 1
+#
+## Usage:
+#
+# Edit `output/kube/bosh-task/acceptance-tests-brain.yaml`.
+#
+# Replace the name (`default`) in `serviceAccountName: "default"` with
+# the name of (1).
+#
+# Apply this file before starting/applying
+# `acceptance-tests-brain.yaml`.
+#
+## Description
+#
+# The service account 'suse.cap.test-brain.account' (1) is linked to
+# the roles 'suse:cap:test-brain:base-role' (1) and
+# 'suse:cap:test-brain:nfs-role' (2) via role bindings (4, 5), for the
+# necessary operation permissions.
+#
+# It is further linked to a pod security policy (6), via a cluster role
+# binding (8) and cluster role (7), for more low-level privileges.
+#
+## Notes
+#
+# 1. The roles, role bindings, and service account were taken from the
+#    SCF helm chart, with renaming.
+#
+# 2. PSP and associated cluster role (binding) were taken from the
+#    cap-psp-rbac of cf-ci/qa-tools, with renaming.
+#
+##
+# # ##
+---
+apiVersion: "v1"
+kind: "ServiceAccount"
+metadata:
+  name: "suse.cap.test-brain.account"
+---
+apiVersion: "rbac.authorization.k8s.io/v1beta1"
+kind: "Role"
+metadata:
+  name: "suse:cap:test-brain:base-role"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "pods"
+  verbs:
+  - "get"
+  - "list"
+  - "patch"
+- apiGroups:
+  - ""
+  resources:
+  - "services"
+  verbs:
+  - "get"
+- apiGroups:
+  - "apps"
+  resources:
+  - "statefulsets"
+  verbs:
+  - "get"
+---
+apiVersion: "rbac.authorization.k8s.io/v1beta1"
+kind: "Role"
+metadata:
+  name: "suse:cap:test-brain:nfs-role"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "services"
+  verbs:
+  - "create"
+  - "get"
+  - "delete"
+- apiGroups:
+  - "apps"
+  resources:
+  - "statefulsets"
+  verbs:
+  - "create"
+  - "get"
+  - "update"
+  - "delete"
+- apiGroups:
+  - ""
+  resources:
+  - "pods/exec"
+  verbs:
+  - "create"
+  - "delete"
+- apiGroups:
+  - ""
+  resources:
+  - "pods/log"
+  verbs:
+  - "create"
+  - "delete"
+  - "get"
+  - "list"
+---
+apiVersion: "rbac.authorization.k8s.io/v1beta1"
+kind: "RoleBinding"
+metadata:
+  name: "suse:cap:test-brain:bind:base-role"
+subjects:
+- kind: "ServiceAccount"
+  name: "suse.cap.test-brain.account"
+roleRef:
+  kind: "Role"
+  name: "suse:cap:test-brain:base-role"
+  apiGroup: "rbac.authorization.k8s.io"
+---
+apiVersion: "rbac.authorization.k8s.io/v1beta1"
+kind: "RoleBinding"
+metadata:
+  name: "suse:cap:test-brain:bind:nfs-role"
+subjects:
+- kind: "ServiceAccount"
+  name: "suse.cap.test-brain.account"
+roleRef:
+  kind: "Role"
+  name: "suse:cap:test-brain:nfs-role"
+  apiGroup: "rbac.authorization.k8s.io"
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: suse.cap.test-brain.psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  # Privileged
+  #privileged: false      	<<< default in suse.caasp.psp.unprivileged
+  privileged: true
+  # Volumes and File Systems
+  volumes:
+    # Kubernetes Pseudo Volume Types
+    - configMap
+    - secret
+    - emptyDir
+    - downwardAPI
+    - projected
+    - persistentVolumeClaim
+    # Networked Storage
+    - nfs
+    - rbd
+    - cephFS
+    - glusterfs
+    - fc
+    - iscsi
+    # Cloud Volumes
+    - cinder
+    - gcePersistentDisk
+    - awsElasticBlockStore
+    - azureDisk
+    - azureFile
+    - vsphereVolume
+  allowedFlexVolumes: []
+  allowedHostPaths:
+    # Note: We don't allow hostPath volumes above, but set this to a path we
+    # control anyway as a belt+braces protection. /dev/null may be a better
+    # option, but the implications of pointing this towards a device are
+    # unclear.
+    - pathPrefix: /opt/kubernetes-hostpath-volumes
+  readOnlyRootFilesystem: false
+  # Users and groups
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  # Privilege Escalation
+  #allowPrivilegeEscalation: false	   <<< default in suse.caasp.psp.unprivileged
+  allowPrivilegeEscalation: true
+  #defaultAllowPrivilegeEscalation: false  <<< default in suse.caasp.psp.unprivileged
+  # Capabilities
+  allowedCapabilities: []
+  defaultAddCapabilities: []
+  requiredDropCapabilities: []
+  # Host namespaces
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  hostPorts:
+  - min: 0
+    max: 65535
+  # SELinux
+  seLinux:
+    # SELinux is unsed in CaaSP
+    rule: 'RunAsAny'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: suse:cap:test-brain:psp
+rules:
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['suse.cap.test-brain.psp']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:cap:test-brain:psp:clusterrole
+roleRef:
+  kind: ClusterRole
+  name: suse:cap:test-brain:psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: suse.cap.test-brain.account
+  namespace: scf

--- a/bin/dev/psp-rbac-testbrain.yaml
+++ b/bin/dev/psp-rbac-testbrain.yaml
@@ -168,7 +168,6 @@ spec:
     - azureDisk
     - azureFile
     - vsphereVolume
-  allowedFlexVolumes: []
   allowedHostPaths:
     # Note: We don't allow hostPath volumes above, but set this to a path we
     # control anyway as a belt+braces protection. /dev/null may be a better
@@ -185,7 +184,7 @@ spec:
     rule: RunAsAny
   # Privilege Escalation
   #allowPrivilegeEscalation: false	   <<< default in suse.caasp.psp.unprivileged
-  allowPrivilegeEscalation: true
+  allowPrivilegeEscalation: false
   #defaultAllowPrivilegeEscalation: false  <<< default in suse.caasp.psp.unprivileged
   # Capabilities
   allowedCapabilities: []

--- a/bin/dev/psp-rbac-testbrain.yaml
+++ b/bin/dev/psp-rbac-testbrain.yaml
@@ -1,7 +1,7 @@
 # # ##
 ## Objects specified in this file
 #
-# 1. ServiceAccount     "suse.cap.test-brain.account"
+# 1. ServiceAccount     "suse-cap-test-brain-account"
 # 2. Role               "suse:cap:test-brain:base-role"
 # 3. Role               "suse:cap:test-brain:nfs-role"
 # 4. RoleBinding        "suse:cap:test-brain:bind:base-role"  -- 2 <~> 1
@@ -22,7 +22,7 @@
 #
 ## Description
 #
-# The service account 'suse.cap.test-brain.account' (1) is linked to
+# The service account 'suse-cap-test-brain-account' (1) is linked to
 # the roles 'suse:cap:test-brain:base-role' (1) and
 # 'suse:cap:test-brain:nfs-role' (2) via role bindings (4, 5), for the
 # necessary operation permissions.
@@ -44,7 +44,7 @@
 apiVersion: "v1"
 kind: "ServiceAccount"
 metadata:
-  name: "suse.cap.test-brain.account"
+  name: "suse-cap-test-brain-account"
 ---
 apiVersion: "rbac.authorization.k8s.io/v1beta1"
 kind: "Role"
@@ -117,7 +117,7 @@ metadata:
   name: "suse:cap:test-brain:bind:base-role"
 subjects:
 - kind: "ServiceAccount"
-  name: "suse.cap.test-brain.account"
+  name: "suse-cap-test-brain-account"
 roleRef:
   kind: "Role"
   name: "suse:cap:test-brain:base-role"
@@ -129,7 +129,7 @@ metadata:
   name: "suse:cap:test-brain:bind:nfs-role"
 subjects:
 - kind: "ServiceAccount"
-  name: "suse.cap.test-brain.account"
+  name: "suse-cap-test-brain-account"
 roleRef:
   kind: "Role"
   name: "suse:cap:test-brain:nfs-role"
@@ -223,5 +223,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: suse.cap.test-brain.account
+  name: suse-cap-test-brain-account
   namespace: scf

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1251,7 +1251,7 @@ instance_groups:
     flight-stage: manual
     capabilities: []
     exposed-ports: []
-    service-account: test-brain
+    service-account: default
 - name: acceptance-tests
   type: bosh-task
   tags:
@@ -1553,26 +1553,11 @@ configuration:
       - apiGroups: [""]
         resources: [configmaps, secrets]
         verbs: [create, get, list, patch, update, delete]
-      test-role:
-      - apiGroups: [""]
-        resources: [services]
-        verbs: [create, get, delete]
-      - apiGroups: [apps]
-        resources: [statefulsets]
-        verbs: [create, get, update, delete]
-      - apiGroups: [""]
-        resources: ["pods/exec"]
-        verbs: [create, delete]
-      - apiGroups: [""]
-        resources: ["pods/log"]
-        verbs: [create, delete, get, list]
     accounts:
       default:
         roles: [configgin-role]
       secret-generator:
         roles: [configgin-role, secrets-role]
-      test-brain:
-        roles: [configgin-role, test-role]
   variables:
   - name: ALLOWED_CORS_DOMAINS
     default: []

--- a/make/tests
+++ b/make/tests
@@ -10,6 +10,12 @@ if [ ! -f "output/kube/bosh-task/${POD_NAME}.yaml" ]; then
 fi
 shift
 
+# Detect special case of brain tests
+case ${POD_NAME} in
+    *brain*) BRAIN=/bin/true  ;;
+    *)       BRAIN=/bin/false ;;
+esac
+
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 METRICS="${GIT_ROOT}/scf_metrics.csv"
 
@@ -43,6 +49,20 @@ stampy "${METRICS}" "$0" "make-tests::${POD_NAME}::create" start
 kubectl delete --namespace="${NAMESPACE}" --filename="output/kube/bosh-task/${POD_NAME}.yaml" \
     2> /dev/null || /bin/true
 
+PSPCONFIG=$(mktemp)
+remove_test_config () { rm -f "${PSPCONFIG}" ; }
+trap remove_test_config EXIT
+
+if $BRAIN ; then
+    # Configure the SA etc for the actual namespace used.
+    sed < "bin/dev/psp-rbac-testbrain.yaml" > "${PSPCONFIG}" \
+	-e "s|namespace: scf|namespace: ${NAMESPACE}|"
+
+    # Delete leftovers based on the new namespace.
+    kubectl delete --namespace="${NAMESPACE}" --filename="${PSPCONFIG}" \
+    2> /dev/null || /bin/true
+fi
+
 echo "Waiting for pod ${POD_NAME} to be deleted..."
 while has_pod ; do
     sleep 1
@@ -54,8 +74,19 @@ done
 CONFIG=$(mktemp)
 ruby bin/kube_overrides.rb "${NAMESPACE}" "${DOMAIN:-}" "output/kube/bosh-task/${POD_NAME}.yaml" "$@" > "${CONFIG}"
 
-remove_test_config () { rm "${CONFIG}" ; }
+remove_test_config () { rm -f "${CONFIG}" "${PSPCONFIG}" ; }
 trap remove_test_config EXIT
+
+if $BRAIN ; then
+    # Redirect task to the new service account with its PSP
+    sed < "${CONFIG}" > $$ \
+	-e 's|"serviceAccountName":"default"|"serviceAccountName":"suse-cap-test-brain-account"|'
+    mv $$ "${CONFIG}"
+
+    # Enter the new SA and associated objects.
+    kubectl create --namespace="${NAMESPACE}" --filename="${PSPCONFIG}"
+fi
+
 kubectl create --namespace="${NAMESPACE}" --filename="${CONFIG}"
 
 stampy "${METRICS}" "$0" "make-tests::${POD_NAME}::create" end


### PR DESCRIPTION
Ref: https://trello.com/c/8b8F5QCt/767-serviceaccountname-changes-required-for-brains-to-pass

Alternate solution to the service account for brain tests.
First PR is https://github.com/SUSE/scf/pull/1692

This solution pulls the SA and role information for brain tests out of the manifest and into a separate kube config.This config is further extended with a PSP and associated cluster role (binding).

To keep fissile working the brain test SA is set to `default`.

At test time the actual namespace is inserted into the new SA+PSP configuration, and the name of the actual SA from that into the brain config. This is conditional to brain tests. smoke and cats are not edited.










