### PR TITLE
Bumped groot-btrfs to version 1.0.4

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -120,9 +120,9 @@ releases:
   url: "https://s3.amazonaws.com/suse-final-releases/cf-usb-release-1.0.1.tgz"
   sha1: "3dc34e90b55d9d61f93f204fce11655b7cd87c87"
 - name: groot-btrfs
-  version: "1.0.3"
-  url: "https://s3.amazonaws.com/suse-final-releases/groot-btrfs-release-1.0.3.tgz"
-  sha1: "e2a505254b40956d52b80c3ff9f107d325d949ff"
+  version: "1.0.4"
+  url: "https://s3.amazonaws.com/suse-final-releases/groot-btrfs-release-1.0.4.tgz"
+  sha1: "22381250b0f334d2c5dde04e85a9c1116d8e04fa"
 - name: scf-helper
   version: "1.0.1"
   url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.1.tgz"


### PR DESCRIPTION
## Description

Ties to the bug seen while trying to mount a file as a filesystem on the Diego Cell.