### PR TITLE
Enable mutual TLS between Cloud Controller and GoRouter

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -789,6 +789,9 @@ instance_groups:
         - name: api-tls
           protocol: TCP
           internal: 9023
+        - name: api-mutual-tls
+          protocol: TCP
+          internal: 9024
         - name: statsd
           protocol: TCP
           internal: 8125
@@ -827,7 +830,7 @@ instance_groups:
   - sequential-startup
   configuration:
     templates:
-      properties.route_registrar.routes: '[{"name":"api", "port":9022, "tags":{"component":"CloudController"}, "uris":["api.((DOMAIN))"], "registration_interval":"10s"}]'
+      properties.route_registrar.routes: '[{"name": "api", "port": ((CC_PORT_PUBLIC_INSECURE)), "tls_port": ((CC_PORT_PUBLIC_TLS)), "server_cert_domain_san": "api-set", "tags": {"component": "CloudController"}, "uris": ["api.((DOMAIN))"], "registration_interval": "10s"}]'
 - name: cc-worker
   scripts:
   - scripts/forward_logfiles.sh
@@ -2470,6 +2473,10 @@ configuration:
     properties.cc.packages.webdav_config.password: '"((BLOBSTORE_PASSWORD))"'
     properties.cc.packages.webdav_config.private_endpoint: https://blobstore-blobstore.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):4443
     properties.cc.packages.webdav_config.public_endpoint: '"https://blobstore.((DOMAIN))"'
+    properties.cc.public_tls.ca_cert: '"((INTERNAL_CA_CERT))"'
+    properties.cc.public_tls.certificate: '"((CC_PUBLIC_TLS_CERT))"'
+    properties.cc.public_tls.port: '"((CC_PORT_PUBLIC_TLS))"'
+    properties.cc.public_tls.private_key: '"((CC_PUBLIC_TLS_CERT_KEY))"'
     properties.cc.resource_pool.webdav_config.password: '"((BLOBSTORE_PASSWORD))"'
     properties.cc.resource_pool.webdav_config.private_endpoint: https://blobstore-blobstore.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):4443
     properties.cc.resource_pool.webdav_config.public_endpoint: '"https://blobstore.((DOMAIN))"'
@@ -2488,8 +2495,8 @@ configuration:
     properties.cf-usb.mysql_address: 'mysql-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))'
     properties.cf-usb.mysql_password: "((MYSQL_CF_USB_PASSWORD))"
     properties.cf.admin_password: '"((CLUSTER_ADMIN_PASSWORD))"'
-    properties.cf.api_url: https://api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):9023
-    properties.cf.insecure_api_url: http://api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):9022 # For post-deployment-setup, because cf cli has no client certs
+    properties.cf.api_url: https://api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):((CC_PORT_PUBLIC_TLS))
+    properties.cf.insecure_api_url: http://api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):((CC_PORT_PUBLIC_INSECURE)) # For post-deployment-setup, because cf cli has no client certs.
     properties.cf_mysql.host: '"mysql-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"'
     properties.cf_mysql.mysql.advertise_host: mysql-((KUBE_COMPONENT_INDEX)).mysql-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
     properties.cf_mysql.mysql.seeded_databases: '[{"name":"ccdb","username":"ccadmin","password":"((MYSQL_CCDB_ROLE_PASSWORD))"},{"name":"diego","username":"diego","password":"((MYSQL_DIEGO_PASSWORD))"},{"name":"routing-api","username":"routing-api","password":"((MYSQL_ROUTING_API_PASSWORD))"},{"name":"usb","username":"usb","password":"((MYSQL_CF_USB_PASSWORD))"},{"name":"nfsvolume","username":"nfsvolume","password":"((MYSQL_PERSI_NFS_PASSWORD))"},{"name":"diego_locket","username":"diego_locket","password":"((MYSQL_DIEGO_LOCKET_PASSWORD))"},{"name":"credhub_user","username":"credhub_user","password":"((MYSQL_CREDHUB_USER_PASSWORD))"}]'
@@ -3399,6 +3406,29 @@ variables:
     description: A map of labels and encryption keys
     secret: true
     default: "~"
+- name: CC_PORT_PUBLIC_INSECURE
+  options:
+    default: 9022
+    description: The CC port for plain HTTP communication.
+- name: CC_PORT_PUBLIC_TLS
+  options:
+    default: 9024
+    description: The CC port for TLS with gorouter.
+- name: CC_PUBLIC_TLS_CERT
+  options:
+    secret: true
+    ca: INTERNAL_CA_CERT
+    alternative_names:
+    - "api-set"
+    - "api-set.{{ .KUBERNETES_NAMESPACE }}.svc.{{ .KUBERNETES_CLUSTER_DOMAIN }}"
+    description: The PEM-encoded certificate for secure TLS communication over external endpoints.
+    required: true
+  type: certificate
+- name: CC_PUBLIC_TLS_CERT_KEY
+  options:
+    secret: true
+    description: The PEM-encoded key for secure TLS communication over external endpoints.
+    required: true
 - name: CC_SERVER_CRT
   options:
     secret: true


### PR DESCRIPTION
## Description

Use port 9024 instead of 9022 on CC for mutual TLS with GoRouter.

Reference https://bosh.io/jobs/cloud_controller_ng?source=github.com/cloudfoundry/capi-release&version=1.66.0#p%3dcc.public_tls

## Test plan

Deploy SCF and perform an operation with the cf CLI. Then get a shell session to the `router-0` and `cat /var/vcap/sys/log/gorouter/access.log`. It shall show it is using port 9024. E.g.:

```
api.cf-dev.io - [2019-03-05T03:33:33.282+0000] "GET /v2/jobs/... HTTP/1.1" 200 0 270 "-" "go-cli 6.40.0+07673feb9.2018-10-08 / linux" "172.16.0.1:56432" "172.16.1.182:9024" x_forwarded_for:"172.16.0.1" x_forwarded_proto:"https" vcap_request_id:"..." response_time:0.01207756 app_id:"-" app_index:"-"
```