### PR TITLE
Dist: upload helm charts without separately

### DIFF
--- a/make/bundle-dist
+++ b/make/bundle-dist
@@ -18,7 +18,7 @@ elif [[ ${FISSILE_STEMCELL} =~ ^.*fissile-stemcell-sle.*$ ]] ; then
     stemcell_os="sle"
     suffix=""
 else
-    echo "Unkown stemcell operating system: ${FISSILE_STEMCELL}"
+    echo "Unknown stemcell operating system: ${FISSILE_STEMCELL}"
     exit 1
 fi
 ARCHIVE_ROOT="${GIT_ROOT}/output/scf-${stemcell_os}-${APP_VERSION}"

--- a/make/bundle-dist
+++ b/make/bundle-dist
@@ -13,8 +13,10 @@ trap "rm -rf '${tmp_dir}'" EXIT
 
 if [[ ${FISSILE_STEMCELL} =~ ^.*fissile-stemcell-opensuse.*$ ]] ; then
     stemcell_os="opensuse"
+    suffix="-opensuse"
 elif [[ ${FISSILE_STEMCELL} =~ ^.*fissile-stemcell-sle.*$ ]] ; then
     stemcell_os="sle"
+    suffix=""
 else
     echo "Unkown stemcell operating system: ${FISSILE_STEMCELL}"
     exit 1
@@ -24,18 +26,19 @@ ARCHIVE_ROOT="${GIT_ROOT}/output/scf-${stemcell_os}-${APP_VERSION}"
 echo Packaging, taking "${APP_VERSION}" ...
 
 # Assembling the pieces ...
-mkdir -p ${tmp_dir}/kube ${tmp_dir}/helm
+find "${tmp_dir}"
 
-# kube configs
-tar xf "${GIT_ROOT}/output/${ARTIFACT_NAME}-kube-${APP_VERSION}.tgz" -C "${tmp_dir}/kube"
-# helm charts
-tar xf "${GIT_ROOT}/output/${ARTIFACT_NAME}-helm-${APP_VERSION}.tgz" -C "${tmp_dir}/helm"
+for project in uaa cf ; do
+    for variant in kube helm ; do
+        mkdir -p "${tmp_dir}/${variant}/${project}${suffix}"
+        tar xf "${GIT_ROOT}/output/${project}-${stemcell_os}-${variant}-${APP_VERSION}.tgz" -C "${tmp_dir}/${variant}/${project}${suffix}"
+    done
+done
 
 # "Am I Ok" for kube
-cp ${GIT_ROOT}/bin/dev/kube-ready-state-check.sh ${tmp_dir}/
+cp ${GIT_ROOT}/bin/dev/kube-ready-state-check.sh "${tmp_dir}/"
 
 # Package the assembly. This directly places it into the output
 # For now, include both zip and tgz in order to transition smoothly
 cd "${tmp_dir}"
-tar czvf "${ARCHIVE_ROOT}.tgz" -- *
 zip -r9 "${ARCHIVE_ROOT}.zip" -- *

--- a/make/bundle-dist
+++ b/make/bundle-dist
@@ -27,11 +27,11 @@ echo Packaging, taking "${APP_VERSION}" ...
 
 # Assembling the pieces ...
 find "${tmp_dir}"
+mkdir -p "${tmp_dir}/helm"
 
 for project in uaa cf ; do
     mkdir -p "${tmp_dir}/kube/${project}${suffix}"
     tar xf "${GIT_ROOT}/output/${project}-${stemcell_os}-kube-${APP_VERSION}.tgz" -C "${tmp_dir}/kube/${project}${suffix}/"
-    mkdir -p "${tmp_dir}/helm"
     tar xf "${GIT_ROOT}/output/${project}-${stemcell_os}-helm-${APP_VERSION}.tgz" -C "${tmp_dir}/helm/"
 done
 

--- a/make/bundle-dist
+++ b/make/bundle-dist
@@ -29,10 +29,10 @@ echo Packaging, taking "${APP_VERSION}" ...
 find "${tmp_dir}"
 
 for project in uaa cf ; do
-    for variant in kube helm ; do
-        mkdir -p "${tmp_dir}/${variant}/${project}${suffix}"
-        tar xf "${GIT_ROOT}/output/${project}-${stemcell_os}-${variant}-${APP_VERSION}.tgz" -C "${tmp_dir}/${variant}/${project}${suffix}"
-    done
+    mkdir -p "${tmp_dir}/kube/${project}${suffix}"
+    tar xf "${GIT_ROOT}/output/${project}-${stemcell_os}-kube-${APP_VERSION}.tgz" -C "${tmp_dir}/kube/${project}${suffix}/"
+    mkdir -p "${tmp_dir}/helm"
+    tar xf "${GIT_ROOT}/output/${project}-${stemcell_os}-helm-${APP_VERSION}.tgz" -C "${tmp_dir}/helm/"
 done
 
 # "Am I Ok" for kube

