### PR TITLE
Move deployment name to properties section

### DIFF
--- a/container-host-files/etc/scf/config/opinions-common.yml
+++ b/container-host-files/etc/scf/config/opinions-common.yml
@@ -279,6 +279,7 @@ properties:
     proxy:
       api_force_https: false
       api_username: 'mysql_proxy'
+  deployment: scf-deployment
   diego:
     auctioneer:
       rep:
@@ -344,8 +345,6 @@ properties:
     reserved_space_for_other_jobs_in_mb: 3000
   loggregator:
     use_v2_api: true
-  metron_agent:
-    deployment: scf-deployment
   nats:
     port: 4222
     user: nats


### PR DESCRIPTION
With the move from `metron agent` to `loggregator agent`, the setting
for the deployment name changed from being under `metron_agent` to be
under the main properties section. Configuration for the setting in
the spec file: https://github.com/cloudfoundry/loggregator-agent-release/blob/develop/jobs/loggregator_agent/spec#L37

Compare with https://github.com/cloudfoundry/cf-deployment/blob/38b304405764e1307f606d02856e4366b2337cbd/operations/community/change-metron-agent-deployment.yml
which shows the change in an operations file.

Without this change, the event envelope of the loggregator agent will
have an empty value for the deployment name and this might cause
consumers to bail out with a malformed envelope error.

Run `cf nozzle` to check whether a deployment name is set or not:
```
origin:"garden-linux"
eventType:ValueMetric
timestamp:1545133376894390811
deployment:""
job:"diego-cell"
index:"diego-cell-1"
tags:<key:"source_id" value:"garden-linux" >
valueMetric:<name:"numCPUS" value:4 unit:"count" >
```