### PR TITLE
Remove consul and postgres roles

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -89,69 +89,6 @@ instance_groups:
           internal: 8080
   - name: loggregator_agent
     release: loggregator-agent
-- name: consul
-  environment_scripts:
-  - scripts/configure-HA-hosts.sh
-  scripts:
-  - scripts/forward_logfiles.sh
-  - scripts/patches/fix_monit_rsyslog.sh
-  jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
-    release: scf-helper
-  - name: consul_agent
-    release: consul
-    consumes:
-      consul_common: {}
-      consul_server: {}
-    provides:
-      consul_common: {}
-      consul_server: {}
-    properties:
-      bosh_containerization:
-        run:
-          scaling:
-            min: 0
-            max: 1
-            ha: 1
-            must_be_odd: true
-          memory: 256
-          virtual-cpus: 1
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                  - key: skiff-role-name
-                    operator: In
-                    values: [ consul ]      
-        ports:
-        - name: consul-server
-          external: 8300
-          internal: 8300
-          protocol: TCP
-        - name: consul-http
-          external: 8500
-          internal: 8500
-          protocol: TCP
-        - name: serf-tcp
-          external: 8301
-          internal: 8301
-          protocol: TCP
-        - name: serf-udp
-          external: 8301
-          internal: 8301
-          protocol: UDP
-  configuration:
-    templates:
-      properties.consul.agent.mode: server
-      properties.consul.agent.node_name_includes_id: false
-      properties.consul.agent_cert: ((CONSUL_SERVER_CERT))
-      properties.consul.agent_key: ((CONSUL_SERVER_CERT_KEY))
-      properties.consul.encrypt_keys: "[((CONSUL_SERVER_ENCRYPT_KEY))]"
-      properties.consul.server_cert: ((CONSUL_SERVER_CERT))
-      properties.consul.server_key: ((CONSUL_SERVER_CERT_KEY))
 - name: nats
   environment_scripts:
   - scripts/configure-HA-hosts.sh
@@ -293,54 +230,6 @@ instance_groups:
       properties.cf_mysql.mysql.galera_healthcheck.endpoint_password: ((MYSQL_GALERA_HEALTHCHECK_ENDPOINT_PASSWORD))
       properties.cf_mysql.proxy.api_password: ((MYSQL_PROXY_ADMIN_PASSWORD))
       properties.cf_mysql.proxy.healthcheck_timeout_millis: ((MYSQL_PROXY_HEALTHCHECK_TIMEOUT))
-- name: postgres
-  scripts:
-  - scripts/chown_vcap_store.sh
-  - scripts/forward_logfiles.sh
-  - scripts/patches/fix_monit_rsyslog.sh
-  jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
-    release: scf-helper
-  - name: postgres
-    release: postgres
-    provides:
-      postgres: { as: postgres-database }
-    properties:
-      bosh_containerization:
-        run:
-          scaling:
-            min: 1
-            max: 3
-            ha: 2
-          volumes:
-          - path: /var/vcap/store
-            type: persistent
-            tag: postgres-data
-            size: 20
-          memory: 3072
-          virtual-cpus: 2
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
-                podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                    - key: "skiff-role-name"
-                      operator: In
-                      values:
-                      - postgres
-                  topologyKey: "beta.kubernetes.io/os"
-        ports:
-        - name: postgres
-          protocol: TCP
-          internal: 5524
-  tags:
-  - sequential-startup
-  configuration:
-    templates:
-      properties.databases.port: 5524
-      properties.databases.roles: '[{"name":"pgadmin","password":"((POSTGRES_PASSWORD))"}]'
 - name: cf-usb
   environment_scripts:
   - scripts/configure-HA-hosts.sh
