### PR TITLE
Document how to customize the application domain in CAP (1.3.1 or higher, not 1.3).

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Table of Contents
    * [Deploying SCF on Kubernetes](#deploying-scf-on-kubernetes)
       * [Makefile targets](#makefile-targets)
          * [Vagrant VM Targets](#vagrant-vm-targets)
+   * [Deployment Customizations](#deployment-customizations)
+     * [Customize The Application Domain](#customize-the-application-domain)
    * [Development FAQ](#development-faq)
       * [Where do I find logs?](#where-do-i-find-logs)
       * [How do I clear all data and begin anew without rebuilding everything?](#how-do-i-clear-all-data-and-begin-anew-without-rebuilding-everything)
@@ -313,6 +315,51 @@ Name            | Effect |
 `stop`            | Stop SCF on the current node |
 `vagrant-box`    | Build the Vagrant box image using `packer` |
 `vagrant-prep`    | Shortcut for building everything needed for `make run` |
+
+# Deployment Customizations
+
+## Customize The Application Domain
+
+In a standard installation the domain used by applications pushed to
+CF is the same as the domain configured for CF itself.
+
+This document describes how to change this so that CF and applications
+use separate domains.
+
+:warning: The changes described below will work only for CAP 1.3.1,
+and higher.  They do not work for CAP 1.3, and will not work for the
+CAP 2 series to be.
+
+1. Follow the basic steps for deploying UAA and SCF.
+1. When deploying SCF add a section like
+
+   ```
+   bosh:
+     instance_groups:
+     - name: api-group
+       jobs:
+       - name: cloud_controller_ng
+         properties:
+           app_domains:
+           - APPDOMAIN
+   ```
+
+   to the `scf-config-values.yaml` override file. The placeholder
+   `APPDOMAIN` has to be replaced with whatever domain is desired to
+   be used by the applications.
+
+After deployment use
+
+```
+cf curl /v2/info | grep endpoint
+```
+
+to verify that the CF domain is __not__ `APPDOMAIN`.
+
+Further verify, by pushing an application, that `APPDOMAIN` is printed
+as the domain used by the application.
+
+
 
 # Development FAQ
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Name            | Effect |
 
 ## Customize The Application Domain
 
-In a standard installation the domain used by applications pushed to
+In a standard installation, the domain used by applications pushed to
 CF is the same as the domain configured for CF.
 
 This document describes how to change this behaviour so that CF and

--- a/README.md
+++ b/README.md
@@ -321,17 +321,17 @@ Name            | Effect |
 ## Customize The Application Domain
 
 In a standard installation the domain used by applications pushed to
-CF is the same as the domain configured for CF itself.
+CF is the same as the domain configured for CF.
 
-This document describes how to change this so that CF and applications
-use separate domains.
+This document describes how to change this behaviour so that CF and
+applications use separate domains.
 
 :warning: The changes described below will work only for CAP 1.3.1,
-and higher.  They do not work for CAP 1.3, and will not work for the
+and higher. They do not work for CAP 1.3, and will not work for the
 CAP 2 series to be.
 
 1. Follow the basic steps for deploying UAA and SCF.
-1. When deploying SCF add a section like
+1. When deploying SCF, add a section like
 
    ```
    bosh:
@@ -341,11 +341,11 @@ CAP 2 series to be.
        - name: cloud_controller_ng
          properties:
            app_domains:
-           - APPDOMAIN
+           - <APPDOMAIN>
    ```
 
    to the `scf-config-values.yaml` override file. The placeholder
-   `APPDOMAIN` has to be replaced with whatever domain is desired to
+   `<APPDOMAIN>` has to be replaced with whatever domain is desired to
    be used by the applications.
 
 After deployment use
@@ -354,12 +354,10 @@ After deployment use
 cf curl /v2/info | grep endpoint
 ```
 
-to verify that the CF domain is __not__ `APPDOMAIN`.
+to verify that the CF domain is __not__ `<APPDOMAIN>`.
 
-Further verify, by pushing an application, that `APPDOMAIN` is printed
-as the domain used by the application.
-
-
+Further, by pushing an application, verify that `<APPDOMAIN>` is
+printed as the domain used by the application.
 
 # Development FAQ
 


### PR DESCRIPTION
Ref: https://trello.com/c/Vr7di1lY/875-make-app-domains-configurable
Also: https://github.com/SUSE/scf/wiki/How-To-Customize-the-Application-Domains