### PR TITLE
Submit obs buildpack dependencies for legal review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ password
 /output/
 personal-setup
 src/scf-helper-release/src/acceptance-tests-brain/test-resources/buildpack_inspector_buildpack/buildpack_inspector_buildpack-*.zip
+/OSCTEMP/
+/source-output/

--- a/bin/dev/legalscan.sh
+++ b/bin/dev/legalscan.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-for PACKAGE in $(osc ls Cloud:Platform:buildpacks:dependencies); do
-  osc submitrequest --yes --message=legal-review Cloud:Platform:buildpacks:dependencies $PACKAGE Cloud:Platform:sources:buildpacks:reviewed
-done
-
-PROJECTS="Cloud:Platform:sources:scf Cloud:Platform:sources:buildpacks Cloud:Platform:sources:sidecars"
+PROJECTS="Cloud:Platform:sources:scf Cloud:Platform:sources:buildpacks Cloud:Platform:buildpacks:dependencies Cloud:Platform:sources:sidecars"
 for PROJECT in ${PROJECTS}; do
   for PACKAGE in $(osc ls $PROJECT); do
     osc submitrequest --yes --message=legal-review $PROJECT $PACKAGE ${PROJECT}:reviewed

--- a/bin/dev/legalscan.sh
+++ b/bin/dev/legalscan.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 PROJECTS="Cloud:Platform:sources:scf Cloud:Platform:sources:buildpacks Cloud:Platform:buildpacks:dependencies Cloud:Platform:sources:sidecars"
-for PROJECT in ${PROJECTS}; do
-  for PACKAGE in $(osc ls $PROJECT); do
-    osc submitrequest --yes --message=legal-review $PROJECT $PACKAGE ${PROJECT}:reviewed
+for SOURCE_OBS_PROJECT in ${PROJECTS}; do
+  for PACKAGE in $(osc ls ${SOURCE_OBS_PROJECT}); do
+    TARGET_OBS_PROJECT="${SOURCE_OBS_PROJECT}:reviewed"
+    osc submitrequest --yes --message=legal-review ${SOURCE_OBS_PROJECT} ${PACKAGE} ${TARGET_OBS_PROJECT}
   done
 done

--- a/bin/dev/legalscan.sh
+++ b/bin/dev/legalscan.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+for PACKAGE in $(osc ls Cloud:Platform:buildpacks:dependencies); do
+  osc submitrequest --yes --message=legal-review Cloud:Platform:buildpacks:dependencies $PACKAGE Cloud:Platform:sources:buildpacks:reviewed
+done
+
 PROJECTS="Cloud:Platform:sources:scf Cloud:Platform:sources:buildpacks Cloud:Platform:sources:sidecars"
 for PROJECT in ${PROJECTS}; do
   for PACKAGE in $(osc ls $PROJECT); do


### PR DESCRIPTION
Submit OBS built buildpack dependencies for legal review. For the old buildpacks the sources are committed via Concourse which was not the case for the buildpacks built in obs.