### PR TITLE
Customization of Vagrant box with provided scripts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,15 @@ Vagrant.configure(2) do |config|
   vm_box_version = ENV.fetch('SCF_VM_BOX_VERSION', ENV.fetch('VM_BOX_VERSION', '2.0.15'))
   vm_registry_mirror = ENV.fetch('SCF_VM_REGISTRY_MIRROR', ENV.fetch('VM_REGISTRY_MIRROR', ''))
 
+  home = "/home/vagrant"
+
+  # Set this environment variable to a directory containing shell scripts to be executed as part of
+  # the provisioning of the Vagrant machine.
+  custom_config_scripts_env = "CUSTOM_CONFIG_SCRIPTS"
+  # The target directory where the custom setup scripts are mounted if the custom config scripts env
+  # is set.
+  mounted_custom_config_scripts = "#{home}/.config/custom_config_scripts"
+
   config.vm.provider "virtualbox" do |vb, override|
     # Need to shorten the URL for Windows' sake.
     override.vm.box = "https://cf-opensusefs2.s3.amazonaws.com/vagrant/scf-virtualbox-v#{vm_box_version}.box"
@@ -42,8 +51,13 @@ Vagrant.configure(2) do |config|
     vb.customize ['modifyvm', :id, '--paravirtprovider', 'minimal']
 
     # https://github.com/mitchellh/vagrant/issues/351
-    override.vm.synced_folder ".fissile/.bosh", "/home/vagrant/.bosh", type: "nfs"
-    override.vm.synced_folder ".", "/home/vagrant/scf", type: "nfs"
+    override.vm.synced_folder ".fissile/.bosh", "#{home}/.bosh", type: "nfs"
+    override.vm.synced_folder ".", "#{home}/scf", type: "nfs"
+
+    if ENV.include? custom_config_scripts_env
+      override.vm.synced_folder ENV.fetch(custom_config_scripts_env),
+        mounted_custom_config_scripts, type: "nfs"
+    end
   end
 
   config.vm.provider "libvirt" do |libvirt, override|
@@ -64,8 +78,13 @@ Vagrant.configure(2) do |config|
     libvirt.cpus = vm_cpus
     libvirt.random model: 'random'
 
-    override.vm.synced_folder ".fissile/.bosh", "/home/vagrant/.bosh", type: "nfs"
-    override.vm.synced_folder ".", "/home/vagrant/scf", type: "nfs"
+    override.vm.synced_folder ".fissile/.bosh", "#{home}/.bosh", type: "nfs"
+    override.vm.synced_folder ".", "#{home}/scf", type: "nfs"
+
+    if ENV.include? custom_config_scripts_env
+      override.vm.synced_folder ENV.fetch(custom_config_scripts_env),
+        mounted_custom_config_scripts, type: "nfs"
+    end
   end
 
   config.ssh.forward_env = ["FISSILE_COMPILATION_CACHE_CONFIG"]
@@ -97,8 +116,8 @@ Vagrant.configure(2) do |config|
   # Install common and dev tools.
   config.vm.provision :shell, privileged: true, inline: <<-SHELL
     set -o errexit -o xtrace -o verbose
-    export HOME=/home/vagrant
-    export PATH=$PATH:/home/vagrant/bin
+    export HOME="#{home}"
+    export PATH="${PATH}:#{home}/bin"
     export SCF_BIN_DIR=/usr/local/bin
 
     if [ -n "#{vm_registry_mirror}" ]; then
@@ -160,15 +179,25 @@ Vagrant.configure(2) do |config|
     set -o errexit
     echo 'if test -e /mnt/hgfs ; then /mnt/hgfs/scf/bin/dev/setup_vmware_mounts.sh ; fi' >> .profile
 
-    echo 'export PATH=$PATH:/home/vagrant/scf/container-host-files/opt/scf/bin/' >> .profile
-    echo 'test -f /home/vagrant/scf/personal-setup && . /home/vagrant/scf/personal-setup' >> .profile
+    echo 'export PATH="${PATH}:#{home}/scf/container-host-files/opt/scf/bin/"' >> .profile
 
