### PR TITLE
Rewrite assembly of light opinions to avoid issues with nfs mounting …

### DIFF
--- a/bin/fissile
+++ b/bin/fissile
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -o errexit
+
 export FISSILE_TAG_EXTRA=$(git -C "${FISSILE_GIT_ROOT:-$PWD}" rev-parse HEAD)${FISSILE_TAG_EXTRA:+-${FISSILE_TAG_EXTRA}}
 
 if [ -f ${FISSILE_GIT_ROOT}/Jenkinsfile ] ; then

--- a/bin/fissile
+++ b/bin/fissile
@@ -10,13 +10,14 @@ if [ -f ${FISSILE_GIT_ROOT}/Jenkinsfile ] ; then
     # add the common part, which references them.
 
     if [ "${USE_SLE_BASE}" = "false" ]; then
-	SRC_BASE="${FISSILE_LIGHT_OPEN42}"
+        SRC_BASE="${FISSILE_LIGHT_OPEN42}"
     else
-	SRC_BASE="${FISSILE_LIGHT_SLE12}"
+        SRC_BASE="${FISSILE_LIGHT_SLE12}"
     fi
 
-    cat "${SRC_BASE}" "${FISSILE_LIGHT_COMMON}" > "${HOME}/$$"
-    mv "${HOME}/$$" "${FISSILE_LIGHT_OPINIONS}"
+    tmp_file=$(mktemp -t tmp.XXXXXXXXXXXXXXXXXXXX) || exit 1
+    cat "${SRC_BASE}" "${FISSILE_LIGHT_COMMON}" > "${tmp_file}"
+    mv "${tmp_file}" "${FISSILE_LIGHT_OPINIONS}"
 fi
 
 exec fissile.real "$@"

--- a/bin/fissile
+++ b/bin/fissile
@@ -10,12 +10,13 @@ if [ -f ${FISSILE_GIT_ROOT}/Jenkinsfile ] ; then
     # add the common part, which references them.
 
     if [ "${USE_SLE_BASE}" = "false" ]; then
-	cp "${FISSILE_LIGHT_OPEN42}" "${FISSILE_LIGHT_OPINIONS}"
+	SRC_BASE="${FISSILE_LIGHT_OPEN42}"
     else
-	cp "${FISSILE_LIGHT_SLE12}" "${FISSILE_LIGHT_OPINIONS}"
+	SRC_BASE="${FISSILE_LIGHT_SLE12}"
     fi
 
-    cat "${FISSILE_LIGHT_COMMON}" >> "${FISSILE_LIGHT_OPINIONS}"
+    cat "${SRC_BASE}" "${FISSILE_LIGHT_COMMON}" > "${HOME}/$$"
+    mv "${HOME}/$$" "${FISSILE_LIGHT_OPINIONS}"
 fi
 
 exec fissile.real "$@"


### PR DESCRIPTION
…and/or other processes interfering, leaving us with non-usable result from time to time.

Ref https://trello.com/c/do6iTmyY/849-5-investigate-many-cats-failures-with-jenkins

Assembly now happens in a separate file, in a single command.
The result is then renamed/moved into place.

Now further broken results were seen with this.