### PR TITLE
Ingress resource - add necessary annotations and small refactors

### DIFF
--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.services.ingress }}
+{{- if .Values.services.ingress -}}
 ---
 # The cert and the key cannot be filled automatically. If we could it
 # would roughly look like the lines below. As is it is the
@@ -14,7 +14,8 @@ apiVersion: "v1"
 kind: "Secret"
 type: kubernetes.io/tls
 metadata:
-  name: "{{ .Release.Namespace }}-secrets-nic"
+  name: "{{ .Values.services.ingress.class }}-ingress-tls"
+  namespace: "{{ .Release.Namespace }}"
 data:
   tls.crt: ""
   tls.key: ""
@@ -31,14 +32,19 @@ data:
 apiVersion: "extensions/v1beta1"
 kind: "Ingress"
 metadata:
-  name: "ingress-scf"
-  namespace: {{ .Release.Namespace | quote }}
+  name: "{{ .Release.Name }}-{{ .Values.services.ingress.class }}"
+  namespace: "{{ .Release.Namespace }}"
   annotations:
+    kubernetes.io/ingress.class: {{ .Values.services.ingress.class }}
+    {{ if eq .Values.services.ingress.class "nginx" -}}
     nginx.ingress.kubernetes.io/secure-backends: "true"
-    kubernetes.io/ingress.class: {{ .Values.services.ingress }}
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false" # Doesn't enforce HTTPS.
+    nginx.ingress.kubernetes.io/proxy-body-size: "8m"
+    {{- end }}
 spec:
   tls:
-  - secretName: "{{ .Release.Namespace }}-secrets-nic"
+  - secretName: "{{ .Values.services.ingress.class }}-ingress-tls"
     hosts:
     - "*.{{ .Values.env.DOMAIN }}"
     - "{{ .Values.env.DOMAIN }}"
@@ -49,12 +55,12 @@ spec:
           - path: "/"
             backend:
               serviceName: "router-gorouter-public"
-              servicePort: 443
+              servicePort: {{ .Values.services.ingress.backends.router.port }}
     - host: "{{ .Values.env.DOMAIN }}"
       http:
         paths:
           - path: "/"
             backend:
               serviceName: "router-gorouter-public"
-              servicePort: 443
+              servicePort: {{ .Values.services.ingress.backends.router.port }}
 {{- end }}


### PR DESCRIPTION
## Description

- Adds missing NGINX Ingress Controller annotations.
- Changes the name of the resources to more meaningful ones (not tied to a specific Ingress Controller).
- Injects the backend port.

## Test plan

- Deploy the NGINX Ingress Controller.
- Deploy SCF with the below additional values and no `kube.external_ips`:
```
services:
  ingress:
    class: nginx
    backends:
      router:
        port: 443
```
- Check GoRouter can be reached through the Ingress Controller.