-    echo -e '\nexport HISTFILE=/home/vagrant/scf/output/.bash_history' >> .profile
+    echo -e '\nexport HISTFILE="#{home}/scf/output/.bash_history"' >> .profile
 
     # Check that the cluster is reasonable.
-    /home/vagrant/scf/bin/dev/kube-ready-state-check.sh
+    #{home}/scf/bin/dev/kube-ready-state-check.sh
 
-    direnv exec /home/vagrant/scf make -C /home/vagrant/scf copy-compile-cache
+    direnv exec #{home}/scf make -C #{home}/scf copy-compile-cache
+  SHELL
+
+  # Provision the custom config scripts and personal setup.
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    set -o errexit
+
+    if [ -d "#{mounted_custom_config_scripts}" ]; then
+      find "#{mounted_custom_config_scripts}" -iname "*.sh" -exec "{}" \\;
+    fi
+
+    echo 'test -f "#{home}/scf/personal-setup" && . "#{home}/scf/personal-setup"' >> .profile
 
     echo -e "\n\nAll done - you can \e[1;96mvagrant ssh\e[0m\n\n"
   SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,10 +30,10 @@ Vagrant.configure(2) do |config|
   # part of the provisioning of the Vagrant machine. If the directory contains a subdirectory called
   # `provision.d`, every script inside this folder will be executed as part of the provisioning of
   # the Vagrant VM.
-  custom_config_scripts_env = "SCF_VM_CUSTOM_SETUP_SCRIPTS"
+  custom_setup_scripts_env = "SCF_VM_CUSTOM_SETUP_SCRIPTS"
   # The target directory where the custom setup scripts are mounted if the custom config scripts env
   # is set.
-  mounted_custom_config_scripts = "#{HOME}/.config/custom_vagrant_setup_scripts"
+  mounted_custom_setup_scripts = "#{HOME}/.config/custom_vagrant_setup_scripts"
 
   config.vm.provider "virtualbox" do |vb, override|
     # Need to shorten the URL for Windows' sake.
@@ -56,9 +56,9 @@ Vagrant.configure(2) do |config|
     override.vm.synced_folder ".fissile/.bosh", "#{HOME}/.bosh", type: "nfs"
     override.vm.synced_folder ".", "#{HOME}/scf", type: "nfs"
 
-    if ENV.include? custom_config_scripts_env
-      override.vm.synced_folder ENV.fetch(custom_config_scripts_env),
-        mounted_custom_config_scripts, type: "nfs"
+    if ENV.include? custom_setup_scripts_env
+      override.vm.synced_folder ENV.fetch(custom_setup_scripts_env),
+        mounted_custom_setup_scripts, type: "nfs"
     end
   end
 
@@ -83,9 +83,9 @@ Vagrant.configure(2) do |config|
     override.vm.synced_folder ".fissile/.bosh", "#{HOME}/.bosh", type: "nfs"
     override.vm.synced_folder ".", "#{HOME}/scf", type: "nfs"
 
-    if ENV.include? custom_config_scripts_env
-      override.vm.synced_folder ENV.fetch(custom_config_scripts_env),
-        mounted_custom_config_scripts, type: "nfs"
+    if ENV.include? custom_setup_scripts_env
+      override.vm.synced_folder ENV.fetch(custom_setup_scripts_env),
+        mounted_custom_setup_scripts, type: "nfs"
     end
   end
 
@@ -195,8 +195,8 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     set -o errexit
 
-    if [ -d "#{mounted_custom_config_scripts}/provision.d" ]; then
-      scripts=($(find "#{mounted_custom_config_scripts}/provision.d" -iname "*.sh" -executable -print | sort))
+    if [ -d "#{mounted_custom_setup_scripts}/provision.d" ]; then
+      scripts=($(find "#{mounted_custom_setup_scripts}/provision.d" -iname "*.sh" -executable -print | sort))
       for script in ${scripts}; do
         "${script}"
       done

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -194,7 +194,10 @@ Vagrant.configure(2) do |config|
     set -o errexit
 
     if [ -d "#{mounted_custom_config_scripts}/provision.d" ]; then
