### PR TITLE
Support multiple versions of the helm client

### DIFF
--- a/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
@@ -6,23 +6,23 @@ set -o errexit
 # of the server. Check if we have a client for that version packaged,
 # and if yes, put it on the PATH. Else fails with a nice message.
 
-HBASE=/var/vcap/packages/helm/bin
-HELM_VERSION="$(${HBASE}/helm version| grep Server | sed -e 's/.*"v//' -e 's/".*//')"
+HELM_BIN_DIR=/var/vcap/packages/helm/bin
+HELM_VERSION="$(${HELM_BIN_DIR}/helm version | grep Server | sed -e 's/.*"v//' -e 's/".*//')"
 
 echo Packaged helm clients ...
-( cd ${HBASE} ; find . -type f | sed -e 's/^/= /' )
+( cd ${HELM_BIN_DIR} ; find . -type f | sed -e 's/^/= /' )
 echo Helm server ${HELM_VERSION}
 echo Compare
 
-if test -f "${HBASE}/${HELM_VERSION}/helm"
+if test -f "${HELM_BIN_DIR}/${HELM_VERSION}/helm"
 then
     echo Match
 else
-    echo "Helm server ${HELM_VERSION} not supported, only: $(cd ${HBASE} ; ls | sort)"
+    echo "Helm server ${HELM_VERSION} not supported, only: $(cd ${HELM_BIN_DIR} ; ls | sort)"
     exit 1
 fi
 
-export PATH="${HBASE}/${HELM_VERSION}:${PATH}"
+export PATH="${HELM_BIN_DIR}/${HELM_VERSION}:${PATH}"
 export PATH="/var/vcap/packages/cli/bin:${PATH}"
 export PATH="/var/vcap/packages/kubectl/bin:${PATH}"
 export PATH="/var/vcap/packages/credhub-cli/bin:${PATH}"

--- a/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
@@ -2,11 +2,31 @@
 
 set -o errexit
 
+# Use the primary linked helm client to determine the actual version
+# of the server. Check if we have a client for that version packaged,
+# and if yes, put it on the PATH. Else fails with a nice message.
+
+HBASE=/var/vcap/packages/helm/bin
+HELM_VERSION="$(${HBASE}/helm version| grep Server | sed -e 's/.*"v//' -e 's/".*//')"
+
+echo Packaged helm clients ...
+( cd ${HBASE} ; find . -type f | sed -e 's/^/= /' )
+echo Helm server ${HELM_VERSION}
+echo Compare
+
+if test -f "${HBASE}/${HELM_VERSION}/helm"
+then
+    echo Match
+else
+    echo "Helm server ${HELM_VERSION} not supported, only: $(cd ${HBASE} ; ls | sort)"
+    exit 1
+fi
+
+export PATH="${HBASE}/${HELM_VERSION}:${PATH}"
 export PATH="/var/vcap/packages/cli/bin:${PATH}"
 export PATH="/var/vcap/packages/kubectl/bin:${PATH}"
 export PATH="/var/vcap/packages/credhub-cli/bin:${PATH}"
 export PATH="/var/vcap/packages/mariadb-client/bin:${PATH}"
-export PATH="/var/vcap/packages/helm/bin:${PATH}"
 export PATH="/var/vcap/packages/acceptance-tests-brain/bin:${PATH}"
 
 source /var/vcap/jobs/acceptance-tests-brain/bin/environment.sh
@@ -18,8 +38,9 @@ export SCRIPTS_FOLDER="${BRAIN}/test-scripts"
 # Announce the versions of the helper apps used by this job. This also
 # causes an early abort if these are somehow missing, or not
 # accessible/found through the PATH.
-cf version
-kubectl version
+cf version      | sed -e 's/^/CF   = /'
+kubectl version | sed -e 's/^/KUBE = /'
+helm version    | sed -e 's/^/HELM = /'
 
 shopt -s nullglob
 for i in "${ASSETS}/plugins/"*; do

--- a/src/scf-release/packages/helm/packaging
+++ b/src/scf-release/packages/helm/packaging
@@ -2,13 +2,28 @@
 
 set -e
 
-VERSION=v2.9.1
-
-echo Retrieving helm "${VERSION}"
-
-curl -L -o helm.tar.gz "https://storage.googleapis.com/kubernetes-helm/helm-${VERSION}-linux-amd64.tar.gz"
-
 BIN_DIR="${BOSH_INSTALL_TARGET}/bin"
 
-mkdir -p "${BIN_DIR}"
-tar xf helm.tar.gz --strip-components=1 -C "${BIN_DIR}" linux-amd64/helm
+VERSIONS=""
+VERSIONS="${VERSIONS} 2.11.0"
+VERSIONS="${VERSIONS} 2.8.2"
+
+echo Packaging helm cli versions: ${VERSIONS}
+
+for version in $VERSIONS
+do
+    DEST="${BIN_DIR}/${version}"
+
+    echo Retrieving helm cli "${version}"
+    curl -L -o helm.tar.gz "https://storage.googleapis.com/kubernetes-helm/helm-v${version}-linux-amd64.tar.gz"
+
+    mkdir -p "${DEST}"
+    tar xf helm.tar.gz --strip-components=1 -C "${DEST}" linux-amd64/helm
+    rm -f  helm.tar.gz
+
+    # Link the last helm client as the primary.
+    # Note, order of versions above has min version last.
+    ( cd "${BIN_DIR}"
+      rm -f helm
+      ln -s "${DEST}"/helm helm )
+done


### PR DESCRIPTION
Ref https://trello.com/c/ZLlm1pbe/933-minibroker-brain-test-for-redis-fails-due-to-client-mismatch

Package all versions needed by vagrant, our CI, an CaaSP3.
Detect and choose version to use at runtime (brain tests).