### PR TITLE
v3 API use HTTPS instead of HTTP

### DIFF
--- a/container-host-files/etc/scf/config/opinions-common.yml
+++ b/container-host-files/etc/scf/config/opinions-common.yml
@@ -165,7 +165,6 @@ properties:
       blobstore_type: webdav
       webdav_config:
         username: 'blobstore_user'
-    external_protocol: http
     install_buildpacks:
     - name: staticfile_buildpack
       package: staticfile-buildpack


### PR DESCRIPTION
## Description

Changes the URLs for the v3 API to use HTTPS instead of HTTP.

## Test plan

Calling `cf curl /v3` shall report the URLs as HTTPS instead of HTTP.

## Issue tracking

Fixes #1900 