### PR TITLE
acceptance-tests-brain: 012_minibroker_redis: fix image pulling

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.sh
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.sh
@@ -79,6 +79,11 @@ function test_cleanup() {
     cf delete-security-group -f "${CF_SEC_GROUP}"
     cf delete-service-broker -f "${CF_BROKER}"
 
+    if kubectl get namespace minibroker ; then
+        kubectl get pods --namespace minibroker
+        kubectl get pods --namespace minibroker -o yaml
+    fi
+
     helm delete --purge minibroker
     for namespace in minibroker minibroker-pods ; do
         while kubectl get namespace "${namespace}" >/dev/null 2>/dev/null ; do
@@ -125,7 +130,9 @@ helm upgrade minibroker minibroker \
     --set "helmRepoUrl=${KUBERNETES_REPO}" \
     --set "deployServiceCatalog=false" \
     --set "defaultNamespace=minibroker-pods" \
-    --set "image=splatform/minibroker:latest"
+    --set "kube.registry.hostname=index.docker.io" \
+    --set "kube.organization=splatform" \
+    --set "image=minibroker:latest"
 
 wait_for_namespace "minibroker"
 


### PR DESCRIPTION
The minibroker charts changed how the images are fetched; fix up the test scripts so we can find them again (by overriding the appropriate bits in the helm values).

Also, dump out relevant information when tests fail.