--- a/make/kube-dist
+++ b/make/kube-dist
@@ -6,33 +6,31 @@ GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 
 . "${GIT_ROOT}/make/include/versioning"
 
+if [[ ${FISSILE_STEMCELL} =~ ^.*fissile-stemcell-opensuse.*$ ]] ; then
+    stemcell_os="opensuse"
+elif [[ ${FISSILE_STEMCELL} =~ ^.*fissile-stemcell-sle.*$ ]] ; then
+    stemcell_os="sle"
+else
+    echo "Unkown stemcell operating system: ${FISSILE_STEMCELL}"
+    exit 1
+fi
+
 artifacts=("")
-for variant in kube helm ; do
-    tmp_dir=$(mktemp -d)
-    trap "rm -rf '${tmp_dir}'" EXIT
-    artifact="output/${ARTIFACT_NAME}-${variant}-${APP_VERSION}.tgz"
 
-    rm -f "${GIT_ROOT}/${artifact}"
+declare -A directories=(
+    [cf]="${GIT_ROOT}/output"
+    [uaa]="${GIT_ROOT}/src/uaa-fissile-release"
+)
 
-    # Add "-opensuse" suffix to the chart directory if we are on opensuse stemcell.
-    # The directory should match the chart name.
-    if [[ $FISSILE_STEMCELL =~ ^.*fissile-stemcell-opensuse.*$ ]] ; then
-      suffix="-opensuse"
-    fi
-
-    mkdir -p "${tmp_dir}"/{cf,uaa}${suffix:-}
-
-    cp -r "${GIT_ROOT}/output/${variant}/"* "${tmp_dir}/cf${suffix:-}"
-    cp -r "${GIT_ROOT}/src/uaa-fissile-release/${variant}/"* "${tmp_dir}/uaa${suffix:-}"
-
-    (
-        cd "${tmp_dir}"
-        tar czf "${GIT_ROOT}/${artifact}" .
-    )
-
-    rm -rf "${tmp_dir}"
-    trap '' EXIT
-    artifacts=("${artifact}" "${artifacts[@]}")
+for project in "${!directories[@]}" ; do
+    for variant in kube helm ; do
+        artifact="output/${project}-${stemcell_os}-${variant}-${APP_VERSION}.tgz"
+        (
+            cd "${directories[${project}]}/${variant}"
+            tar czf "${GIT_ROOT}/${artifact}" -- *
+        )
+        artifacts+=("${artifact}")
+    done
 done
 
 echo "Generated ${artifacts[*]}"

--- a/make/kube-dist
+++ b/make/kube-dist
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -o errexit -o nounset
-set -x
 
 GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 

--- a/make/kube-dist
+++ b/make/kube-dist
@@ -11,7 +11,7 @@ if [[ ${FISSILE_STEMCELL} =~ ^.*fissile-stemcell-opensuse.*$ ]] ; then
 elif [[ ${FISSILE_STEMCELL} =~ ^.*fissile-stemcell-sle.*$ ]] ; then
     stemcell_os="sle"
 else
-    echo "Unkown stemcell operating system: ${FISSILE_STEMCELL}"
+    echo "Unknown stemcell operating system: ${FISSILE_STEMCELL}"
     exit 1
 fi
 

--- a/make/kube-dist
+++ b/make/kube-dist
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -o errexit -o nounset
+set -x
 
 GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 
@@ -15,6 +16,9 @@ else
     exit 1
 fi
 
+tmp_dir=$(mktemp -d)
+trap "rm -rf '${tmp_dir}'" EXIT
+
 artifacts=("")
 
 declare -A directories=(
@@ -26,8 +30,15 @@ for project in "${!directories[@]}" ; do
     for variant in kube helm ; do
         artifact="output/${project}-${stemcell_os}-${variant}-${APP_VERSION}.tgz"
         (
-            cd "${directories[${project}]}/${variant}"
-            tar czf "${GIT_ROOT}/${artifact}" -- *
+            if test -r "${directories[${project}]}/${variant}/Chart.yaml" ; then
+                chart_name="$(awk '/^name:/ { print $2 }' "${directories[${project}]}/${variant}/Chart.yaml")"
+                cp -r "${directories[${project}]}/${variant}" "${tmp_dir}/${chart_name}"
+                cd "${tmp_dir}"
+                tar czf "${GIT_ROOT}/${artifact}" -- "${chart_name}"
+            else
+                cd "${directories[${project}]}/${variant}"
+                tar czf "${GIT_ROOT}/${artifact}" -- *
+            fi
         )
         artifacts+=("${artifact}")
     done


### PR DESCRIPTION
Helm can't install tgz charts if there are directories in the archive. This also means we can go back to uploading zip files for the release tool, since that needs to be manually extracted anyway.