### PR TITLE
Fix klog.sh for changed output from kubectl in 1.10

### DIFF
--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -40,7 +40,7 @@ if [ ! -f "${DONE}" ]; then
     rm -rf "${KLOG:?}/${NS:?}"
     mkdir -p "${KLOG}/${NS}"
 
-    PODS=($(kubectl get pods --namespace "${NS}" --output name --show-all=true | sed 's/pods\///'))
+    PODS=($(kubectl get pods --namespace "${NS}" --output name --show-all=true | sed 's/pods\?\///'))
 
     for POD in "${PODS[@]}"; do
         DIR="${KLOG}/${NS}/${POD}"


### PR DESCRIPTION
```
$ kubectl-1.9 get pods --output name --all-namespaces --show-all=true
pods/api-0
...

$ kubectl-1.10 get pods --output name --all-namespaces --show-all=true
pod/api-0
...
```