### PR TITLE
pod-status: mark completed pods as successful

### DIFF
--- a/container-host-files/opt/scf/bin/pod-status
+++ b/container-host-files/opt/scf/bin/pod-status
@@ -43,4 +43,4 @@ while true ; do
 done
 
 kubectl get pods ${NS:+--namespace="${NS}"} ${NS:---all-namespaces} \
-    | perl -p -e 's@^(\S+\s+\S+\s*)(\d+)/(\d+)@"$1\e[0;" . ($2 == $3 ? "32" : "31;1") . "m$2/$3\e[0m"@e'
+    | perl -p -e 's@^((?:\S+\s+)?\S+\s*)(\d+)/(\d+)(\s+)(\w+)@"$1\e[0;" . (($2 == $3 || $5 eq "Completed") ? "32" : "31;1") . "m$2/$3\e[0m$4$5"@e'


### PR DESCRIPTION
In newer versions of kubectl, pods from completed jobs show up too; we should mark them as successful.