### PR TITLE
forward_logfiles: use explicit path to monit

### DIFF
--- a/container-host-files/etc/scf/config/scripts/forward_logfiles.sh
+++ b/container-host-files/etc/scf/config/scripts/forward_logfiles.sh
@@ -165,7 +165,7 @@ fi
 if searchTargetDir "${RSYSLOG_FORWARDER_WATCH_DIR}"; then
         if test -r "${PID_FILE}"; then
                 if test -d "/proc/$(cat "${PID_FILE}")"; then
-                        monit restart rsyslogd
+                        /var/vcap/bosh/bin/monit restart rsyslogd
                 fi
         fi
 fi


### PR DESCRIPTION
`monit` is normally not in the `$PATH` since it was moved into a (BOSH) package; refer to it by the explicit path to ensure that we can find it.