-      find "#{mounted_custom_config_scripts}/provision.d" -iname "*.sh" -exec "{}" \\;
+      scripts=($(find "#{mounted_custom_config_scripts}/provision.d" -iname "*.sh" -executable -print | sort))
+      for script in $scripts; do
+        "$script"
+      done
     fi
 
     echo 'test -f "#{HOME}/scf/personal-setup" && . "#{HOME}/scf/personal-setup"' >> .profile

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -193,8 +193,8 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     set -o errexit
 
-    if [ -d "#{mounted_custom_config_scripts}" ]; then
-      find "#{mounted_custom_config_scripts}" -iname "*.sh" -exec "{}" \\;
+    if [ -d "#{mounted_custom_config_scripts}/provision.d" ]; then
+      find "#{mounted_custom_config_scripts}/provision.d" -iname "*.sh" -exec "{}" \\;
     fi
 
     echo 'test -f "#{HOME}/scf/personal-setup" && . "#{HOME}/scf/personal-setup"' >> .profile

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,14 +24,14 @@ Vagrant.configure(2) do |config|
   vm_box_version = ENV.fetch('SCF_VM_BOX_VERSION', ENV.fetch('VM_BOX_VERSION', '2.0.15'))
   vm_registry_mirror = ENV.fetch('SCF_VM_REGISTRY_MIRROR', ENV.fetch('VM_REGISTRY_MIRROR', ''))
 
-  home = "/home/vagrant"
+  HOME = "/home/vagrant"
 
   # Set this environment variable to a directory containing shell scripts to be executed as part of
   # the provisioning of the Vagrant machine.
   custom_config_scripts_env = "CUSTOM_CONFIG_SCRIPTS"
   # The target directory where the custom setup scripts are mounted if the custom config scripts env
   # is set.
-  mounted_custom_config_scripts = "#{home}/.config/custom_config_scripts"
+  mounted_custom_config_scripts = "#{HOME}/.config/custom_config_scripts"
 
   config.vm.provider "virtualbox" do |vb, override|
     # Need to shorten the URL for Windows' sake.
@@ -51,8 +51,8 @@ Vagrant.configure(2) do |config|
     vb.customize ['modifyvm', :id, '--paravirtprovider', 'minimal']
 
     # https://github.com/mitchellh/vagrant/issues/351
-    override.vm.synced_folder ".fissile/.bosh", "#{home}/.bosh", type: "nfs"
-    override.vm.synced_folder ".", "#{home}/scf", type: "nfs"
+    override.vm.synced_folder ".fissile/.bosh", "#{HOME}/.bosh", type: "nfs"
+    override.vm.synced_folder ".", "#{HOME}/scf", type: "nfs"
 
     if ENV.include? custom_config_scripts_env
       override.vm.synced_folder ENV.fetch(custom_config_scripts_env),
@@ -78,8 +78,8 @@ Vagrant.configure(2) do |config|
     libvirt.cpus = vm_cpus
     libvirt.random model: 'random'
 
-    override.vm.synced_folder ".fissile/.bosh", "#{home}/.bosh", type: "nfs"
-    override.vm.synced_folder ".", "#{home}/scf", type: "nfs"
+    override.vm.synced_folder ".fissile/.bosh", "#{HOME}/.bosh", type: "nfs"
+    override.vm.synced_folder ".", "#{HOME}/scf", type: "nfs"
 
     if ENV.include? custom_config_scripts_env
       override.vm.synced_folder ENV.fetch(custom_config_scripts_env),
@@ -116,8 +116,8 @@ Vagrant.configure(2) do |config|
   # Install common and dev tools.
   config.vm.provision :shell, privileged: true, inline: <<-SHELL
     set -o errexit -o xtrace -o verbose
