### PR TITLE
versions: Bump to 1.3.2

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -40,7 +40,7 @@ export GOLANG_VERSION=1.7
 
 # Used in: make/include/versioning
 
-export PRODUCT_VERSION="1.13.1"
+export PRODUCT_VERSION="1.3.2"
 export CF_VERSION=5.1.0
 
 # Show versions, if called on its own.


### PR DESCRIPTION
Note that it was previously mistakenly set to 1.13.1 when it should have been 1.3.1