### PR TITLE
Enable extra admission plugins on k8s inside Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ end
 Vagrant.configure(2) do |config|
   vm_memory = ENV.fetch('SCF_VM_MEMORY', ENV.fetch('VM_MEMORY', 10 * 1024)).to_i
   vm_cpus = ENV.fetch('SCF_VM_CPUS', ENV.fetch('VM_CPUS', 4)).to_i
-  vm_box_version = ENV.fetch('SCF_VM_BOX_VERSION', ENV.fetch('VM_BOX_VERSION', '2.0.15'))
+  vm_box_version = ENV.fetch('SCF_VM_BOX_VERSION', ENV.fetch('VM_BOX_VERSION', '2.0.16'))
   vm_registry_mirror = ENV.fetch('SCF_VM_REGISTRY_MIRROR', ENV.fetch('VM_REGISTRY_MIRROR', ''))
 
   HOME = "/home/vagrant"

--- a/packer/.gitignore
+++ b/packer/.gitignore
@@ -1,3 +1,4 @@
 /packer_cache/
+/output/
 /output-*/
 /http/*-autoyast.xml

--- a/packer/http/apiserver-vagrant-overrides.env
+++ b/packer/http/apiserver-vagrant-overrides.env
@@ -1,6 +1,6 @@
-# This file overrides the default CaaSP values
+# This file overrides the default CaaSP values.
 KUBE_API_ADDRESS="--insecure-bind-address=0.0.0.0"
-# Allow privileged containers for diego-cell (also need to adjust kubelet)
+# Allow privileged containers for diego-cell (also need to adjust kubelet).
 KUBE_ALLOW_PRIV="--allow-privileged"
 KUBE_ADMISSION_CONTROL="--enable-admission-plugins \
 NamespaceLifecycle,\

--- a/packer/http/apiserver-vagrant-overrides.env
+++ b/packer/http/apiserver-vagrant-overrides.env
@@ -2,16 +2,6 @@
 KUBE_API_ADDRESS="--insecure-bind-address=0.0.0.0"
 # Allow privileged containers for diego-cell (also need to adjust kubelet).
 KUBE_ALLOW_PRIV="--allow-privileged"
-KUBE_ADMISSION_CONTROL="--enable-admission-plugins \
-NamespaceLifecycle,\
-LimitRanger,\
-ServiceAccount,\
-DefaultStorageClass,\
-MutatingAdmissionWebhook,\
-PodSecurityPolicy,\
-ResourceQuota,\
-ValidatingAdmissionWebhook"
-
-KUBE_API_ARGS="\
---authorization-mode=RBAC \
---runtime-config=admissionregistration.k8s.io/v1alpha1"
+KUBE_ADMISSION_CONTROL="--enable-admission-plugins MutatingAdmissionWebhook,PodSecurityPolicy,ValidatingAdmissionWebhook"
+# KUBE_API_ARGS contains the default value (--authorization-mode=RBAC) plus other arguments.
+KUBE_API_ARGS="--authorization-mode=RBAC --runtime-config=admissionregistration.k8s.io/v1alpha1"

--- a/packer/http/apiserver-vagrant-overrides.env
+++ b/packer/http/apiserver-vagrant-overrides.env
@@ -2,5 +2,16 @@
 KUBE_API_ADDRESS="--insecure-bind-address=0.0.0.0"
 # Allow privileged containers for diego-cell (also need to adjust kubelet)
 KUBE_ALLOW_PRIV="--allow-privileged"
-# Modify admission control policies to enforce pod security policies
-KUBE_ADMISSION_CONTROL="--enable-admission-plugins PodSecurityPolicy"
+KUBE_ADMISSION_CONTROL="--enable-admission-plugins \
+NamespaceLifecycle,\
+LimitRanger,\
+ServiceAccount,\
+DefaultStorageClass,\
+MutatingAdmissionWebhook,\
+PodSecurityPolicy,\
+ResourceQuota,\
+ValidatingAdmissionWebhook"
+
+KUBE_API_ARGS="\
+--authorization-mode=RBAC \
+--runtime-config=admissionregistration.k8s.io/v1alpha1"

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "2.0.15",
+        "version": "2.0.16",
         "vm_name": "scf-vagrant",
         "output_directory": "output",
         "ssh_username": "vagrant",


### PR DESCRIPTION
## Description

- Added the default admission plugins (the ones when `--enable-admission-plugins` is not set).
- Kept `PodSecurityPolicy`.
- Added `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` as requested for Istio automatic sidecar injection (https://istio.io/docs/setup/kubernetes/sidecar-injection/#automatic-sidecar-injection).
- Added `KUBE_API_ARGS` with its default value and appended `--runtime-config=admissionregistration.k8s.io/v1alpha1` to it to get `admissionregistration.k8s.io/v1alpha1` enabled, also a requirement for Istio automatic sidecar injection.

## Test plan

- On a current running Vagrant machine, replace the contents of `/etc/systemd/system/kube-apiserver.service.d/vagrant-overrides.env` by the ones in this PR.
- Restart the `kube-apiserver`: `sudo systemctl restart kube-apiserver`.
- Check it was restarted with the correct flags: `ps -eo pid,cmd | grep 'apiserver' | grep -v grep`.
- Check the `admissionregistration.k8s.io/v1alpha1` is present: `kubectl api-versions | grep admissionregistration`.

## Issue tracking

Resolves https://github.com/SUSE/scf/issues/1960