### PR TITLE
bin/dev/kube-ready-state-check.sh: support not using hyperkube

### DIFF
--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -114,14 +114,12 @@ fi
 
 # privileged pods are enabled in K8s
 if having_category api ; then
-    kube_apiserver=$(pgrep -ax hyperkube | grep " apiserver " )
-    [[ $kube_apiserver == *"--allow-privileged"* ]]
+    pgrep -ax 'hyperkube|apiserver' | grep apiserver | grep --silent -- --allow-privileged
     status "Privileged must be enabled in 'kube-apiserver'"
 fi
 
 if having_category node ; then
-    kubelet=$(pgrep -ax hyperkube | grep " kubelet " )
-    [[ $kubelet == *"--allow-privileged"* ]]
+    pgrep -ax 'hyperkube|kubelet' | grep kubelet | grep --silent -- --allow-privileged
     status "Privileged must be enabled in 'kubelet'"
 fi
 


### PR DESCRIPTION
We were explicitly checking that hyperkube is used, when sometimes the system may be running apiserver or kubelet (either as a stub for hyperkube, or as a standalone binary).  Fix our detection to support either (as long as we're still running the specific binary).

Fixes #1724.