### PR TITLE
matchExpression has to match component name (api-group)

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -694,7 +694,7 @@ instance_groups:
                     - key: "app.kubernetes.io/component"
                       operator: In
                       values:
-                      - api
+                      - api-group
                   topologyKey: "beta.kubernetes.io/os"
         ports:
         - name: api


### PR DESCRIPTION
The predefined podAntiAffinity rule does have an outdated component name (api), causing the matchExpression to be invalid.
Previously the api-group was named api, hence the values filter did still work.

https://github.com/SUSE/scf/blob/develop/container-host-files/etc/scf/config/role-manifest.yml#L648