### PR TITLE
Create brain test for credhub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -560,7 +560,8 @@ pipeline {
                         --set secrets.UAA_CA_CERT="\${UAA_CA_CERT}" \
                         --set "kube.external_ips[0]=192.0.2.84" \
                         --set "kube.external_ips[1]=${ipAddress()}" \
-                        --set kube.storage_class.persistent=hostpath
+                        --set kube.storage_class.persistent=hostpath \
+                        --set sizing.credhub_user.count=1
 
                     echo Waiting for all pods to be ready...
                     for ns in "${jobBaseName()}-${BUILD_NUMBER}-uaa" "${jobBaseName()}-${BUILD_NUMBER}-scf" ; do
@@ -634,6 +635,7 @@ pipeline {
                         --set secrets.UAA_CA_CERT="\${UAA_CA_CERT}"
                         --set kube.storage_class.persistent=hostpath
                         --set kube.secrets_generation_counter=2
+                        --set sizing.credhub_user.count=1
                     )
 
                     # The extra IP address is to check that the code to set up multiple

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -561,7 +561,6 @@ pipeline {
                         --set "kube.external_ips[0]=192.0.2.84" \
                         --set "kube.external_ips[1]=${ipAddress()}" \
                         --set kube.storage_class.persistent=hostpath \
-                        --set sizing.credhub_user.count=1
 
                     echo Waiting for all pods to be ready...
                     for ns in "${jobBaseName()}-${BUILD_NUMBER}-uaa" "${jobBaseName()}-${BUILD_NUMBER}-scf" ; do

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1302,13 +1302,13 @@ instance_groups:
           shared-volumes: []
           memory: 2000
           virtual-cpus: 2
-          exposed-ports:
-          - name: api #apiserverport
-            protocol: TCP
-            external: 8844
-            internal: 8844
           healthcheck:
             readiness:      
+        ports:
+        - name: api #apiserverport
+          protocol: TCP
+          external: 8844
+          internal: 8844
   - name: route_registrar
     release: routing
   configuration:

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1562,6 +1562,9 @@ configuration:
       - apiGroups: [""]
         resources: ["pods/log"]
         verbs: [create, delete, get, list]
+      - apiGroups: [""]
+        resources: ["secrets"]
+        verbs: [get, list]
     accounts:
       default:
         roles: [configgin-role]

--- a/make/tests
+++ b/make/tests
@@ -76,7 +76,11 @@ ruby "${GIT_ROOT}/bin/kube_overrides.rb" "${NAMESPACE}" "${DOMAIN}" "${TEST_FILE
 
 remove_test_config () { rm "${CONFIG}" ; }
 trap remove_test_config EXIT
-kubectl create --namespace="${NAMESPACE}" --filename="${CONFIG}"
+
+# Use apply - Creates anything on first run.
+# On subsequent runs identical existing definitions are ignored.
+# (Ex: cluster role bindings for tests)
+kubectl apply --namespace="${NAMESPACE}" --filename="${CONFIG}"
 
 stampy "${METRICS}" "$0" "make-tests::${POD_NAME}::create" end
 

--- a/src/scf-release/jobs/acceptance-tests-brain/spec
+++ b/src/scf-release/jobs/acceptance-tests-brain/spec
@@ -8,6 +8,8 @@ packages:
   - kubectl
   - acceptance-tests-brain
   - docker-distribution
+  - credhub-cli
+  - mariadb-client
 
 templates:
   run.erb: bin/run

--- a/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
@@ -4,6 +4,8 @@ set -o errexit
 
 export PATH="/var/vcap/packages/cli/bin:${PATH}"
 export PATH="/var/vcap/packages/kubectl/bin:${PATH}"
+export PATH="/var/vcap/packages/credhub-cli/bin:${PATH}"
+export PATH="/var/vcap/packages/mariadb-client/bin:${PATH}"
 export PATH="/var/vcap/packages/acceptance-tests-brain/bin:${PATH}"
 
 source /var/vcap/jobs/acceptance-tests-brain/bin/environment.sh

--- a/src/scf-release/packages/acceptance-tests-brain/packaging
+++ b/src/scf-release/packages/acceptance-tests-brain/packaging
@@ -87,13 +87,3 @@ go install github.com/docker/distribution/cmd/registry
 # docker-uploader needs to run without ld-linux.so
 CGO_ENABLED=0 go install test-resources/docker-uploader
 test -x "${GOBIN}/docker-uploader"
-
-# Install the mysql client into the package
-zypper install -y mariadb-client
-cp /usr/bin/mysql "${BIN_DIR}"
-
-# Install the credhub client into the package
-
-wget https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/2.0.0/credhub-linux-2.0.0.tgz
-tar xfz ./credhub-linux-2.0.0.tgz
-cp ./credhub "${BIN_DIR}"

--- a/src/scf-release/packages/acceptance-tests-brain/packaging
+++ b/src/scf-release/packages/acceptance-tests-brain/packaging
@@ -91,3 +91,9 @@ test -x "${GOBIN}/docker-uploader"
 # Install the mysql client into the package
 zypper install -y mariadb-client
 cp /usr/bin/mysql "${BIN_DIR}"
+
+# Install the credhub client into the package
+
+wget https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/2.0.0/credhub-linux-2.0.0.tgz
+tar xfz ./credhub-linux-2.0.0.tgz
+cp ./credhub "${BIN_DIR}"

--- a/src/scf-release/packages/acceptance-tests-brain/spec
+++ b/src/scf-release/packages/acceptance-tests-brain/spec
@@ -4,8 +4,6 @@ dependencies:
   - cli
   - kubectl
   - golang1.10
-  - credhub-cli
-  - mariadb-client
 files:
   - acceptance-tests-brain/test-scripts/*
   - acceptance-tests-brain/test-resources/**/*

--- a/src/scf-release/packages/acceptance-tests-brain/spec
+++ b/src/scf-release/packages/acceptance-tests-brain/spec
@@ -4,6 +4,8 @@ dependencies:
   - cli
   - kubectl
   - golang1.10
+  - credhub-cli
+  - mariadb-client
 files:
   - acceptance-tests-brain/test-scripts/*
   - acceptance-tests-brain/test-resources/**/*

--- a/src/scf-release/packages/credhub-cli/packaging
+++ b/src/scf-release/packages/credhub-cli/packaging
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e -x
+
+# # ## ### ##### ######## support
+
+BIN_DIR=${BOSH_INSTALL_TARGET}/bin
+VERSION=2.0.0
+
+mkdir -p ${BIN_DIR}
+
+# Install the credhub client into the package
+
+wget https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/$VERSION/credhub-linux-$VERSION.tgz
+tar xfz ./credhub-linux-$VERSION.tgz
+cp ./credhub "${BIN_DIR}"

--- a/src/scf-release/packages/credhub-cli/spec
+++ b/src/scf-release/packages/credhub-cli/spec
@@ -1,0 +1,3 @@
+---
+name: credhub-cli
+files:

--- a/src/scf-release/packages/mariadb-client/packaging
+++ b/src/scf-release/packages/mariadb-client/packaging
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e -x
+
+BIN_DIR=${BOSH_INSTALL_TARGET}/bin
+
+mkdir -p ${BIN_DIR}
+
+# Install the mysql client into the package
+zypper install -y mariadb-client
+cp /usr/bin/mysql "${BIN_DIR}"

--- a/src/scf-release/packages/mariadb-client/spec
+++ b/src/scf-release/packages/mariadb-client/spec
@@ -1,0 +1,3 @@
+---
+name: mariadb-client
+files:

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/004_tcprouting_test.sh
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/004_tcprouting_test.sh
@@ -39,7 +39,7 @@ cf target -s ${CF_SPACE}
 SELFDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP=${SELFDIR}/../test-resources/node-env
 APP_NAME=tcp-route-node-env-$(random_suffix)
-TMP=$(mktemp -dt 006_tcprouting.XXXXXX)
+TMP="$(mktemp -dt "$(basename "${0}" .sh).XXXXXX")"
 
 ## # # ## ### Test-specific code ### ## # #
 

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/007_buildpacks_test.sh
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/007_buildpacks_test.sh
@@ -35,7 +35,7 @@ cf target -s ${CF_SPACE}
 
 # Location of the test script. All other assets will be found relative
 # to this.
-TMP=$(mktemp -dt 017_buildpacks.XXXXXX)
+TMP="$(mktemp -dt "$(basename "${0}" .sh).XXXXXX")"
 SELFDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSPECTOR_BUILDPACK_DIR=${SELFDIR}/../test-resources/buildpack_inspector_buildpack
 

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/008_cf_usb_test.sh
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/008_cf_usb_test.sh
@@ -88,7 +88,7 @@ cf target -s    "${CF_SPACE}"
 
 # Location of the test script. All other assets will be found relative
 # to this.
-TMP=$(mktemp -dt 008_cf_usb.XXXXXX)
+TMP="$(mktemp -dt "$(basename "${0}" .sh).XXXXXX")"
 
 MYSQL_USER=root
 MYSQL_PASS=testpass

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.sh
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.sh
@@ -51,7 +51,7 @@ SMOUNT=${SELFDIR}/../test-resources/nfs_mount.json
 SKUBEC=${SELFDIR}/../test-resources/nfs_server_kube.yaml
 PORAPP=${SELFDIR}/../test-resources/persi-acceptance-tests/assets/pora
 
-TMP=$(mktemp -dt 011_nfspersi.XXXXXX)
+TMP="$(mktemp -dt "$(basename "${0}" .sh).XXXXXX")"
 
 ## # # ## ### Test-specific code ### ## # #
 

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.sh
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.sh
@@ -51,7 +51,7 @@ SMOUNT=${SELFDIR}/../test-resources/nfs_mount.json
 SKUBEC=${SELFDIR}/../test-resources/nfs_server_kube.yaml
 PORAPP=${SELFDIR}/../test-resources/persi-acceptance-tests/assets/pora
 
-TMP=$(mktemp -dt 010_nfspersi.XXXXXX)
+TMP=$(mktemp -dt 011_nfspersi.XXXXXX)
 
 ## # # ## ### Test-specific code ### ## # #
 

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/013_credhub_test.sh
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/013_credhub_test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+## # # ## ### Tracing and common configuration ### ## # #
+
+set -o errexit
+set -o xtrace
+
+function random_suffix { head -c2 /dev/urandom | hexdump -e '"%04x"'; }
+CF_ORG=${CF_ORG:-org}-$(random_suffix)
+CF_SPACE=${CF_SPACE:-space}-$(random_suffix)
+
+# Shorter handle, and shows up in the log.
+NS="${KUBERNETES_NAMESPACE}"
+
+CLI=credhub
+CH_SERVICE="https://credhub.${CF_DOMAIN}"
+
+## # # ## ### Login & standard entity setup/cleanup ### ## # #
+
+function login_cleanup() {
+    trap "" EXIT ERR
+    set +o errexit
+
+    cf delete-space -f "${CF_SPACE}"
+    cf delete-org   -f "${CF_ORG}"
+
+    set -o errexit
+}
+trap login_cleanup EXIT ERR
+
+# target, login, create work org and space
+cf api --skip-ssl-validation "api.${CF_DOMAIN}"
+cf auth "${CF_USERNAME}" "${CF_PASSWORD}"
+
+cf create-org "${CF_ORG}"
+cf target -o  "${CF_ORG}"
+
+cf create-space "${CF_SPACE}"
+cf target -s    "${CF_SPACE}"
+
+## # # ## ### Test-specific configuration ### ## # #
+## Remove and extend as needed
+
+# Location of the test script. All other assets will be found relative
+# to this.
+SELFDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SECRET="$(kubectl get secrets --namespace "${NS}" | awk '/^secrets-/ { print $1 }')"
+CH_SECRET="$(kubectl get secrets --namespace "${NS}" "${SECRET}" -o jsonpath="{.data['uaa-clients-credhub-user-cli-secret']}"|base64 -d)"
+CLIENT=credhub_user_cli
+
+TMP=$(mktemp -dt 013_credhub.XXXXXX)
+
+## # # ## ### Test-specific code ### ## # #
+
+function test_cleanup() {
+    trap "" EXIT ERR
+    set +o errexit
+
+    rm -rf "${TMP}"
+    
+    set -o errexit
+    login_cleanup
+}
+trap test_cleanup EXIT ERR
+
+# Target the credhub service directly through its kube service
+"${CLI}" api  --skip-tls-validation --server "${CH_SERVICE}"
+
+# Log into credhub
+"${CLI}" login --client-name="${CLIENT}" --client-secret="${CH_SECRET}"
+
+# Insert ...
+"${CLI}" set -n FOX -t value -v 'fox over lazy dog' > ${TMP}/fox
+"${CLI}" set -n DOG -t user -z dog -w fox           > ${TMP}/dog
+
+# Retrieve ...
+"${CLI}" get -n FOX > ${TMP}/fox2
+"${CLI}" get -n DOG > ${TMP}/dog2
+
+# Show (in case of failure) ...
+for i in fox fox2 dog dog2
+do
+    echo __________________________________ ${i}
+    cat "${TMP}/${i}"
+done
+echo __________________________________
+
+# Check ...
+
+grep 'name: /FOX'        "${TMP}/fox"
+grep 'type: value'       "${TMP}/fox"
+grep 'value: <redacted>' "${TMP}/fox"
+
+grep 'name: /FOX'               "${TMP}/fox2"
+grep 'type: value'              "${TMP}/fox2"
+grep 'value: fox over lazy dog' "${TMP}/fox2"
+
+id=$(awk '/^id:/ { print $2 }' < "${TMP}/fox")
+grep "^id: ${id}$" "${TMP}/fox2"
+
+grep 'name: /DOG'        "${TMP}/dog"
+grep 'type: user'        "${TMP}/dog"
+grep 'value: <redacted>' "${TMP}/dog"
+
+grep 'name: /DOG'        "${TMP}/dog2"
+grep 'type: user'        "${TMP}/dog2"
+
+id=$(awk '/^id:/ { print $2 }' < "${TMP}/dog")
+grep "^id: ${id}$" "${TMP}/dog2"
+
+grep 'password: fox' "${TMP}/dog2"
+grep 'username: dog' "${TMP}/dog2"
+
+# Not checking the `password_hash` (it is expected to change from run
+# to run, due to random seed changes, salting)
+#
+# Similarly, `version_created_at` is an ever changing timestamp.
+
+exit

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/013_credhub_test.sh
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/013_credhub_test.sh
@@ -48,7 +48,7 @@ SELFDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # properly, and query after a rotation as well.
 
 SECRET=$(kubectl get pods --namespace "${NS}" \
-		 -o jsonpath='{.items[*?(.metadata.name=="nats-0")].spec.containers[?(.name=="nats")].env[?(.name=="INTERNAL_CA_CERT")].valueFrom.secretKeyRef.name}')
+		 -o jsonpath='{.items[?(.metadata.name=="nats-0")].spec.containers[?(.name=="nats")].env[?(.name=="INTERNAL_CA_CERT")].valueFrom.secretKeyRef.name}')
 
 CH_SECRET="$(kubectl get secrets --namespace "${NS}" "${SECRET}" -o jsonpath="{.data['uaa-clients-credhub-user-cli-secret']}"|base64 -d)"
 CLIENT=credhub_user_cli


### PR DESCRIPTION
Ref: https://trello.com/c/T7m367ac/814-3-create-brain-test-for-credhub

Testing under vagrant passes.

Two semi-related changes:
- Use apply in `make/tests` now. `create` will error for pre-existing CR, CRB from previous test runs. `apply` either ignores or overwrites them (with the same).
- Small typo in tmp dir name for 011 test.
