### PR TITLE
Role manifest: Remove diego-cell readiness probe

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1284,10 +1284,6 @@ instance_groups:
             tag: host-cgroup
           memory: 2800
           virtual-cpus: 4
-          healthcheck:
-            readiness:
-              command:
-                - /var/vcap/jobs/global-properties/bin/readiness/diego-cell
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Turns out we didn't actually _have_ a probe script; it previously worked because the role manifest had an error and the readiness probe was never used.  Now that we fixed the typo, we try to make it use a non-existent readiness probe instead, which always fails.

See also #2015 (merged in 04f0c59c6d55151d2a440c11e9508d16f424d668) where we merged the typo fix (and broke the build).

See also https://github.com/SUSE/scf-helper-release/tree/master/jobs/global-properties/templates where there is no `diego-cell` readiness probe.