### PR TITLE
acceptance-tests-brain: helpers: don't accept podless namespace as ready

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
@@ -133,7 +133,7 @@ end
 def wait_for_namespace(namespace, sleep_duration=10)
     loop do
         output = capture("kubectl get pods --namespace #{namespace} --no-headers")
-        ready = true
+        ready = !output.empty?
         output.each_line do |line|
             name, readiness, status, restarts, age = line.split
             next if status == 'Completed'


### PR DESCRIPTION
If we find no pods, then assume the pods just haven't been created yet, and don't finish the wait loop.