### PR TITLE
packer: fix kube-controller-manager systemd unit

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ end
 Vagrant.configure(2) do |config|
   vm_memory = ENV.fetch('SCF_VM_MEMORY', ENV.fetch('VM_MEMORY', 10 * 1024)).to_i
   vm_cpus = ENV.fetch('SCF_VM_CPUS', ENV.fetch('VM_CPUS', 4)).to_i
-  vm_box_version = ENV.fetch('SCF_VM_BOX_VERSION', ENV.fetch('VM_BOX_VERSION', '2.0.16'))
+  vm_box_version = ENV.fetch('SCF_VM_BOX_VERSION', ENV.fetch('VM_BOX_VERSION', '2.0.17'))
   vm_registry_mirror = ENV.fetch('SCF_VM_REGISTRY_MIRROR', ENV.fetch('VM_REGISTRY_MIRROR', ''))
 
   HOME = "/home/vagrant"

--- a/packer/http/controller-manager-vagrant-overrides.conf
+++ b/packer/http/controller-manager-vagrant-overrides.conf
@@ -1,10 +1,12 @@
+[Unit]
+After=kube-apiserver.service
+
 [Service]
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/ca/
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/apiserver.crt /var/run/kubernetes/serviceaccount.crt
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/apiserver.key /var/run/kubernetes/serviceaccount.key
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/CA.kube.vagrant.crt /etc/kubernetes/ca/ca.pem
 ExecStartPre=/usr/bin/ln -sf /etc/kubernetes/certs/CA.kube.vagrant.key /etc/kubernetes/ca/ca.key
-After=kube-apiserver.service
 
 # This needs to be run as root to correctly delete volumes (owned by users in containers)
 # See https://github.com/SUSE/scf/issues/999

--- a/packer/vagrant-box.json
+++ b/packer/vagrant-box.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "version": "2.0.16",
+        "version": "2.0.17",
         "vm_name": "scf-vagrant",
         "output_directory": "output",
         "ssh_username": "vagrant",


### PR DESCRIPTION
The `After=` line goes in the `[Unit]` section, not the `[Service]` section.