### PR TITLE
Restoring DEFAULT_STACK to users.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -30,12 +30,16 @@ FISSILE_RELEASE="${FISSILE_RELEASE},${PWD}/src/scf-release"
 
 export FISSILE_RELEASE="${FISSILE_RELEASE#,}"
 
-# Path to an SCF role manifest
-export FISSILE_ROLE_MANIFEST="${PWD}/container-host-files/etc/scf/config/role-manifest.yml"
+# Note: Both role manifest and light opinions are assembled by the
+# fissile wrapper, see `(output)/bin/fissile`.  Here we only
+# initialize various env variables referencing all the parts, making
+# it easier on the wrapper.
 
-# Note: The light opinions are assembled by the fissile wrapper, see `(output)/bin/fissile`.
-# Here we only initialize env variables referencing all the parts, making it easier on
-# wrapper.
+# Path to an SCF role manifest, common parts, final destination.
+# Note that we cannot place this in the output directory, that would
+# break the paths to the scripts.
+export FISSILE_MANIFEST_COMMON="${PWD}/container-host-files/etc/scf/config/role-manifest.yml"
+export FISSILE_ROLE_MANIFEST="${PWD}/container-host-files/etc/scf/config/role-manifest-final.yml"
 
 export FISSILE_LIGHT_SLE12="${PWD}/container-host-files/etc/scf/config/opinions-sle12.yml"
 export FISSILE_LIGHT_OPEN42="${PWD}/container-host-files/etc/scf/config/opinions-opensuse42.yml"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ password
 /src/buildpacks/*-clone
 /bin/settings/certs.env
 /bin/settings/kube/ca.env
+/container-host-files/etc/scf/config/role-manifest-final.yml
 # `make dist` output of various forms
 /output/
 personal-setup

--- a/bin/fissile
+++ b/bin/fissile
@@ -19,6 +19,8 @@ if [ -f ${FISSILE_GIT_ROOT}/Jenkinsfile ] ; then
     fi
 
     tmp_file=$(mktemp -t tmp.XXXXXXXXXXXXXXXXXXXX)
+    trap "rm -f $tmp_file" EXIT
+
     cat "${STACK_BASE}" "${FISSILE_LIGHT_COMMON}" > "${tmp_file}"
     mv "${tmp_file}" "${FISSILE_LIGHT_OPINIONS}"
 
@@ -26,6 +28,8 @@ if [ -f ${FISSILE_GIT_ROOT}/Jenkinsfile ] ; then
     # stack-specific parts, in the same manner.
 
     tmp_file=$(mktemp -t tmp.XXXXXXXXXXXXXXXXXXXX)
+    trap "rm -f $tmp_file" EXIT
+
     cat "${STACK_BASE}" "${FISSILE_MANIFEST_COMMON}" > "${tmp_file}"
     mv "${tmp_file}" "${FISSILE_ROLE_MANIFEST}"
 fi

--- a/bin/fissile
+++ b/bin/fissile
@@ -13,14 +13,21 @@ if [ -f ${FISSILE_GIT_ROOT}/Jenkinsfile ] ; then
     # add the common part, which references them.
 
     if [ "${USE_SLE_BASE}" = "false" ]; then
-        SRC_BASE="${FISSILE_LIGHT_OPEN42}"
+        STACK_BASE="${FISSILE_LIGHT_OPEN42}"
     else
-        SRC_BASE="${FISSILE_LIGHT_SLE12}"
+        STACK_BASE="${FISSILE_LIGHT_SLE12}"
     fi
 
     tmp_file=$(mktemp -t tmp.XXXXXXXXXXXXXXXXXXXX)
-    cat "${SRC_BASE}" "${FISSILE_LIGHT_COMMON}" > "${tmp_file}"
+    cat "${STACK_BASE}" "${FISSILE_LIGHT_COMMON}" > "${tmp_file}"
     mv "${tmp_file}" "${FISSILE_LIGHT_OPINIONS}"
+
+    # Further assemble the BOSH role manifest, from common and
+    # stack-specific parts, in the same manner.
+
+    tmp_file=$(mktemp -t tmp.XXXXXXXXXXXXXXXXXXXX)
+    cat "${STACK_BASE}" "${FISSILE_MANIFEST_COMMON}" > "${tmp_file}"
+    mv "${tmp_file}" "${FISSILE_ROLE_MANIFEST}"
 fi
 
 exec fissile.real "$@"

--- a/container-host-files/etc/scf/config/opinions-common.yml
+++ b/container-host-files/etc/scf/config/opinions-common.yml
@@ -154,12 +154,10 @@ properties:
     default_running_security_groups:
     - public_networks
     - dns
-    default_stack: *the-stack-name
     default_staging_security_groups:
     - public_networks
     - dns
     diego:
-      docker_staging_stack: *the-stack-name
       lifecycle_bundles: *the-bundles
     droplets:
       blobstore_type: webdav

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1,4 +1,3 @@
----
 releases:
 - name: bpm
   version: "1.0.0"
@@ -2046,8 +2045,10 @@ configuration:
     properties.cc.default_app_disk_in_mb: '"((DEFAULT_APP_DISK_IN_MB))"'
     properties.cc.default_app_memory: '"((DEFAULT_APP_MEMORY))"'
     properties.cc.default_app_ssh_access: '"((DEFAULT_APP_SSH_ACCESS))"'
+    properties.cc.default_stack: '"((DEFAULT_STACK))"'
     properties.cc.diego.bbs.url: https://diego-api-bbs.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8889
     properties.cc.diego.cc_uploader_https_url: https://cc-uploader-cc-uploader.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):9091
+    properties.cc.diego.docker_staging_stack: '"((DEFAULT_STACK))"'
     properties.cc.diego.file_server_url: http://diego-access.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8080
     properties.cc.diego.insecure_docker_registry_list: '[((INSECURE_DOCKER_REGISTRIES))]'
     properties.cc.diego.use_privileged_containers_for_running: ((USE_DIEGO_PRIVILEGED_CONTAINERS))
@@ -3132,6 +3133,10 @@ variables:
     description: If set apps pushed to spaces that allow SSH access will have SSH
       enabled by default.
     required: true
+- name: DEFAULT_STACK
+  options:
+    default: *the-stack-name
+    description: The default stack to use if no custom stack is specified by an app.
 - name: DIEGO_CELL_DISK_CAPACITY_MB
   options:
     default: auto


### PR DESCRIPTION
Ref: https://trello.com/c/W0YvSEfG/917-2-add-back-defaultstack-setting

- Removed the associated properties from the opinions.

- Role manifest
  - Restored the DEFAULT_STACK parameter exposing this setting.
  - Restored the property assignments using this parameter.

- Modified the fissile wrapper script to assemble a role manifest like
  it does for the light opinions. This brings in the proper
  `the-stack-name` which got selected via USE_SLE_BASE, and makes it
  referable from the `default` key of the `DEFAULT_STACK`
  parameter. We use the same stack-specific part files as for the
  light opinions.

  Note: The new final role manifest is a sibling of the original role
  manifest which is now serving as parts. Needed to not break the
  script paths.

- This way of handling the changed default value for `DEFAULT_STACK`
  works with the existing system (re-use of information, kept
  central), and with the format itself (yaml anchor and references,
  instead of brittle text-manipulation).