### PR TITLE
Updated execution order for acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,8 +399,9 @@ and execute the following commands:
 
 ```bash
 make smoke
-make cats
 make brain
+make scaler-smoke
+make cats 
 ```
 
 #### How do I run a subset of SCF acceptance tests?


### PR DESCRIPTION
This change re-orders the execution commands for acceptance tests listed in README. Since `cats` test might be destructive, therefore must be run in the end. Also, adding scalar-smoke test.