### PR TITLE
Pre-start check on Diego cell for swap accounting

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1237,6 +1237,7 @@ instance_groups:
   - scripts/configure-az.sh
   - scripts/configure-pz.sh
   scripts:
+  - scripts/check_swapaccounting.sh
   - scripts/configure-nested-net.sh
   - scripts/cleanup-garden-graph.sh
   - scripts/forward_logfiles.sh

--- a/container-host-files/etc/scf/config/scripts/check_swapaccounting.sh
+++ b/container-host-files/etc/scf/config/scripts/check_swapaccounting.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# This script checks if swapaccounting is enabled on the kernel.
+
+if [ ! -e /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes ]; then
+	red='\033[0;31m'
+	no_color='\033[0m'
+	(>&2 printf "${red}")
+	(>&2 printf "cgroup swap accounting is currently not enabled.")
+	(>&2 printf " You should enable it on all your k8s nodes by setting the boot option \"swapaccount=1\".")
+	(>&2 printf "${no_color}\\n")
+	sleep 60
+	exit 1
+fi


### PR DESCRIPTION
## Description

Added a pre-start check to Diego cell for swap accounting.
If swap accounting is not enabled, it prints a red message to the stderr and exits with 1.

## Test plan

The logic is simple, disable swap accounting on the machine you are going to perform the test and deploy CAP. Diego cell should never come up.

On a Vagrant machine this can be done through the following:
1. `sudo vim /etc/default/grub`, then remove `swapaccount=1` from `GRUB_CMDLINE_LINUX_DEFAULT`.
2. `sudo grub2-mkconfig -o /boot/grub2/grub.cfg`.
3. From the host, run `vagrant reload`.
4. `vagrant ssh` back and watch for the Diego cell pod.
5. Check the logs with `kubectl logs --follow --namespace cf diego-cell-0 -c diego-cell`.
6. Put `swapaccount=1` back to the grub kernel boot parameters and reboot with `vagrant reload`.
7. Check that Diego cell comes back to life.