-    export HOME="#{home}"
-    export PATH="${PATH}:#{home}/bin"
+    export HOME="#{HOME}"
+    export PATH="${PATH}:#{HOME}/bin"
     export SCF_BIN_DIR=/usr/local/bin
 
     if [ -n "#{vm_registry_mirror}" ]; then
@@ -179,14 +179,14 @@ Vagrant.configure(2) do |config|
     set -o errexit
     echo 'if test -e /mnt/hgfs ; then /mnt/hgfs/scf/bin/dev/setup_vmware_mounts.sh ; fi' >> .profile
 
-    echo 'export PATH="${PATH}:#{home}/scf/container-host-files/opt/scf/bin/"' >> .profile
+    echo 'export PATH="${PATH}:#{HOME}/scf/container-host-files/opt/scf/bin/"' >> .profile
 
-    echo -e '\nexport HISTFILE="#{home}/scf/output/.bash_history"' >> .profile
+    echo -e '\nexport HISTFILE="#{HOME}/scf/output/.bash_history"' >> .profile
 
     # Check that the cluster is reasonable.
-    #{home}/scf/bin/dev/kube-ready-state-check.sh
+    #{HOME}/scf/bin/dev/kube-ready-state-check.sh
 
-    direnv exec #{home}/scf make -C #{home}/scf copy-compile-cache
+    direnv exec #{HOME}/scf make -C #{HOME}/scf copy-compile-cache
   SHELL
 
   # Provision the custom config scripts and personal setup.
@@ -197,7 +197,7 @@ Vagrant.configure(2) do |config|
       find "#{mounted_custom_config_scripts}" -iname "*.sh" -exec "{}" \\;
     fi
 
-    echo 'test -f "#{home}/scf/personal-setup" && . "#{home}/scf/personal-setup"' >> .profile
+    echo 'test -f "#{HOME}/scf/personal-setup" && . "#{HOME}/scf/personal-setup"' >> .profile
 
     echo -e "\n\nAll done - you can \e[1;96mvagrant ssh\e[0m\n\n"
   SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,12 +26,14 @@ Vagrant.configure(2) do |config|
 
   HOME = "/home/vagrant"
 
-  # Set this environment variable to a directory containing shell scripts to be executed as part of
-  # the provisioning of the Vagrant machine.
-  custom_config_scripts_env = "CUSTOM_CONFIG_SCRIPTS"
+  # Set this environment variable pointing to a directory containing shell scripts to be executed as
+  # part of the provisioning of the Vagrant machine. If the directory contains a subdirectory called
+  # `provision.d`, every script inside this folder will be executed as part of the provisioning of
+  # the Vagrant VM.
+  custom_config_scripts_env = "SCF_VM_CUSTOM_SETUP_SCRIPTS"
   # The target directory where the custom setup scripts are mounted if the custom config scripts env
   # is set.
-  mounted_custom_config_scripts = "#{HOME}/.config/custom_config_scripts"
+  mounted_custom_config_scripts = "#{HOME}/.config/custom_vagrant_setup_scripts"
 
   config.vm.provider "virtualbox" do |vb, override|
     # Need to shorten the URL for Windows' sake.
@@ -195,8 +197,8 @@ Vagrant.configure(2) do |config|
 
     if [ -d "#{mounted_custom_config_scripts}/provision.d" ]; then
       scripts=($(find "#{mounted_custom_config_scripts}/provision.d" -iname "*.sh" -executable -print | sort))
-      for script in $scripts; do
-        "$script"
+      for script in ${scripts}; do
+        "${script}"
       done
     fi
 


### PR DESCRIPTION
## Description

Allows customization of the Vagrant machine.

## Test plan

- Create a directory somewhere outside the repo.
- Create a `provision.d/` directory under it.
- Add some custom scripts to `provision.d/`. E.g.
```
#!/bin/sh

zypper install -y vim
```
- Start Vagrant with `SCF_VM_CUSTOM_SETUP_SCRIPTS=<directory_containing_the_provision.d> vagrant up`
- Check that vim was installed inside the Vagrant machine.