### PR TITLE
scf-release: Bump CF CLI version to 6.42.0

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -8,7 +8,7 @@ set -o errexit -o nounset
 # Used in: bin/dev/install_tools.sh
 
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
-export CFCLI_VERSION="6.37.0"
+export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="develop"
 export FISSILE_VERSION="7.0.0+227.g89b5d91"
 export HELM_VERSION="2.11.0"

--- a/src/scf-release/config/blobs.yml
+++ b/src/scf-release/config/blobs.yml
@@ -3,10 +3,10 @@ container-networking/v0-14-0-network-policy-plugin-linux64:
   object_id: v0-14-0-network-policy-plugin-linux64
   sha: df087aee2480e2ec67a6b0433fddd351b9f2cc21
   size: 8472248
-cli/cf-cli_6.37.0_linux_x86-64.tgz:
-  object_id: cf-cli_6.37.0_linux_x86-64.tgz
-  sha: 87034130ce9327628169690b99a43ffe9f4167cf
-  size: 6005188
+cli/cf-cli_6.42.0_linux_x86-64.tgz:
+  object_id: cf-cli_6.42.0_linux_x86-64.tgz
+  sha: 8cde11d372b6a022c101e78df1a563cd5d034269
+  size: 7361332
 golang/go1.10.linux-amd64.tar.gz:
   size: 119905205
   object_id: go1.10.linux-amd64.tar.gz

--- a/src/scf-release/packages/cli/spec
+++ b/src/scf-release/packages/cli/spec
@@ -1,4 +1,4 @@
 ---
 name: cli
 files:
-  - cli/cf-cli_6.37.0_linux_x86-64.tgz
+  - cli/cf-cli_6.42.0_linux_x86-64.tgz


### PR DESCRIPTION
It appears that nothing major has changed (for our purposes), and the tests continue passing.