### PR TITLE
role manifest: ask for SYS_RESOURCE caps where necessary

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -251,6 +251,7 @@ instance_groups:
                       values:
                       - nats
                   topologyKey: "beta.kubernetes.io/os"
+          service-account: withsysresource
         ports:
         - name: nats
           protocol: TCP
@@ -454,6 +455,7 @@ instance_groups:
                       values:
                       - diego-api
                   topologyKey: "beta.kubernetes.io/os"
+          service-account: withsysresource
         ports:
         - name: cell-bbs-api
           protocol: TCP
@@ -666,6 +668,7 @@ instance_groups:
                   topologyKey: "beta.kubernetes.io/os"
           # All the routes exposed require UAA auth, so we stick with the TCP healthcheck
           active-passive-probe: head -c0 </dev/tcp/${HOSTNAME}/3000
+          service-account: withsysresource
         ports:
         - name: routing-api
           protocol: TCP
@@ -1057,6 +1060,7 @@ instance_groups:
                   topologyKey: "beta.kubernetes.io/os"
           # Auctioneer has no useful healthcheck routes; we can only use the TCP port
           active-passive-probe: head -c0 </dev/tcp/${HOSTNAME}/9016
+          service-account: withsysresource
         ports:
         - name: diego-auction
           protocol: TCP
@@ -1113,6 +1117,7 @@ instance_groups:
                       values:
                       - cc-uploader
                   topologyKey: "beta.kubernetes.io/os"
+          service-account: withsysresource
         ports:
         - name: cc-up-listen
           protocol: TCP
@@ -1161,6 +1166,7 @@ instance_groups:
                       values:
                       - diego-ssh
                   topologyKey: "beta.kubernetes.io/os"
+          service-account: withsysresource
         ports:
         - name: diego-ssh
           protocol: TCP
@@ -1833,6 +1839,11 @@ configuration:
         resourceNames: [nonprivileged]
         resources: [podsecuritypolicies]
         verbs: [use]
+      withsysresource:
+      - apiGroups: [extensions]
+        resourceNames: [withsysresource]
+        resources: [podsecuritypolicies]
+        verbs: [use]
       privileged:
       - apiGroups: [extensions]
         resourceNames: [privileged]
@@ -1862,6 +1873,9 @@ configuration:
         - projected
         - persistentVolumeClaim
         - nfs
+      withsysresource:
+        <<: *psp-nonprivileged
+        allowedCapabilities: [SYS_RESOURCE]
       privileged:
         <<: *psp-nonprivileged
         allowPrivilegeEscalation: true
@@ -1873,6 +1887,9 @@ configuration:
       default:
         roles: [configgin-role]
         cluster-roles: [nonprivileged]
+      withsysresource:
+        roles: [configgin-role]
+        cluster-roles: [withsysresource]
       privileged:
         roles: [configgin-role]
         cluster-roles: [privileged]

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -251,7 +251,7 @@ instance_groups:
                       values:
                       - nats
                   topologyKey: "beta.kubernetes.io/os"
-          service-account: withsysresource
+          service-account: sysres
         ports:
         - name: nats
           protocol: TCP
@@ -455,7 +455,7 @@ instance_groups:
                       values:
                       - diego-api
                   topologyKey: "beta.kubernetes.io/os"
-          service-account: withsysresource
+          service-account: sysres
         ports:
         - name: cell-bbs-api
           protocol: TCP
@@ -668,7 +668,7 @@ instance_groups:
                   topologyKey: "beta.kubernetes.io/os"
           # All the routes exposed require UAA auth, so we stick with the TCP healthcheck
           active-passive-probe: head -c0 </dev/tcp/${HOSTNAME}/3000
-          service-account: withsysresource
+          service-account: sysres
         ports:
         - name: routing-api
           protocol: TCP
@@ -1060,7 +1060,7 @@ instance_groups:
                   topologyKey: "beta.kubernetes.io/os"
           # Auctioneer has no useful healthcheck routes; we can only use the TCP port
           active-passive-probe: head -c0 </dev/tcp/${HOSTNAME}/9016
-          service-account: withsysresource
+          service-account: sysres
         ports:
         - name: diego-auction
           protocol: TCP
@@ -1117,7 +1117,7 @@ instance_groups:
                       values:
                       - cc-uploader
                   topologyKey: "beta.kubernetes.io/os"
-          service-account: withsysresource
+          service-account: sysres
         ports:
         - name: cc-up-listen
           protocol: TCP
@@ -1166,7 +1166,7 @@ instance_groups:
                       values:
                       - diego-ssh
                   topologyKey: "beta.kubernetes.io/os"
-          service-account: withsysresource
+          service-account: sysres
         ports:
         - name: diego-ssh
           protocol: TCP
@@ -1839,9 +1839,9 @@ configuration:
         resourceNames: [nonprivileged]
         resources: [podsecuritypolicies]
         verbs: [use]
-      withsysresource:
+      sysres:
       - apiGroups: [extensions]
-        resourceNames: [withsysresource]
+        resourceNames: [sysres]
         resources: [podsecuritypolicies]
         verbs: [use]
       privileged:
@@ -1873,7 +1873,7 @@ configuration:
         - projected
         - persistentVolumeClaim
         - nfs
-      withsysresource:
+      sysres:
         <<: *psp-nonprivileged
         allowedCapabilities: [SYS_RESOURCE]
       privileged:
@@ -1887,9 +1887,9 @@ configuration:
       default:
         roles: [configgin-role]
         cluster-roles: [nonprivileged]
-      withsysresource:
+      sysres:
         roles: [configgin-role]
-        cluster-roles: [withsysresource]
+        cluster-roles: [sysres]
       privileged:
         roles: [configgin-role]
         cluster-roles: [privileged]

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -236,7 +236,7 @@ instance_groups:
             min: 1
             max: 3
             ha: 2
-          capabilities: []
+          capabilities: [SYS_RESOURCE]
           memory: 128
           virtual-cpus: 2
           affinity:
@@ -434,7 +434,7 @@ instance_groups:
             min: 1
             max: 3
             ha: 2
-          capabilities: []
+          capabilities: [SYS_RESOURCE]
           memory: 128
           virtual-cpus: 2
           active-passive-probe: /var/vcap/jobs/global-properties/bin/readiness/diego-api
@@ -515,7 +515,7 @@ instance_groups:
             min: 1
             max: 65535
             ha: 2
-          capabilities: []
+          capabilities: [SYS_RESOURCE]
           memory: 128
           virtual-cpus: 4
           healthcheck:
@@ -649,7 +649,7 @@ instance_groups:
             min: 1
             max: 3
             ha: 2
-          capabilities: []
+          capabilities: [SYS_RESOURCE]
           memory: 128
           virtual-cpus: 4
           affinity:
@@ -1040,7 +1040,7 @@ instance_groups:
             min: 1
             max: 3
             ha: 2
-          capabilities: []
+          capabilities: [SYS_RESOURCE]
           memory: 128
           virtual-cpus: 4
           affinity:
@@ -1098,7 +1098,7 @@ instance_groups:
             min: 1
             max: 3
             ha: 2
-          capabilities: []
+          capabilities: [SYS_RESOURCE]
           memory: 128
           virtual-cpus: 4
           affinity:
@@ -1142,7 +1142,7 @@ instance_groups:
             min: 1
             max: 3
             ha: 2
-          capabilities: []
+          capabilities: [SYS_RESOURCE]
           memory: 128
           virtual-cpus: 2
           healthcheck:


### PR DESCRIPTION
These instance groups include scripts which attempt to set `ulimit -n`, which requires `SYS_RESOURCE` to do.