### PR TITLE
Brain tests - match the helm client according to the server version

### DIFF
--- a/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
@@ -9,17 +9,13 @@ set -o errexit
 HELM_BIN_DIR=/var/vcap/packages/helm/bin
 HELM_VERSION="$(${HELM_BIN_DIR}/helm version | grep Server | sed -e 's/.*"v//' -e 's/".*//')"
 
-echo Packaged helm clients ...
-( cd ${HELM_BIN_DIR} ; find . -type f | sed -e 's/^/= /' )
 echo Helm server ${HELM_VERSION}
-echo Compare
 
-if test -f "${HELM_BIN_DIR}/${HELM_VERSION}/helm"
-then
-    echo Match
-else
-    echo "Helm server ${HELM_VERSION} not supported, only: $(cd ${HELM_BIN_DIR} ; ls | sort)"
-    exit 1
+if ! test -f "${HELM_BIN_DIR}/${HELM_VERSION}/helm"; then
+    printf "Helm v%s could not be found. Installing...\\n" "${HELM_VERSION}"
+    helm_url="https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+    mkdir -p "${HELM_BIN_DIR}/${HELM_VERSION}"
+    curl -L "${helm_url}" | tar zx --strip-components 1 -C "${HELM_BIN_DIR}/${HELM_VERSION}"
 fi
 
 export PATH="${HELM_BIN_DIR}/${HELM_VERSION}:${PATH}"

--- a/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
@@ -11,10 +11,13 @@ HELM_VERSION="$(${HELM_BIN_DIR}/helm version | grep Server | sed -e 's/.*"v//' -
 
 echo Helm server ${HELM_VERSION}
 
-if ! test -f "${HELM_BIN_DIR}/${HELM_VERSION}/helm"; then
-    printf "Helm v%s could not be found. Installing...\\n" "${HELM_VERSION}"
-    helm_url="https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+if [ ! -f "${HELM_BIN_DIR}/${HELM_VERSION}/helm" ]; then
+    printf "Helm v%s could not be found.\\n" "${HELM_VERSION}"
+    printf "Installed Helm clients:\\n"
+    find "${HELM_BIN_DIR}" -type f | sed -e 's/^/= /'
+    printf "Downloading and installing v%s...\\n" "${HELM_VERSION}"
     mkdir -p "${HELM_BIN_DIR}/${HELM_VERSION}"
+    helm_url="https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
     curl -L "${helm_url}" | tar zx --strip-components 1 -C "${HELM_BIN_DIR}/${HELM_VERSION}"
 fi
 

--- a/src/scf-release/packages/helm/packaging
+++ b/src/scf-release/packages/helm/packaging
@@ -4,26 +4,15 @@ set -e
 
 BIN_DIR="${BOSH_INSTALL_TARGET}/bin"
 
-VERSIONS=""
-VERSIONS="${VERSIONS} 2.11.0"
-VERSIONS="${VERSIONS} 2.8.2"
+VERSION="2.11.0"
 
-echo Packaging helm cli versions: ${VERSIONS}
+echo Packaging Helm CLI version: ${VERSION}
 
-for version in $VERSIONS
-do
-    DEST="${BIN_DIR}/${version}"
+DEST="${BIN_DIR}/${VERSION}"
 
-    echo Retrieving helm cli "${version}"
-    curl -L -o helm.tar.gz "https://storage.googleapis.com/kubernetes-helm/helm-v${version}-linux-amd64.tar.gz"
+echo Retrieving helm cli "${VERSION}"
+helm_url="https://storage.googleapis.com/kubernetes-helm/helm-v${VERSION}-linux-amd64.tar.gz"
+mkdir -p "${DEST}"
+curl -L "${helm_url}" | tar zx --strip-components 1 -C "${DEST}"
 
-    mkdir -p "${DEST}"
-    tar xf helm.tar.gz --strip-components=1 -C "${DEST}" linux-amd64/helm
-    rm -f  helm.tar.gz
-
-    # Link the last helm client as the primary.
-    # Note, order of versions above has min version last.
-    ( cd "${BIN_DIR}"
-      rm -f helm
-      ln -s "${DEST}"/helm helm )
-done
+ln -s "${DEST}/helm" "${BIN_DIR}/helm"

--- a/src/scf-release/packages/helm/packaging
+++ b/src/scf-release/packages/helm/packaging
@@ -1,18 +1,23 @@
 #!/bin/bash
 
-set -e
+set -o errexit
 
 BIN_DIR="${BOSH_INSTALL_TARGET}/bin"
 
-VERSION="2.11.0"
+HELM_VERSIONS=(
+  "2.8.2" # Version shipped with CaaSP 3 by default.
+  "2.11.0" # Version shipped with the Vagrant box by default.
+)
 
-echo Packaging Helm CLI version: ${VERSION}
+for helm_version in "${HELM_VERSIONS[@]}"
+do
+    echo Downloading and installing Helm CLI "${helm_version}"
 
-DEST="${BIN_DIR}/${VERSION}"
+    DEST="${BIN_DIR}/${helm_version}"
+    mkdir -p "${DEST}"
+    helm_url="https://storage.googleapis.com/kubernetes-helm/helm-v${helm_version}-linux-amd64.tar.gz"
+    curl -L "${helm_url}" | tar zx --strip-components 1 -C "${DEST}"
+done
 
-echo Retrieving helm cli "${VERSION}"
-helm_url="https://storage.googleapis.com/kubernetes-helm/helm-v${VERSION}-linux-amd64.tar.gz"
-mkdir -p "${DEST}"
-curl -L "${helm_url}" | tar zx --strip-components 1 -C "${DEST}"
-
-ln -s "${DEST}/helm" "${BIN_DIR}/helm"
+# Link the last Helm client as the primary.
+ln -s "${BIN_DIR}/${HELM_VERSIONS[${#HELM_VERSIONS[@]}-1]}/helm" "${BIN_DIR}/helm"


### PR DESCRIPTION
## Description

**For brain tests**

Perform a check whether the helm client matches the server version. If not, download the version to match the server.

## Test plan

Get a Tiller version different than 2.11.0 deployed to a supported k8s cluster and run a minibroker brain test.