### PR TITLE
Handle WebSockets in the ingress controller

### DIFF
--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -41,6 +41,7 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/ssl-redirect: "false" # Doesn't enforce HTTPS.
     nginx.ingress.kubernetes.io/proxy-body-size: "8m"
+    nginx.org/websocket-services: "router-gorouter-public"
     {{- end }}
 spec:
   tls:

--- a/container-host-files/etc/scf/config/opinions-common.yml
+++ b/container-host-files/etc/scf/config/opinions-common.yml
@@ -318,8 +318,6 @@ properties:
         user: nats
     ssh_proxy:
       enable_cf_auth: true
-  doppler:
-    port: 4443
   enable_consul_service_registration: false
   etcd:
     bootstrap_node: etcd-0

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -601,11 +601,6 @@ instance_groups:
           protocol: TCP
           internal: 443
           public: true
-        - name: doppler-ssl
-          protocol: TCP
-          external: 4443
-          internal: 443
-          public: true
 - name: tcp-router
   # XXX haproxy might be able to co-locate with one of the others
   # But this is a _different_ HAProxy from the one in the CF release.

--- a/make/ingress/nginx/run
+++ b/make/ingress/nginx/run
@@ -24,7 +24,6 @@ values=(
   --set "tcp.20006=${CF_NAMESPACE}/tcp-router-tcp-router-public:20006"
   --set "tcp.20007=${CF_NAMESPACE}/tcp-router-tcp-router-public:20007"
   --set "tcp.20008=${CF_NAMESPACE}/tcp-router-tcp-router-public:20008"
-  --set "tcp.4443=${CF_NAMESPACE}/router-gorouter-public:4443"
   --set "tcp.2222=${CF_NAMESPACE}/diego-ssh-ssh-proxy-public:2222"
 )
 


### PR DESCRIPTION
## Description

Switch from port 4443 to port 443 (which is the default value) for doppler. GoRouter handles both https and wss on port 443 by default.

This PR also removes the TCP passthrough from the NGINX Ingress Controller make scripts that deploy it to Vagrant, making the WebSocket connection to go through the Ingress Controller when it is enabled.

## Test plan

- CI should pass with the current configuration (no Ingress Controller enabled).
- On a Vagrant machine, deploy SCF with `(export INGRESS_CONTROLLER=nginx; make run)`.
- Run the tests related to logging, which should use doppler to consume them.