### PR TITLE
autoscaler: don't mark ports as public

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1573,7 +1573,6 @@ instance_groups:
           protocol: TCP
           external: 7106
           internal: 7106
-          public: true
         run:
           scaling:
             min: 0
@@ -1720,7 +1719,6 @@ instance_groups:
           protocol: TCP
           external: 7101
           internal: 7101
-          public: true
   - name: route_registrar
     release: routing
   - name: bpm


### PR DESCRIPTION
The ports go via the gorouter anyway; don't mark them as public so that things work correctly behind load balancers.

Testing this in a PR to free up local resources; this has not been previously tested and shouldn't even be reviewed until the autoscaler smoke test passes in CI.