### PR TITLE
UAA through ingress controller

### DIFF
--- a/make/ingress/nginx/run
+++ b/make/ingress/nginx/run
@@ -26,7 +26,6 @@ values=(
   --set "tcp.20008=${CF_NAMESPACE}/tcp-router-tcp-router-public:20008"
   --set "tcp.4443=${CF_NAMESPACE}/router-gorouter-public:4443"
   --set "tcp.2222=${CF_NAMESPACE}/diego-ssh-ssh-proxy-public:2222"
-  --set "tcp.${UAA_PORT}=${UAA_NAMESPACE}/uaa-uaa-public:${UAA_PORT}"
 )
 
 helm upgrade --install "${args[@]}" "${NGINX_INGRESS_CHART}" "${values[@]}"

--- a/make/run
+++ b/make/run
@@ -55,7 +55,6 @@ helm_args=(
     --set "env.DOMAIN=${DOMAIN}"
     --set "env.TCP_DOMAIN=${TCP_DOMAIN}"
     --set "env.UAA_HOST=${UAA_HOST}"
-    --set "env.UAA_PORT=${UAA_PORT}"
     --set "env.INSECURE_DOCKER_REGISTRIES=${INSECURE_DOCKER_REGISTRIES}"
     --set "secrets.UAA_CA_CERT=${CA_CERT}"
     --set "kube.storage_class.persistent=${STORAGE_CLASS}"
@@ -65,10 +64,12 @@ if [ -n "${INGRESS_CONTROLLER:-}" ]; then
     helm_args+=(
         --set "services.ingress.class=${INGRESS_CONTROLLER}"
         --set "services.ingress.backends.router.port=443"
+        --set "env.UAA_PORT=443"
     )
 else
     helm_args+=(
         --set "kube.external_ips[0]=$(getent hosts "${DOMAIN}" | awk 'NR=1{print $1}')"
+        --set "env.UAA_PORT=${UAA_PORT}"
     )
 fi
 

--- a/make/upgrade
+++ b/make/upgrade
@@ -34,7 +34,6 @@ helm_args=(
     --set "env.DOMAIN=${DOMAIN}"
     --set "env.TCP_DOMAIN=${TCP_DOMAIN}"
     --set "env.UAA_HOST=${UAA_HOST}"
-    --set "env.UAA_PORT=${UAA_PORT}"
     --set "env.INSECURE_DOCKER_REGISTRIES=${INSECURE_DOCKER_REGISTRIES}"
     --set "secrets.UAA_CA_CERT=${UAA_CA_CERT}"
     --set "kube.storage_class.persistent=${STORAGE_CLASS}"
@@ -44,10 +43,12 @@ if [ -n "${INGRESS_CONTROLLER:-}" ]; then
     helm_args+=(
         --set "services.ingress.class=${INGRESS_CONTROLLER}"
         --set "services.ingress.backends.router.port=443"
+        --set "env.UAA_PORT=443"
     )
 else
     helm_args+=(
         --set "kube.external_ips[0]=$(getent hosts "${DOMAIN}" | awk 'NR=1{print $1}')"
+        --set "env.UAA_PORT=${UAA_PORT}"
     )
 fi
 


### PR DESCRIPTION
## Description

Updated the make scripts to deploy SCF with `UAA_PORT=443` when the Ingress Controller is enabled.
This PR also bumps the uaa-fissile-release that introduces the possibility to specify `UAA_PUBLIC_PORT`.

## Test plan

- Deploy SCF with Ingress Controller set to `nginx`.
- Verify that the port 2793 is not in the NGINX Ingress Controller passthrough.
- Run the tests.