### PR TITLE
SUSE nginx-ingress

### DIFF
--- a/make/include/defaults
+++ b/make/include/defaults
@@ -35,6 +35,6 @@ export UAA_CLIENT_ID=cf
 : "${ISTIO_NAMESPACE:=istio-system}"
 : "${ISTIO_HELM_RELEASE:=istio}"
 
-: "${NGINX_INGRESS_CHART:=stable/nginx-ingress}"
+: "${NGINX_INGRESS_CHART:=suse/nginx-ingress}"
 : "${NGINX_INGRESS_NAMESPACE:=nginx-ingress}"
 : "${NGINX_INGRESS_HELM_RELEASE:=nginx-ingress}"

--- a/make/include/wait_for
+++ b/make/include/wait_for
@@ -4,20 +4,20 @@ set -o errexit -o nounset
 
 # Flags for wait_for_job:
 #   -n    namespace where the job is executed.
-#   -l    label/selector for the job.
+#   -s    jq select for filtering the job.
 #   -t    time to wait between checks.
 wait_for_job() {
   local namespace
-  local selector
+  local select
   local time_to_sleep=3
   OPTIND=1
-  while getopts "n:l:t:" opt "$@"; do
+  while getopts "n:s:t:" opt "$@"; do
     case $opt in
       n)
         namespace=$OPTARG
         ;;
-      l)
-        selector=$OPTARG
+      s)
+        select=$OPTARG
         ;;
       t)
         time_to_sleep=$OPTARG
@@ -38,18 +38,19 @@ wait_for_job() {
     return 1
   fi
 
-  if [[ -z "${selector:-}" ]]; then
-    echo "Missing selector. '-l' must be specified." >&2
+  if [[ -z "${select:-}" ]]; then
+    echo "Missing select. '-s' must be specified." >&2
     return 1
   fi
 
-  check_args=(
+  local kubectl_args=(
     --namespace "${namespace}"
-    --selector "${selector}"
-    --output 'jsonpath={.items[?(@.status.succeeded==1)].status.conditions[?(@.type=="Complete")]}'
+    --output json
   )
 
-  until [[ -n "$(kubectl get jobs "${check_args[@]}")" ]]; do
+  local jq_arg=".items[] | select(.status.succeeded == 1) | select(${select})"
+
+  until [[ -n "$(kubectl get jobs "${kubectl_args[@]}" | jq -c "${jq_arg}")" ]]; do
     sleep "${time_to_sleep}"
   done
 }

--- a/make/ingress/update_secrets
+++ b/make/ingress/update_secrets
@@ -12,7 +12,7 @@ source "${GIT_ROOT}/make/include/secrets"
 source "${GIT_ROOT}/make/include/wait_for"
 
 printf "Waiting for UAA secret generation job to finish... "
-wait_for_job -n "${UAA_NAMESPACE}" -l "app.kubernetes.io/component=secret-generation-1"
+wait_for_job -n "${UAA_NAMESPACE}" -s '.metadata.labels["app.kubernetes.io/component"] | test("^secret-generation-[0-9]+$")'
 printf "ok\\n"
 
 uaa_secret_name="${INGRESS_CONTROLLER}-ingress-tls"
@@ -36,7 +36,7 @@ data:
 EOF
 
 printf "Waiting for CF secret generation job to finish... "
-wait_for_job -n "${CF_NAMESPACE}" -l "app.kubernetes.io/component=secret-generation-1"
+wait_for_job -n "${CF_NAMESPACE}" -s '.metadata.labels["app.kubernetes.io/component"] | test("^secret-generation-[0-9]+$")'
 printf "ok\\n"
 
 cf_secret_name="${INGRESS_CONTROLLER}-ingress-tls"


### PR DESCRIPTION
## Description

- Switch from `stable/nginx-ingress` to `suse/nginx-ingress`.
- Fix to the function that waits for a job.

## Test plan

Deploy SCF with NGINX Ingress Controller:
```
(export INGRESS_CONTROLLER=nginx; make run)
```

Upgrade SCF to add the missing bits:
```
(export INGRESS_CONTROLLER=nginx; export SCF_ENABLE_AUTOSCALER=true; export SCF_ENABLE_CREDHUB=true; make upgrade)
```

Run CATS.