### PR TITLE
vagrantfile: libvirt: passthrough random

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -132,6 +132,7 @@ Vagrant.configure(2) do |config|
     # Allow downloading boxes from sites with self-signed certs
     libvirt.memory = vm_memory
     libvirt.cpus = vm_cpus
+    libvirt.random model: 'random'
     override.vm.synced_folder ".fissile/.bosh", "/home/vagrant/.bosh", type: "nfs"
     override.vm.synced_folder ".", "/home/vagrant/scf", type: "nfs"
   end


### PR DESCRIPTION
This passes through `/dev/random` to the VM to hopefully let it get more entropy.

Documentation on the argument: https://github.com/vagrant-libvirt/vagrant-libvirt#random-number-generator-passthrough