### PR TITLE
Upgrade Jenkins slave (on AWS) to kube 1.10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -527,7 +527,7 @@ pipeline {
                         --set env.UAA_HOST=uaa.${domain()} \
                         --set env.UAA_PORT=2793 \
                         --set secrets.CLUSTER_ADMIN_PASSWORD=changeme \
-                        --set secrets.UAA_ADMIN_CLIENT_SECRET=uaa-admin-client-secret \
+                        --set secrets.UAA_ADMIN_CLIENT_SECRET=admin_secret \
                         --set kube.external_ips[0]=${ipAddress()} \
                         --set kube.storage_class.persistent=hostpath
 
@@ -543,24 +543,12 @@ pipeline {
                     done
                     set -x
 
-                    UAA_CA_CERT="\$(get_secret "${jobBaseName()}-${BUILD_NUMBER}-uaa" "uaa" "INTERNAL_CA_CERT")"
-
-                    # The extra IP address is to check that the code to set up multiple
-                    # addresses for services is working correctly; it isn't used in
-                    # actual routing.
-                    helm install output/unzipped/helm/cf\${suffix} \
-                        --name ${jobBaseName()}-${BUILD_NUMBER}-scf \
-                        --namespace ${jobBaseName()}-${BUILD_NUMBER}-scf \
-                        --set env.DOMAIN=${domain()} \
-                        --set env.UAA_HOST=uaa.${domain()} \
-                        --set env.UAA_PORT=2793 \
-                        --set env.INSECURE_DOCKER_REGISTRIES='"insecure-registry.${domain()}:20005"' \
-                        --set secrets.CLUSTER_ADMIN_PASSWORD=changeme \
-                        --set secrets.UAA_ADMIN_CLIENT_SECRET=uaa-admin-client-secret \
-                        --set secrets.UAA_CA_CERT="\${UAA_CA_CERT}" \
-                        --set "kube.external_ips[0]=192.0.2.84" \
-                        --set "kube.external_ips[1]=${ipAddress()}" \
-                        --set kube.storage_class.persistent=hostpath \
+                    # Use `make/run` to run the deployment to ensure we have updated settings
+                    export NAMESPACE="${jobBaseName()}-${BUILD_NUMBER}-scf"
+                    export UAA_NAMESPACE="${jobBaseName()}-${BUILD_NUMBER}-uaa"
+                    export DOMAIN="${domain()}"
+                    export CF_CHART="output/unzipped/helm/cf\${suffix}"
+                    make/run
 
                     echo Waiting for all pods to be ready...
                     for ns in "${jobBaseName()}-${BUILD_NUMBER}-uaa" "${jobBaseName()}-${BUILD_NUMBER}-scf" ; do
@@ -606,7 +594,7 @@ pipeline {
                         --set env.UAA_HOST=uaa.${domain()} \
                         --set env.UAA_PORT=2793 \
                         --set secrets.CLUSTER_ADMIN_PASSWORD=changeme \
-                        --set secrets.UAA_ADMIN_CLIENT_SECRET=uaa-admin-client-secret \
+                        --set secrets.UAA_ADMIN_CLIENT_SECRET=admin_secret \
                         --set kube.external_ips[0]=${ipAddress()} \
                         --set kube.storage_class.persistent=hostpath \
                         --set kube.secrets_generation_counter=2
@@ -621,43 +609,16 @@ pipeline {
                     done
                     set -o xtrace
 
-                    UAA_CA_CERT="\$(get_secret "${jobBaseName()}-${BUILD_NUMBER}-uaa" "uaa" "INTERNAL_CA_CERT")"
+                    # Use `make/upgrade` to run the deployment to ensure we have updated settings
+                    export DOMAIN="${domain()}"
+                    export NAMESPACE="${jobBaseName()}-${BUILD_NUMBER}-scf"
+                    export UAA_NAMESPACE="${jobBaseName()}-${BUILD_NUMBER}-uaa"
+                    export CF_CHART="output/unzipped/helm/cf\${suffix}"
+                    export SCF_SECRETS_GENERATION_COUNTER=2
+                    export SCF_ENABLE_AUTOSCALER=1
+                    export SCF_ENABLE_CREDHUB=1
 
-                    UPGRADE_ARGS=(
-                        --namespace ${jobBaseName()}-${BUILD_NUMBER}-scf
-                        --set env.DOMAIN=${domain()}
-                        --set env.UAA_HOST=uaa.${domain()}
-                        --set env.UAA_PORT=2793
-                        --set env.INSECURE_DOCKER_REGISTRIES='"insecure-registry.${domain()}:20005"' \
-                        --set secrets.CLUSTER_ADMIN_PASSWORD=changeme
-                        --set secrets.UAA_ADMIN_CLIENT_SECRET=uaa-admin-client-secret
-                        --set secrets.UAA_CA_CERT="\${UAA_CA_CERT}"
-                        --set kube.storage_class.persistent=hostpath
-                        --set kube.secrets_generation_counter=2
-                        --set sizing.credhub_user.count=1
-                    )
-
-                    # The extra IP address is to check that the code to set up multiple
-                    # addresses for services is working correctly; it isn't used in
-                    # actual routing.
-                    UPGRADE_ARGS=(
-                        "\${UPGRADE_ARGS[@]}"
-                        --set "kube.external_ips[0]=192.0.2.84"
-                        --set "kube.external_ips[1]=${ipAddress()}"
-                    )
-
-                    # Enable the autoscaler so we can run it through smoke tests
-                    for f in output/unzipped/helm/cf\${suffix}/templates/autoscaler-* ; do
-                        f="\${f##*/}" # strip leading directories
-                        f="\${f%.*}"  # strip file extension
-                        UPGRADE_ARGS=(
-                            "\${UPGRADE_ARGS[@]}"
-                            --set "sizing.\${f//-/_}.count=1"
-                        )
-                    done
-
-                    helm upgrade "${jobBaseName()}-${BUILD_NUMBER}-scf" output/unzipped/helm/cf\${suffix} \
-                        "\${UPGRADE_ARGS[@]}"
+                    make/upgrade
 
                     # Ensure old pods have time to terminate
                     sleep 60

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,7 +118,7 @@ Boolean noOverwrites() {
 }
 
 pipeline {
-    agent { label ((["scf"] + (params.AGENT_LABELS ? params.AGENT_LABELS : "").tokenize()).join("&&")) }
+    agent { label ((params.AGENT_LABELS ?: "scf prod").tokenize().join("&&")) }
     options {
         ansiColor('xterm')
         skipDefaultCheckout() // We do our own checkout so it can be disabled
@@ -254,7 +254,7 @@ pipeline {
         )
         string(
             name: 'AGENT_LABELS',
-            defaultValue: '',
+            defaultValue: 'scf prod',
             description: 'Extra labels for Jenkins slave selection',
         )
         credentials(

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure(2) do |config|
 
   vm_memory = ENV.fetch('SCF_VM_MEMORY', ENV.fetch('VM_MEMORY', 10 * 1024)).to_i
   vm_cpus = ENV.fetch('SCF_VM_CPUS', ENV.fetch('VM_CPUS', 4)).to_i
-  vm_box_version = ENV.fetch('SCF_VM_BOX_VERSION', ENV.fetch('VM_BOX_VERSION', '2.0.14'))
+  vm_box_version = ENV.fetch('SCF_VM_BOX_VERSION', ENV.fetch('VM_BOX_VERSION', '2.0.15'))
   vm_registry_mirror = ENV.fetch('SCF_VM_REGISTRY_MIRROR', ENV.fetch('VM_REGISTRY_MIRROR', ''))
 
   # Create a private network, which allows host-only access to the machine

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.37.0"
 export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+170.g9083142"
+export FISSILE_VERSION="7.0.0+172.gb4a87d2"
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"
 export KUBECTL_VERSION="1.9.6"

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -537,6 +537,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/use_routing_api_private_endpoint.sh
   - scripts/patches/fix_monit_rsyslog.sh
+  - scripts/patches/cc_pre_start_home.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release: scf-helper

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -476,7 +476,7 @@ instance_groups:
           max: 20
   configuration:
     templates:
-      properties.dns_health_check_host: 'mysql-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))'
+      properties.dns_health_check_host: 'mysql-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)).'
 - name: routing-api
   environment_scripts:
   - scripts/configure-HA-hosts.sh
@@ -526,7 +526,7 @@ instance_groups:
   - sequential-startup
   configuration:
     templates:
-      properties.dns_health_check_host: 'mysql-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))'
+      properties.dns_health_check_host: 'mysql-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)).'
 - name: api-group
   environment_scripts:
   - scripts/configure-HA-hosts.sh
@@ -1984,7 +1984,7 @@ configuration:
     properties.router.balancing_algorithm: '"((ROUTER_BALANCING_ALGORITHM))"'
     properties.router.client_cert_validation: '"((ROUTER_CLIENT_CERT_VALIDATION))"'
     # We use mysql because it comes up without any other dependencies and its critical for the cluster
-    properties.router.dns_health_check_host: 'mysql-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))'
+    properties.router.dns_health_check_host: 'mysql-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)).'
     properties.router.force_forwarded_proto_https: ((FORCE_FORWARDED_PROTO_AS_HTTPS))
     properties.router.forwarded_client_cert: "((ROUTER_FORWARDED_CLIENT_CERT))"
     properties.router.logging_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'

--- a/container-host-files/etc/scf/config/scripts/patches/cc_pre_start_home.sh
+++ b/container-host-files/etc/scf/config/scripts/patches/cc_pre_start_home.sh
@@ -1,0 +1,27 @@
+#! /usr/bin/env bash
+
+set -e
+
+PATCH_DIR=/var/vcap/jobs-src/cloud_controller_ng/templates
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+patch -d "$PATCH_DIR" --force -p0 <<'PATCH'
+--- migrate_db.sh.erb	2018-11-14 18:29:27.530328727 +0000
++++ migrate_db.sh.erb	2018-11-14 18:29:58.470328727 +0000
+@@ -34,6 +34,7 @@
+ }
+
+ function main {
++  export HOME=/home/vcap # rake needs it to be set to run tasks
+   migrate
+ }
+
+PATCH
+
+touch "${SENTINEL}"
+
+exit 0

--- a/make/run
+++ b/make/run
@@ -7,8 +7,9 @@ cd "${GIT_ROOT}"
 
 . make/include/secrets
 
-NAMESPACE="cf"
-UAA_NAMESPACE="uaa"
+NAMESPACE="${NAMESPACE:-cf}"
+UAA_NAMESPACE="${UAA_NAMESPACE:-uaa}"
+CF_CHART="${CF_CHART:-output/helm}"
 
 supports_psp() {
     kubectl get podsecuritypolicy -o name >/dev/null 2>/dev/null
@@ -55,12 +56,12 @@ kubectl get storageclass | grep --silent '(default)' 2>/dev/null || {
         "${GIT_ROOT}/src/uaa-fissile-release/kube-test/storage-class-host-path.yml" | \
     kubectl create -f -
 }
-STORAGE_CLASS="${STORAGE_CLASS:=$(kubectl get storageclass 2>/dev/null | awk '/(default)/ { print $1 ; exit }')}"
 
-DOMAIN=${DOMAIN:-cf-dev.io}
-TCP_DOMAIN=tcp.${DOMAIN}
-UAA_HOST=uaa.${DOMAIN}
-INSECURE_DOCKER_REGISTRIES="\"insecure-registry.${DOMAIN}:20005\""
+: "${STORAGE_CLASS:=$(kubectl get storageclass 2>/dev/null | awk '/(default)/ { print $1 ; exit }')}"
+: "${DOMAIN:=cf-dev.io}"
+: "${TCP_DOMAIN:=tcp.${DOMAIN}}"
+: "${UAA_HOST:=uaa.${DOMAIN}}"
+: "${INSECURE_DOCKER_REGISTRIES:=\"insecure-registry.${DOMAIN}:20005\"}"
 
 helm_args=(
     --name "${NAMESPACE}"
@@ -114,7 +115,7 @@ if supports_psp ; then
     fi
 fi
 
-helm install output/helm "${helm_args[@]}" "$@"
+helm install "${CF_CHART}" "${helm_args[@]}" "$@"
 
 stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-run::create end
 

--- a/make/upgrade
+++ b/make/upgrade
@@ -6,8 +6,9 @@
 
 set -o errexit -o nounset
 
-NAMESPACE="cf"
-UAA_NAMESPACE="uaa"
+NAMESPACE="${NAMESPACE:-cf}"
+UAA_NAMESPACE="${UAA_NAMESPACE:-uaa}"
+CF_CHART="${CF_CHART:-output/helm}"
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 cd "${GIT_ROOT}"
@@ -19,28 +20,92 @@ cd "${GIT_ROOT}"
 RELEASE=${NAMESPACE}
 echo Upgrading ${NAMESPACE} release \"${RELEASE}\" ...
 
+supports_psp() {
+    kubectl get podsecuritypolicy -o name >/dev/null 2>/dev/null
+}
+
 stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-run start
 stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-run::upgrade start
 
-DOMAIN=${DOMAIN:-cf-dev.io}
-TCP_DOMAIN=tcp.${DOMAIN}
-UAA_HOST=uaa.${DOMAIN}
-INSECURE_DOCKER_REGISTRIES="insecure-registry.${DOMAIN}:20005"
+: "${STORAGE_CLASS:=$(kubectl get storageclass 2>/dev/null | awk '/(default)/ { print $1 ; exit }')}"
+: "${DOMAIN:=cf-dev.io}"
+: "${TCP_DOMAIN:=tcp.${DOMAIN}}"
+: "${UAA_HOST:=uaa.${DOMAIN}}"
+: "${INSECURE_DOCKER_REGISTRIES:=\"insecure-registry.${DOMAIN}:20005\"}"
 
 UAA_CA_CERT="$(get_secret "${UAA_NAMESPACE}" "uaa" "INTERNAL_CA_CERT")"
 
-helm upgrade ${RELEASE} output/helm \
-     --namespace ${NAMESPACE} \
-     --values "bin/settings.yaml" \
-     --set "env.DOMAIN=${DOMAIN}" \
-     --set "env.TCP_DOMAIN=${TCP_DOMAIN}" \
-     --set "env.UAA_HOST=${UAA_HOST}" \
-     --set "env.INSECURE_DOCKER_REGISTRIES=${INSECURE_DOCKER_REGISTRIES}" \
-     --set "kube.auth=rbac" \
-     --set "kube.external_ips[0]=192.0.2.42" \
-     --set "kube.external_ips[1]=$(dig +short "${DOMAIN}")" \
-     --set "secrets.UAA_CA_CERT=${UAA_CA_CERT}" \
-     "$@"
+helm_args=(
+    --namespace "${NAMESPACE}"
+    --values "bin/settings.yaml" \
+    --set "env.DOMAIN=${DOMAIN}"
+    --set "env.TCP_DOMAIN=${TCP_DOMAIN}"
+    --set "env.UAA_HOST=${UAA_HOST}"
+    --set "env.INSECURE_DOCKER_REGISTRIES=${INSECURE_DOCKER_REGISTRIES}"
+    --set "secrets.UAA_CA_CERT=${UAA_CA_CERT}"
+    --set "kube.storage_class.persistent=${STORAGE_CLASS}"
+)
+
+# The extra IP address for `kube.external_ips` is to ensure that we can
+# create services binding to multiple addresses correctly.  It points at
+# an address that shouldn't exist in real life.
+helm_args+=(
+    --set "kube.external_ips[0]=192.0.2.42"
+    --set "kube.external_ips[1]=$(getent hosts "${DOMAIN}" | awk 'NR=1{print $1}')"
+)
+
+if supports_psp ; then
+    psp_privileged="$(kubectl get podsecuritypolicy -o json | jq -r '
+            [
+                .items[] |
+                select(
+                    .spec.allowedCapabilities // [] |
+                    contains(["*"])
+                )
+            ] |
+            first | .metadata.name
+            // ""
+        ')"
+    psp_nonprivileged="$(kubectl get podsecuritypolicy -o json | jq -r '
+            [
+                .items[] |
+                select(
+                    .spec.allowedCapabilities // [] |
+                    contains(["*"]) |
+                    not
+                )
+            ] |
+            first | .metadata.name
+            // ""
+        ')"
+    if [ -n "${psp_privileged}" ] ; then
+        helm_args+=(
+            --set "kube.psp.privileged=${psp_privileged}"
+            --set "kube.psp.nonprivileged=${psp_nonprivileged:-${psp_privileged}}"
+        )
+    fi
+fi
+
+# Force rotate secrets
+if [ -n "${SCF_SECRETS_GENERATION_COUNTER:-}" ] ; then
+    helm_args+=(
+        --set "kube.secrets_generation_counter=${SCF_SECRETS_GENERATION_COUNTER}"
+    )
+fi
+
+if [ -n "${SCF_ENABLE_AUTOSCALER:-}" ] ; then
+    for f in "${CF_CHART}"/templates/autoscaler-* ; do
+        f="${f##*/}" # strip leading directories
+        f="${f%.*}"  # strip file extension
+        helm_args+=( --set "sizing.${f//-/_}.count=1" )
+    done
+fi
+
+if [ -n "${SCF_ENABLE_CREDHUB:-}" ] ; then
+    helm_args+=( --set "sizing.credhub_user.count=1" )
+fi
+
+helm upgrade "${RELEASE}" "${CF_CHART}" "${helm_args[@]}" "$@"
 
 stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-run::upgrade end
 stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-run 'done'

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -12,7 +12,7 @@ vagrant-virtualbox \
 jenkins-slave \
 aws-slave \
 	: http/vagrant-autoyast.xml
-	packer build -only $@ vagrant-box.json
+	packer build -only $@ -var output_directory="$${PACKER_OUTPUT:-$${PWD}/output}" vagrant-box.json
 
 # The following build pieces require txtplate to evaluate Go templates
 http/scf-autoyast.xml: http/autoyast.xml.tpl

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -6,12 +6,13 @@ scf-cached-libvirt: http/scf-autoyast.xml
 		-var ssh_username=scf \
 		-var ssh_password=changeme \
 		vagrant-box.json
-vagrant-libvirt: http/vagrant-autoyast.xml
-	packer build -only vagrant-libvirt vagrant-box.json
-vagrant-virtualbox: http/vagrant-autoyast.xml
-	packer build -only vagrant-virtualbox vagrant-box.json
-jenkins-slave: http/vagrant-autoyast.xml
-	packer build -only jenkins-slave vagrant-box.json
+
+vagrant-libvirt \
+vagrant-virtualbox \
+jenkins-slave \
+aws-slave \
+	: http/vagrant-autoyast.xml
+	packer build -only $@ vagrant-box.json
 
 # The following build pieces require txtplate to evaluate Go templates
 http/scf-autoyast.xml: http/autoyast.xml.tpl

--- a/packer/http/add-github-users.sh
+++ b/packer/http/add-github-users.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Allow GitHub users to access this machine via SSH
+# Requires the following environment variables:
+# - GITHUB_ACCESS_TOKEN
+# - GITHUB_TEAM_ID
+
+set -o errexit -o nounset
+
+curl --silent -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" "https://api.github.com/teams/${GITHUB_TEAM_ID}/members" \
+    | jq -r '.[].login' \
+    | while read id ; do
+        curl --silent "https://github.com/${id}.keys" | sed "s#\$# ${id}@github#" | tee -a ~ec2-user/.ssh/authorized_keys
+    done

--- a/packer/http/apiserver-vagrant-overrides.env
+++ b/packer/http/apiserver-vagrant-overrides.env
@@ -3,4 +3,4 @@ KUBE_API_ADDRESS="--insecure-bind-address=0.0.0.0"
 # Allow privileged containers for diego-cell (also need to adjust kubelet)
 KUBE_ALLOW_PRIV="--allow-privileged"
 # Modify admission control policies to enforce pod security policies
-KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy"
+KUBE_ADMISSION_CONTROL="--enable-admission-plugins PodSecurityPolicy"

--- a/packer/http/controller-manager-vagrant-overrides.conf
+++ b/packer/http/controller-manager-vagrant-overrides.conf
@@ -4,6 +4,7 @@ ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/apiserver.crt /var/run/kubern
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/apiserver.key /var/run/kubernetes/serviceaccount.key
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/CA.kube.vagrant.crt /etc/kubernetes/ca/ca.pem
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/CA.kube.vagrant.key /etc/kubernetes/ca/ca.key
+After=kube-apiserver.service
 
 # This needs to be run as root to correctly delete volumes (owned by users in containers)
 # See https://github.com/SUSE/scf/issues/999

--- a/packer/http/create-kubelet-overrides.sh
+++ b/packer/http/create-kubelet-overrides.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# This file creates kubelet overrides to fix busted packages
+
+mkdir -p /etc/systemd/system/kubelet.service.d/
+perl - /etc/kubernetes/kubelet \
+    > /etc/systemd/system/kubelet.service.d/vagrant-overrides.env \
+    <<"EOF"
+use feature "say";
+say 'KUBE_ALLOW_PRIV="--allow-privileged"';
+while (<>) {
+    if (m/^KUBELET_ARGS/) {
+        # --cgroups-per-qos is needed for constraints
+        # https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#enabling-qos-and-pod-level-cgroups
+        s/--cgroups-per-qos=false//;
+        # --network-plugin-dir is now --cni-bin-dir
+        s/--network-plugin-dir/--cni-bin-dir/;
+        # KubeletConfigFile is always enabled on newer kube
+        s/--feature-gates KubeletConfigFile=true//;
+        say;
+    };
+}
+EOF

--- a/packer/http/docker.conf
+++ b/packer/http/docker.conf
@@ -1,3 +1,3 @@
 # This file is uploaded via packer, but only after the first stage setup is done
 # (because otherwise 192.168.77.77 isn't a valid address to listen on)
-DOCKER_OPTS="--insecure-registry=0.0.0.0/0 --host=unix:///var/run/docker.sock --storage-driver=overlay2"
+DOCKER_OPTS="--insecure-registry=0.0.0.0/0 --host=unix:///var/run/docker.sock --storage-driver=overlay2 --default-ulimit nofile=100000"

--- a/packer/http/install-jenkins-slave.sh
+++ b/packer/http/install-jenkins-slave.sh
@@ -11,7 +11,7 @@
 set -o xtrace -o errexit -o nounset
 
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-JENKINS_LABEL="${INSTANCE_ID}"
+JENKINS_LABEL="${JENKINS_LABEL:-${INSTANCE_ID}}"
 
 mkdir -p /opt/jenkins
 

--- a/packer/http/install-jenkins-slave.sh
+++ b/packer/http/install-jenkins-slave.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# This script installs the Jenkins slave related services
+# This should be run on cloud-init as root
+
+# Requires the following environment variables:
+# JENKINS_URL — 
+# JENKINS_AUTH_USER
+# JENKINS_AUTH_PASS
+
+set -o xtrace -o errexit -o nounset
+
+INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+JENKINS_LABEL="${INSTANCE_ID}"
+
+mkdir -p /opt/jenkins
+
+curl -Lo /opt/jenkins/slave.jar "${JENKINS_URL}/jnlpJars/slave.jar"
+curl -Lo /opt/jenkins/cli.jar "${JENKINS_URL}/jnlpJars/jenkins-cli.jar"
+
+cat <<EOF >/opt/jenkins/node.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<slave>
+  <name>${INSTANCE_ID}</name>
+  <description></description>
+  <remoteFS>/data/jenkins</remoteFS>
+  <numExecutors>1</numExecutors>
+  <mode>NORMAL</mode>
+  <retentionStrategy class="hudson.slaves.RetentionStrategy\$Always"/>
+  <launcher class="hudson.slaves.JNLPLauncher">
+    <workDirSettings>
+      <disabled>false</disabled>
+      <internalDir>remoting</internalDir>
+      <failIfWorkDirIsMissing>false</failIfWorkDirIsMissing>
+    </workDirSettings>
+  </launcher>
+  <label>${JENKINS_LABEL}</label>
+  <nodeProperties/>
+</slave>
+EOF
+
+cat <<EOF >/opt/jenkins/agent
+#! /usr/bin/env bash
+# -*- shell-script -*-
+set -o xtrace
+INSTANCE_ID=${INSTANCE_ID}
+JENKINS_URL=${JENKINS_URL}
+JENKINS_AUTH=${JENKINS_AUTH_USER}:${JENKINS_AUTH_PASS}
+export JENKINS_URL
+if ! java -jar /opt/jenkins/cli.jar -auth "\${JENKINS_AUTH}" get-node "\${INSTANCE_ID}"
+then xml edit --update //slave/name --value "\${INSTANCE_ID}" /opt/jenkins/node.xml \
+        | java -jar /opt/jenkins/cli.jar -auth "\${JENKINS_AUTH}" create-node "\${INSTANCE_ID}"
+fi
+exec java -jar /opt/jenkins/slave.jar -jnlpUrl "\${JENKINS_URL}/computer/\${INSTANCE_ID}/slave-agent.jnlp" -jnlpCredentials "\${JENKINS_AUTH}"
+EOF
+
+chmod +x /opt/jenkins/agent
+
+cat <<EOF >/etc/systemd/system/jenkins-agent.service
+# /etc/systemd/system/jenkins-agent.service
+[Install]
+WantedBy=multi-user.target
+[Unit]
+Description=Jenkins Agent
+After=remote-fs.target network-online.target nss-lookup.target time-sync.target sendmail.service
+Wants=remote-fs.target network-online.target nss-lookup.target
+[Service]
+ExecStart=/opt/jenkins/agent
+Group=jenkins
+PermissionsStartOnly=true
+Restart=no
+User=jenkins
+EOF
+
+mkdir -p /data
+mount -a
+groupadd --system jenkins
+useradd --system --gid jenkins --home-dir /data/jenkins --create-home jenkins
+
+for user in ec2-user jenkins
+    do usermod --append --groups docker "${user}"
+done
+
+systemctl enable --now jenkins-agent.service

--- a/packer/http/kubelet-vagrant-overrides.conf
+++ b/packer/http/kubelet-vagrant-overrides.conf
@@ -2,7 +2,9 @@
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/kubelet.crt /var/run/kubernetes/kubelet.crt
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/kubelet.key /var/run/kubernetes/kubelet.key
 ExecStartPre=/usr/bin/chown kube:kube /tmp/hostpath_pv/
+ExecStartPre=/usr/local/bin/create-kubelet-overrides.sh
 # Allow machines outside vagrant box to talk to kubernetes &c
 # https://docs.docker.com/engine/userguide/networking/default_network/container-communication/#container-communication-between-hosts
 ExecStartPost=/usr/sbin/iptables -t filter -P FORWARD ACCEPT
-EnvironmentFile=/etc/systemd/system/kubelet.service.d/vagrant-overrides.env
+EnvironmentFile=-/etc/systemd/system/kubelet.service.d/vagrant-overrides.env
+After=kube-apiserver.service

--- a/packer/http/kubelet-vagrant-overrides.env
+++ b/packer/http/kubelet-vagrant-overrides.env
@@ -1,4 +1,0 @@
-KUBE_ALLOW_PRIV="--allow-privileged"
-KUBELET_API_SERVER=""
-# --network-plugin-dir was renamed to --cni-bin-dir
-KUBELET_ARGS="--config=/etc/kubernetes/kubelet-config.yaml --volume-plugin-dir=/usr/lib/kubernetes/kubelet-plugins --cluster-dns=10.254.0.254 --cluster-domain=cluster.local --cgroups-per-qos=false --enforce-node-allocatable='' --network-plugin='kubenet' --non-masquerade-cidr=172.16.0.0/16 --pod-cidr=172.16.0.0/16 --cni-bin-dir=/usr/lib/cni/ --kubeconfig /etc/kubernetes/kubelet-config"

--- a/packer/http/make-var-run-kubernetes.service
+++ b/packer/http/make-var-run-kubernetes.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Create /var/run/kubernetes
+After=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/bin/mkdir -p /var/run/kubernetes
+ExecStart=/usr/bin/chown kube:kube /var/run/kubernetes
+
+[Install]
+RequiredBy=kube-apiserver.service

--- a/packer/http/setup-data-partition.sh
+++ b/packer/http/setup-data-partition.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Set up the /data partition for AWS
+
+set -o errexit -o xtrace -o nounset
+exec >&2
+
+debug() {
+    "$@" || true
+}
+
+debug lsblk
+debug partx --show - /dev/nvme0n1
+
+for device in xvdb nvme1n1 nvme0n1 ; do
+    if [ -e "/dev/${device}" ] ; then
+        break
+    fi
+done
+if [ ! -e "/dev/${device}" ] ; then
+    echo "No device found for /data" >&2
+    exit 0
+fi
+
+debug sfdisk --list "/dev/${device}"
+if ! sfdisk --list "/dev/${device}" | grep "Linux filesystem" ; then
+    # No partitions, create it
+    printf 'label: gpt\n- - L\n' | sfdisk "/dev/${device}"
+fi
+
+debug sfdisk --list "/dev/${device}"
+debug lsblk --fs
+
+partition="$(lsblk --fs --pairs "/dev/${device}" | perl -e 'while(<>) { /NAME="(.*?)"/ && { $p = $1 } } ; print $p')"
+
+if ! lsblk --fs "/dev/${partition}" | grep --silent ext4 ; then
+    # No filesystem
+    mkfs.ext4 "/dev/${partition}"
+fi
+
+mkdir -p /data
+
+if ! systemctl cat data.mount | grep --silent "What=/dev/${partition}" ; then
+    cat <<EOF | sed 's@ *@@' > /etc/systemd/system/data.mount
+        [Unit]
+        Description=Mount unit for the /data partition on aws-slave
+        Before=local-fs.target
+
+        [Install]
+        RequiredBy=local-fs.target
+
+        [Mount]
+        Where=/data
+        What=/dev/${partition}
+EOF
+    systemctl daemon-reload
+fi
+
+service=setup-data-partition.service
+if ! systemctl list-units "${service}" | grep --silent "${service}" ; then
+    cat <<EOF | sed 's@ *@@' > "/etc/systemd/system/${service}"
+        [Unit]
+        Description=Set up data partition on aws-slave
+        Before=data.mount
+
+        [Install]
+        RequiredBy=data.mount
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=$0
+EOF
+fi

--- a/packer/scripts/install-certstrap.sh
+++ b/packer/scripts/install-certstrap.sh
@@ -6,10 +6,10 @@ set -o errexit -o xtrace
 echo "Installing certstrap ..."
 # We run chown in docker to avoid requiring sudo
 systemctl start docker.service
-docker run --rm -v /usr/local/bin:/out:rw "golang:1.7" /usr/bin/env GOBIN=/out go get github.com/square/certstrap
+docker run --rm -v /usr/local/bin:/out:rw "golang:1.11" /usr/bin/env GOBIN=/out go get github.com/square/certstrap
 if [[ $(stat -c '%u' "/usr/local/bin/certstrap") -eq 0 ]]; then
   # This pulls the go:1.7 image into the docker image data of the packer-built image. Normally, we'd want to clean this
   # up, but we happen to use this same image in the dev deployment for installing helm-certgen. If the requirement there
   # changes, we should clear the docker image date in the packer building to free up ~200MiB in the image
-  docker run --rm -v /usr/local/bin:/out:rw "golang:1.7" /bin/chown "$(id -u):$(id -g)" /out/certstrap
+  docker run --rm -v /usr/local/bin:/out:rw "golang:1.11" /bin/chown "$(id -u):$(id -g)" /out/certstrap
 fi

--- a/packer/scripts/install-kubernetes.sh
+++ b/packer/scripts/install-kubernetes.sh
@@ -7,13 +7,38 @@ set -o errexit -o xtrace
 # Kube doesn't like swap: https://github.com/kubernetes/kubernetes/blob/e4551d50e57c089aab6f67333412d3ca64bc09ae/pkg/kubelet/cm/container_manager_linux.go#L207-L209
 swapoff -a
 
+if zypper --no-refresh products --installed-only | grep --silent SLES ; then
+    product=SLE
+else
+    product=openSUSE_Leap
+fi
+# $releasever is 12.3 on SLE12SP3, but the repo is ...12_SP3; use the string instead
+releasever="$(awk -F'"' '/^VERSION=/ { print $2 }' /etc/os-release | tr - _)"
+
+# This repo is needed on SLE for conntrack-tools
+if [ "${product}" == "SLE" ] ; then
+    zypper --non-interactive addrepo --gpgcheck --refresh --priority 300 --check \
+        "http://download.opensuse.org/repositories/Cloud:/OpenStack:/Queens/${product}_${releasever}" \
+            OpenStack-Queens
+fi
+
 # Use the expanded repo URL to avoid https -> http redirect
 zypper --non-interactive addrepo --gpgcheck --refresh --priority 120 --check \
-    'http://download.opensuse.org/repositories/devel:/CaaSP:/Head:/ControllerNode/openSUSE_Leap_$releasever' \
+    "http://download.opensuse.org/repositories/devel:/CaaSP:/Head:/ControllerNode/${product}_${releasever}" \
     CaaSP
 
 zypper --non-interactive --gpg-auto-import-keys refresh
 zypper --non-interactive repos --uri --priority # for troubleshooting
+
+# SLE 12SP3 have incompatible versions of these
+zypper search --installed-only --match-exact \
+        containerd \
+        docker \
+        docker-libnetwork \
+        docker-runc \
+        runc \
+    | awk '/^i/ { print $3 }' \
+    | xargs --no-run-if-empty zypper --non-interactive remove --no-confirm
 
 zypper --non-interactive install --no-confirm --from=CaaSP \
     etcd \

--- a/packer/scripts/install-slave-tools.sh
+++ b/packer/scripts/install-slave-tools.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This installs extra tools for Jenkins slaves
+
+zypper() {
+    command zypper --non-interactive "$@"
+}
+
+if zypper --no-refresh products --installed-only | grep --silent SLES ; then
+    product=SLE
+else
+    product=openSUSE_Leap
+fi
+# $releasever is 12.3 on SLE12SP3, but the repo is ...12_SP3; use the string instead
+releasever="$(awk -F'"' '/^VERSION=/ { print $2 }' /etc/os-release | tr - _)"
+
+if ! command -v jq ; then
+    if ! zypper search --match-exact jq ; then
+        repo="http://download.opensuse.org/repositories/Cloud:Platform:SUSE-Stemcell/${product}_${releasever}"
+        zypper addrepo --check --priority 150 "${repo}" utilities
+        zypper --gpg-auto-import-keys refresh utilities
+    fi
+    zypper install jq
+fi

--- a/packer/scripts/setup-pod-security-policies.sh
+++ b/packer/scripts/setup-pod-security-policies.sh
@@ -102,6 +102,34 @@ kubectl create -f - <<EOF
 }
 EOF
 
+kubectl create -f - <<EOF
+{
+  "apiVersion": "rbac.authorization.k8s.io/v1",
+  "kind": "ClusterRole",
+  "metadata": { "name": "suse:cap-vagrant:clusterrole:psp:privileged" },
+  "rules": [ {
+    "apiGroups": [ "extensions" ],
+    "resourceNames": [ "suse.cap-vagrant.psp.privileged" ],
+    "resources": [ "podsecuritypolicies" ],
+    "verbs": [ "use" ]
+  } ]
+}
+EOF
+
+kubectl create -f - <<EOF
+{
+  "apiVersion": "rbac.authorization.k8s.io/v1",
+  "kind": "ClusterRole",
+  "metadata": { "name": "suse:cap-vagrant:clusterrole:psp:unprivileged" },
+  "rules": [ {
+    "apiGroups": [ "extensions" ],
+    "resourceNames": [ "suse.cap-vagrant.psp.unprivileged" ],
+    "resources": [ "podsecuritypolicies" ],
+    "verbs": [ "use" ]
+  } ]
+}
+EOF
+
 # Allow all users and serviceaccounts to use the unprivileged
 # PodSecurityPolicy
 kubectl auth reconcile -f - <<EOF
@@ -114,7 +142,7 @@ kubectl auth reconcile -f - <<EOF
   "roleRef": {
     "apiGroup": "rbac.authorization.k8s.io",
     "kind": "ClusterRole",
-    "name": "suse:cap-vagrant:psp:unprivileged"
+    "name": "suse:cap-vagrant:clusterrole:psp:unprivileged"
   },
   "subjects": [
     {
@@ -142,7 +170,7 @@ kubectl auth reconcile -f - <<EOF
   "roleRef": {
     "apiGroup": "rbac.authorization.k8s.io",
     "kind": "ClusterRole",
-    "name": "suse:cap-vagrant:psp:privileged"
+    "name": "suse:cap-vagrant:clusterrole:psp:privileged"
   },
   "subjects": [
     {

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -181,14 +181,79 @@
     "provisioners": [
         {
             "type": "shell",
-            "only": ["jenkins-slave"],
+            "only": ["aws-slave"],
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
+            "inline": [
+                "# cloud-final can get stuck in a failed state",
+                "while true ; do",
+                "  case \"$(systemctl is-active cloud-final.service)\" in",
+                "    active) break;;",
+                "    failed) systemctl restart cloud-final.service;;",
+                "    *)      sleep 10;;",
+                "  esac",
+                "done"
+            ]
+        },
+        {
+            "type": "shell",
+            "only": ["jenkins-slave", "aws-slave"],
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
             "inline": [
                 "# Create vagrant user",
                 "useradd --create-home vagrant",
                 "echo vagrant:vagrant | chpasswd",
                 "# Enable swap accounting",
-                "perl -p -i -e 's@^(GRUB_CMDLINE_LINUX_DEFAULT)=\"(.*)\"@$1=\"$2 swapaccount=1\"@' /etc/default/grub",
+                "perl -p -i -e 's@^(GRUB_CMDLINE_LINUX(?:_DEFAULT)?)=\"(.*)\"@$1=\"$2 cgroup_enable=memory swapaccount=1\"@' /etc/default/grub",
                 "grub2-mkconfig -o /boot/grub2/grub.cfg"
+            ]
+        },
+        {
+            "type": "file",
+            "only": ["aws-slave"],
+            "source": "http/setup-data-partition.sh",
+            "destination": "/tmp/setup-data-partition.sh"
+        },
+        {
+            "type": "shell",
+            "only": ["aws-slave"],
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
+            "inline": [
+                "set -o xtrace",
+                "mv /tmp/setup-data-partition.sh /usr/local/bin/",
+                "chmod a+x /usr/local/bin/setup-data-partition.sh",
+                "/usr/local/bin/setup-data-partition.sh",
+                "systemctl daemon-reload",
+                "systemctl enable data.mount",
+                "systemctl enable setup-data-partition.service",
+                "if ! systemctl start data.mount ; then",
+                "  journalctl --since=-1min",
+                "  systemctl cat data.mount",
+                "  systemctl status -l data.mount",
+                "  systemctl cat setup-data-partition.service",
+                "  systemctl status -l setup-data-partition.service",
+                "  exit 1",
+                "fi"
+            ]
+        },
+        {
+            "type": "file",
+            "source": "http/docker.conf",
+            "destination": "/tmp/docker.conf"
+        },
+        {
+            "type": "shell",
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
+            "inline": [
+                "mv /tmp/docker.conf /etc/sysconfig/docker"
+            ]
+        },
+        {
+            "type": "shell",
+            "only": ["jenkins-slave", "aws-slave"],
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
+            "inline": [
+                "# jenkins-slave / aws-slave need to put docker graph in /data for the larger disk",
+                "perl -p -i -e 's@(DOCKER_OPTS)=\"(.*)\"@$1=\"$2 --graph=/data/docker\"@' /etc/sysconfig/docker"
             ]
         },
         {
@@ -197,6 +262,11 @@
             "scripts": [
                 "scripts/install-kubernetes.sh"
             ]
+        },
+        {
+            "type": "file",
+            "source": "http/make-var-run-kubernetes.service",
+            "destination": "/tmp/make-var-run-kubernetes.service"
         },
         {
             "type": "file",
@@ -220,13 +290,13 @@
         },
         {
             "type": "file",
-            "source": "http/kubelet-vagrant-overrides.env",
-            "destination": "/tmp/kubelet-vagrant-overrides.env"
+            "source": "http/containerd-vagrant-overrides.conf",
+            "destination": "/tmp/containerd-vagrant-overrides.conf"
         },
         {
             "type": "file",
-            "source": "http/containerd-vagrant-overrides.conf",
-            "destination": "/tmp/containerd-vagrant-overrides.conf"
+            "source": "http/create-kubelet-overrides.sh",
+            "destination": "/tmp/create-kubelet-overrides.sh"
         },
         {
             "type": "file",
@@ -239,15 +309,11 @@
             "destination": "/tmp/user-limits.conf"
         },
         {
-            "type": "file",
-            "source": "http/docker.conf",
-            "destination": "/tmp/docker.conf"
-        },
-        {
             "type": "shell",
             "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
             "inline": [
                 "# Create directories to ensure packer doesn't mess up",
+                "mv /tmp/make-var-run-kubernetes.service /etc/systemd/system/",
                 "mkdir -p /etc/systemd/system/kube-apiserver.service.d/",
                 "mv /tmp/apiserver-vagrant-overrides.conf /etc/systemd/system/kube-apiserver.service.d/vagrant-overrides.conf",
                 "mv /tmp/apiserver-vagrant-overrides.env /etc/systemd/system/kube-apiserver.service.d/vagrant-overrides.env",
@@ -255,45 +321,86 @@
                 "mv /tmp/controller-manager-vagrant-overrides.conf /etc/systemd/system/kube-controller-manager.service.d/vagrant-overrides.conf",
                 "mkdir -p /etc/systemd/system/kubelet.service.d/",
                 "mv /tmp/kubelet-vagrant-overrides.conf /etc/systemd/system/kubelet.service.d/vagrant-overrides.conf",
-                "mv /tmp/kubelet-vagrant-overrides.env /etc/systemd/system/kubelet.service.d/vagrant-overrides.env",
+                "# vagrant-overrides.env generated by create-kubelet-overrides.sh",
+                "mv /tmp/create-kubelet-overrides.sh /usr/local/bin/",
+                "chmod a+x /usr/local/bin/create-kubelet-overrides.sh",
                 "mkdir -p /etc/kubernetes",
                 "mv /tmp/kubelet-config /etc/kubernetes/kubelet-config",
                 "mkdir -p /etc/systemd/system/containerd.service.d",
                 "mv /tmp/containerd-vagrant-overrides.conf /etc/systemd/system/containerd.service.d/vagrant-overrides.conf",
                 "mv /tmp/user-limits.conf /etc/security/limits.d/vagrant-nproc.conf",
-                "mv /tmp/docker.conf /etc/sysconfig/docker"
+                "systemctl daemon-reload",
+                "systemctl enable --now make-var-run-kubernetes.service"
             ]
         },
         {
             "type": "file",
-            "only": ["jenkins-slave"],
+            "only": ["jenkins-slave", "aws-slave"],
             "source": "http/controller-manager-jenkins-overrides.conf",
-            "destination": "/etc/systemd/system/kube-controller-manager.service.d/jenkins-overrides.conf"
+            "destination": "/tmp/controller-manager-jenkins-overrides.conf"
         },
         {
             "type": "file",
-            "only": ["jenkins-slave"],
+            "only": ["jenkins-slave", "aws-slave"],
             "source": "http/data-hostpath-create.service",
-            "destination": "/etc/systemd/system/data-hostpath-create.service"
+            "destination": "/tmp/data-hostpath-create.service"
         },
         {
             "type": "file",
-            "only": ["jenkins-slave"],
+            "only": ["jenkins-slave", "aws-slave"],
             "source": "http/tmp-hostpath_pv.automount",
-            "destination": "/etc/systemd/system/tmp-hostpath_pv.automount"
+            "destination": "/tmp/tmp-hostpath_pv.automount"
         },
         {
             "type": "file",
-            "only": ["jenkins-slave"],
+            "only": ["jenkins-slave", "aws-slave"],
             "source": "http/tmp-hostpath_pv.mount",
-            "destination": "/etc/systemd/system/tmp-hostpath_pv.mount"
+            "destination": "/tmp/tmp-hostpath_pv.mount"
         },
         {
             "type": "shell",
-            "only": ["jenkins-slave"],
+            "only": ["jenkins-slave", "aws-slave"],
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
             "inline": [
-                "# jenkins-slave (triton) needs to put docker graph in /data for the larger disk",
-                "perl -p -i -e 's@(DOCKER_OPTS)=\"(.*)\"@$1=\"$2 --graph=/data/docker\"@' /etc/sysconfig/docker"
+                "# Ensure we mount /data before launching kubernetes",
+                "mkdir -p /etc/systemd/system/kube-controller-manager.service.d/",
+                "mv /tmp/controller-manager-jenkins-overrides.conf /etc/systemd/system/kube-controller-manager.service.d/jenkins-overrides.conf",
+                "mv /tmp/data-hostpath-create.service /etc/systemd/system/",
+                "mv /tmp/tmp-hostpath_pv.automount /etc/systemd/system/",
+                "mv /tmp/tmp-hostpath_pv.mount /etc/systemd/system/",
+                "systemctl daemon-reload"
+            ]
+        },
+        {
+            "type": "shell",
+            "only": ["aws-slave"],
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
+            "scripts": [
+                "scripts/install-slave-tools.sh"
+            ]
+        },
+        {
+            "type": "file",
+            "only": ["aws-slave"],
+            "source": "http/install-jenkins-slave.sh",
+            "destination": "/tmp/install-jenkins-slave.sh"
+        },
+        {
+            "type": "file",
+            "only": ["aws-slave"],
+            "source": "http/add-github-users.sh",
+            "destination": "/tmp/add-github-users.sh"
+        },
+        {
+            "type": "shell",
+            "only": ["aws-slave"],
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
+            "inline": [
+                "for f in install-jenkins-slave.sh add-github-users.sh",
+                "do",
+                "  mv \"/tmp/${f}\" \"/usr/local/bin/${f}\"",
+                "  chmod a+x \"/usr/local/bin/${f}\"",
+                "done"
             ]
         },
         {
@@ -322,7 +429,7 @@
         },
         {
             "type": "shell",
-            "only": ["jenkins-slave", "scf-cached-libvirt"],
+            "only": ["jenkins-slave", "scf-cached-libvirt", "aws-slave" ],
             "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
             "scripts": [
                 "scripts/install-helm.sh",
@@ -350,9 +457,13 @@
         },
         {
             "type": "shell",
-            "only": ["jenkins-slave"],
+            "only": ["jenkins-slave", "aws-slave"],
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
             "inline": [
-                "zypper --non-interactive install jre-openjdk-headless make zip osc"
+                "zypper --non-interactive install jre-openjdk-headless make osc xmlstarlet zip",
+                "# older mozilla-nss + newer JRE doesn't work",
+                "# https://bugzilla.redhat.com/show_bug.cgi?id=1332456",
+                "zypper --non-interactive up mozilla-nss"
             ]
         },
         {
@@ -365,8 +476,22 @@
         },
         {
             "type": "shell",
+            "only": ["aws-slave"],
+            "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
+            "inline": [
+                "# Remove stale cloud-init data",
+                "rm -f /var/log/cloud-init.log /var/log/cloud-init-output.log",
+                "rm -rf /var/lib/cloud/data",
+                "rm -rf /var/lib/cloud/instances",
+                "rm -rf /var/lib/cloud/instance"
+            ]
+        },
+        {
+            "type": "shell",
+            "only": ["vagrant-vmware", "vagrant-virtualbox", "vagrant-libvirt", "jenkins-slave", "scf-cached-libvirt"],
             "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
             "scripts": [
+                "# Compact the disk; unnecessary on AWS",
                 "scripts/compact.sh"
             ],
             "start_retry_timeout": "7m"

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -2,6 +2,7 @@
     "variables": {
         "version": "2.0.15",
         "vm_name": "scf-vagrant",
+        "output_directory": "output",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",
         "iso_url": "http://download.opensuse.org/distribution/leap/15.0/iso/openSUSE-Leap-15.0-NET-x86_64.iso",
@@ -64,6 +65,7 @@
             "iso_url": "{{user `iso_url`}}",
             "iso_checksum": "{{user `iso_checksum`}}",
             "iso_checksum_type": "{{user `iso_checksum_type`}}",
+            "output_directory": "{{user `output_directory`}}/virtualbox",
             "http_directory": "{{user `http_directory`}}",
             "ssh_wait_timeout": "{{user `ssh_wait_timeout`}}",
             "shutdown_command": "{{user `shutdown_command`}}",
@@ -95,6 +97,7 @@
             "iso_url": "{{user `iso_url`}}",
             "iso_checksum": "{{user `iso_checksum`}}",
             "iso_checksum_type": "{{user `iso_checksum_type`}}",
+            "output_directory": "{{user `output_directory`}}/libvirt",
             "http_directory": "{{user `http_directory`}}",
             "shutdown_command": "{{user `shutdown_command`}}",
             "qemuargs": [
@@ -491,7 +494,6 @@
             "only": ["vagrant-vmware", "vagrant-virtualbox", "vagrant-libvirt", "jenkins-slave", "scf-cached-libvirt"],
             "execute_command": "sudo -E /usr/bin/env {{.Vars}} bash '{{.Path}}'",
             "scripts": [
-                "# Compact the disk; unnecessary on AWS",
                 "scripts/compact.sh"
             ],
             "start_retry_timeout": "7m"

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -7,6 +7,9 @@
         "iso_url": "http://download.opensuse.org/distribution/leap/15.0/iso/openSUSE-Leap-15.0-NET-x86_64.iso",
         "iso_checksum": "1a322de7c215da96fdbad4c247d218eb79073c5620a332a759c0291b44746fbc",
         "iso_checksum_type": "sha256",
+        "aws_region": "eu-central-1",
+        "aws_instance_type": "m5d.xlarge",
+        "aws_spot_price": "0.398",
         "http_directory": "http",
         "ssh_wait_timeout": "300m",
         "source_machine_package": "{{ env `SOURCE_MACHINE_PACKAGE` }}",
@@ -148,6 +151,31 @@
             "triton_key_id": "{{ user `triton_key_id` }}",
             "triton_key_material": "{{ user `ssh_private_key_file` }}",
             "triton_url": "{{ user `triton_url` }}"
+        },
+        {
+            "name": "aws-slave",
+            "type": "amazon-ebs",
+            "ami_name": "{{ user `vm_name` }}-{{ user `version` }}-{{ isotime \"20060102-1504\" }}",
+            "instance_type": "{{ user `aws_instance_type` }}",
+            "region": "{{ user `aws_region` }}",
+            "ami_description": "CAP Jenkins slave",
+            "ami_virtualization_type": "hvm",
+            "availability_zone": "{{ user `aws_region` }}a",
+            "ebs_optimized": true,
+            "shutdown_behavior": "terminate",
+            "source_ami_filter": {
+                "filters": {
+                    "virtualization-type": "hvm",
+                    "name": "suse-sles-12-sp3-*-hvm-ssd-x86_64",
+                    "root-device-type": "ebs"
+                },
+                "owners": ["013907871322"],
+                "most_recent": true
+            },
+            "spot_price": "{{ user `aws_spot_price` }}",
+            "ssh_username": "ec2-user",
+            "ssh_keypair_name": "jenkins-slave",
+            "ssh_agent_auth": true
         }
     ],
     "provisioners": [

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "2.0.14",
+        "version": "2.0.15",
         "vm_name": "scf-vagrant",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",


### PR DESCRIPTION
This bumps the Jenkins slave (as an AMI) to kube 1.10.

Includes a workaround for the thing where we need `CAP_SYS_RESOURCE` for a few roles that run `ulimit -n` in their init scripts; we still need a better fix there.  Note also that the new kube supports PSPs (so the scripts are updated to account for it).

Please see the individual commit messages for details.

Resolves #1847