### PR TITLE
acceptance-tests-brain: minibroker/redis: be more verbose

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
@@ -34,7 +34,7 @@ MiniBrokerTest.new('redis', '6379').run_test do |tester|
     run "echo '#{domain_info.to_json}' | jq -C ."
     app_domain = domain_info['entity']['name']
 
-    run "curl -X PUT http://#{app_host}.#{app_domain}/hello -d data=success"
-    output = capture("curl http://#{app_host}.#{app_domain}/hello")
-    fail "Incorrect output" unless output == 'success'
+    run "curl -v -X PUT http://#{app_host}.#{app_domain}/hello -d data=success"
+    output = capture("curl -v http://#{app_host}.#{app_domain}/hello")
+    fail "Incorrect output: got #{output.inspect}" unless output == 'success'
 end


### PR DESCRIPTION
When errors happen, we should provide more information on what is failing; currently it's just a very uninformative message.