### PR TITLE
Fix missing `socat` under SLE

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/017_syslog_forwarding_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/017_syslog_forwarding_test.rb
@@ -114,7 +114,6 @@ Timeout::timeout(ENV.fetch('TESTBRAIN_TIMEOUT', '600').to_i - 60) do
 
     # (B) Configure and run the log receiver pod
 
-    pod_info = JSON.load capture("kubectl get pod -n #{$KUBERNETES_NAMESPACE} #{ENV['HOSTNAME']} -o json")
     image = 'opensuse/leap'
     install_args = "zypper --non-interactive install socat util-linux-systemd"
     socat_args = "/usr/bin/socat #{SCF_LOG_PROTOCOL.upcase}-LISTEN:#{SCF_LOG_PORT},fork 'EXEC:/usr/bin/logger --socket-errors=off --stderr --tag \"\"'"

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/017_syslog_forwarding_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/017_syslog_forwarding_test.rb
@@ -115,7 +115,7 @@ Timeout::timeout(ENV.fetch('TESTBRAIN_TIMEOUT', '600').to_i - 60) do
     # (B) Configure and run the log receiver pod
 
     pod_info = JSON.load capture("kubectl get pod -n #{$KUBERNETES_NAMESPACE} #{ENV['HOSTNAME']} -o json")
-    image = pod_info['spec']['containers'].find { |container| container['image'] }['image']
+    image = 'opensuse/leap'
     install_args = "zypper --non-interactive install socat util-linux-systemd"
     socat_args = "/usr/bin/socat #{SCF_LOG_PROTOCOL.upcase}-LISTEN:#{SCF_LOG_PORT},fork 'EXEC:/usr/bin/logger --socket-errors=off --stderr --tag \"\"'"
     cmd = %W(


### PR DESCRIPTION
Semi-passed Jenkins: The test 017 changed here passed. The unchanged minibroker mongodb test failed. See https://github.com/SUSE/scf/pull/2146 for the PR disabling that test.