### PR TITLE
helm: add product version field as `appVersion`

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -36,6 +36,7 @@ export GOLANG_VERSION=1.7
 
 # Used in: make/include/versioning
 
+export PRODUCT_VERSION="1.13.1"
 export CF_VERSION=2.7.0
 
 # Show versions, if called on its own.
@@ -43,6 +44,7 @@ export CF_VERSION=2.7.0
 
 if [ "X$(basename -- "$0")" = "Xversions.sh" ]
 then
+    echo product '      =' $PRODUCT_VERSION
     echo bosh-cli '     =' $BOSH_CLI_VERSION
     echo cf '           =' $CF_VERSION
     echo cf-cli '       =' $CFCLI_VERSION

--- a/make/kube
+++ b/make/kube
@@ -33,6 +33,7 @@ if [ "${BUILD_TARGET}" = "helm" ]; then
 
     cat > "${FISSILE_OUTPUT_DIR}/Chart.yaml" << EOF
 apiVersion: ${APP_VERSION}
+appVersion: ${PRODUCT_VERSION}
 description: A Helm chart for SUSE Cloud Foundry
 name: cf${chart_name_suffix:-}
 version: ${GIT_TAG}


### PR DESCRIPTION
This will need to be (possibly pre-emptively) bumped for a CAP release; it is basically irrelevant for SCF.