### PR TITLE
Add support for new fissile compilation cache

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.37.0"
 export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+62.ga46b3b4"
+export FISSILE_VERSION="7.0.0+85.gbb4863e"
 export HELM_VERSION="2.9.1"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"
 export KUBECTL_VERSION="1.9.6"

--- a/make/compile
+++ b/make/compile
@@ -25,6 +25,7 @@ get_package_version_list() {
 }
 
 _cache() {
+    test -n "${FISSILE_COMPILATION_CACHE_CONFIG+x}" && return
     test -n "${SCF_DISABLE_PACKAGE_COMPILATION_CACHE+x}" && return
 
     for package_version in $(get_package_version_list) ; do
@@ -52,6 +53,7 @@ cache() {
 }
 
 restore() {
+    test -n "${FISSILE_COMPILATION_CACHE_CONFIG+x}" && return
     test -z "${SCF_PACKAGE_COMPILATION_CACHE}" && return
     test -d "${FISSILE_WORK_DIR}/compilation/${STEMCELL_HASH}/" && return
 
@@ -88,6 +90,7 @@ restore() {
 # This affects both cache on the host, and local cache
 
 clean() {
+    test -n "${FISSILE_COMPILATION_CACHE_CONFIG+x}" && return
     if test -z "$(echo "${SCF_PACKAGE_COMPILATION_CACHE}" | tr -d ./)" ; then
         echo "SCF_PACKAGE_COMPILATION_CACHE is empty; bailing to prevent wiping your disk" >&2
         exit 1


### PR DESCRIPTION
Set FISSILE_COMPILATION_CACHE_CONFIG either directly to a JSON config or point it to a config file (inside the host, so for example `/home/vagrant/scf/output/package-cache.json`) to activate the new
caching code.

If the variable is not set, then the old caching code will still be used (for now).