@@ -1939,11 +1828,6 @@ configuration:
     properties.cf_mysql.mysql.advertise_host: mysql-((KUBE_COMPONENT_INDEX)).mysql-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
     properties.cf_mysql.mysql.seeded_databases: '[{"name":"ccdb","username":"ccadmin","password":"((MYSQL_CCDB_ROLE_PASSWORD))"},{"name":"diego","username":"diego","password":"((MYSQL_DIEGO_PASSWORD))"},{"name":"routing-api","username":"routing-api","password":"((MYSQL_ROUTING_API_PASSWORD))"},{"name":"usb","username":"usb","password":"((MYSQL_CF_USB_PASSWORD))"},{"name":"nfsvolume","username":"nfsvolume","password":"((MYSQL_PERSI_NFS_PASSWORD))"},{"name":"diego_locket","username":"diego_locket","password":"((MYSQL_DIEGO_LOCKET_PASSWORD))"},{"name":"credhub_user","username":"credhub_user","password":"((MYSQL_CREDHUB_USER_PASSWORD))"}]'
     properties.cflinuxfs2-rootfs.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))((#ROOTFS_TRUSTED_CERTS))\n((/ROOTFS_TRUSTED_CERTS))((INTERNAL_CA_CERT))"'
-    properties.consul.agent.domain: ((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
-    properties.consul.agent.servers.lan: ((KUBE_CONSUL_CLUSTER_IPS))
-    properties.consul.agent_cert: ((CONSUL_CLIENT_CERT))
-    properties.consul.agent_key: ((CONSUL_CLIENT_CERT_KEY))
-    properties.consul.ca_cert: ((INTERNAL_CA_CERT))
     properties.containers.trusted_ca_certificates: '((#TRUSTED_CERTS))[((TRUSTED_CERTS))]((/TRUSTED_CERTS))'
     properties.copilot.client_ca_file: ((INTERNAL_CA_CERT))
     # CLUSTER_DESCRIPTION is not wrapped in quotes because it has quotes in the dev env file.
@@ -2872,40 +2756,6 @@ variables:
     default: 2
     description: "'version' attribute in the /v2/info endpoint"
     required: true
-- name: CONSUL_CLIENT_CERT
-  options:
-    secret: true
-    ca: INTERNAL_CA_CERT
-    description: PEM-encoded consul client certificate
-    required: true
-  type: certificate
-- name: CONSUL_CLIENT_CERT_KEY
-  options:
-    secret: true
-    description: PEM-encoded consul client key
-    required: true
-- name: CONSUL_SERVER_CERT
-  options:
-    secret: true
-    ca: INTERNAL_CA_CERT
-    alternative_names:
-    - "*.consul-consul-agent-set"
-    - server.dc1.{{.KUBERNETES_NAMESPACE}}.svc.{{.KUBERNETES_CLUSTER_DOMAIN}}
-    description: PEM-encoded server certificate
-    required: true
-  type: certificate
-- name: CONSUL_SERVER_CERT_KEY
-  options:
-    secret: true
-    description: PEM-encoded server key
-    required: true
-- name: CONSUL_SERVER_ENCRYPT_KEY
-  options:
-    secret: true
-    immutable: true
-    description: Consul server encryption key
-    required: true
-  type: password
 - name: CREDHUB_ENCRYPT_KEY
   options:
     secret: true
@@ -3162,12 +3012,6 @@ variables:
     description: >
       This is an environment variable built-in by fissile.
       It's set to a numeric index for roles with multiple replicas.
-- name: KUBE_CONSUL_CLUSTER_IPS
-  options:
-    type: environment
-    description: A comma-separated list of IP addresses for the machines of the consul
-      sub-cluster. This parameter cannot be set by the user. Its value is automatically
-      computed during cluster setup.
 - name: KUBE_NATS_CLUSTER_IPS
   options:
     type: environment
@@ -3429,13 +3273,6 @@ variables:
       user uids (required for LDAP integration only)
     example: cn=Users,dc=corp,dc=test,dc=com
     default: ''
-- name: POSTGRES_PASSWORD
-  options:
-    secret: true
-    immutable: true
-    description: Password for Postgres administrator account
-    required: true
-  type: password
 - name: REP_SERVER_CERT
   options:
     secret: true


### PR DESCRIPTION
They were originally added in anticipation of integrating the autoscaler, but autoscaler no longer uses consul, and now has its own postgresql instance.

[trello#NBQwKqb4] and [trello#pbFFvuBM]