### PR TITLE
Some paths inside the role-manifest.yml are not correct

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1285,6 +1285,7 @@ instance_groups:
           memory: 2800
           virtual-cpus: 4
           healthcheck:
+            readiness:
               command:
                 - /var/vcap/jobs/global-properties/bin/readiness/diego-cell
           affinity:
@@ -1450,7 +1451,6 @@ instance_groups:
           capabilities: []
           memory: 256
           virtual-cpus: 1
-          exposed-ports: []
 - name: credhub-user
   environment_scripts:
   - scripts/configure-HA-hosts.sh


### PR DESCRIPTION
- for the `diego-cell` ig, the healthcheck command was lacking of a
  parent key, which should be `readiness`, based on the struct
  define in fissile(see [fissile code](https://github.com/cloudfoundry-incubator/fissile/blob/develop/model/role_run.go#L99-L116))
- key `exposed-ports` is obsolete
- the value for a variable under the `default` key, produce errors when
  unmarshalling the YAML, e.g. `yaml: unknown anchor 'the-stack-name' referenced`,   therefore I considered that this value should be quoted.

Opinions?