### PR TITLE
Set fissile --final-releases-dir to the heritage location

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -58,6 +58,9 @@ export FISSILE_WORK_DIR="${FISSILE_WORK_DIR:-${PWD}/output/fissile}"
 # This will be ~/.bosh/cache in vagrant
 export FISSILE_CACHE_DIR="${FISSILE_CACHE_DIR:-${PWD}/output/bosh-cache}"
 
+# Path where fissile stores the downloaded tarballs of final releases referenced in the role manifest.
+export FISSILE_FINAL_RELEASES_DIR="${PWD}/container-host-files/etc/scf/config/.final_releases"
+
 # Metrics for the build
 export FISSILE_METRICS="${FISSILE_GIT_ROOT}/scf_metrics.csv"
 

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.37.0"
 export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+220.g4e5711b"
+export FISSILE_VERSION="7.0.0+224.g6721ef4"
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"
 export KUBECTL_VERSION="1.9.6"


### PR DESCRIPTION
You can now customize the cache location for downloaded final releases in fissile, and the default location has changed to `~/.final-releases`. Under Vagrant this is not part of the shared host folder, so would be lost every time the box is recreated.