### PR TITLE
Set vcap hard and soft nproc limits for every role

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -151,6 +151,7 @@ releases:
 instance_groups:
 - name: syslog-scheduler
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -201,6 +202,7 @@ instance_groups:
         pod-security-policy: privileged
 - name: adapter
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -256,6 +258,7 @@ instance_groups:
   environment_scripts:
   - scripts/configure-HA-hosts.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -308,6 +311,7 @@ instance_groups:
         pod-security-policy: privileged
 - name: mysql
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/create_mysql_data_tmp.sh
   - scripts/chown_vcap_store.sh
   - scripts/patches/fix_mysql_advertise_ip.sh
@@ -406,6 +410,7 @@ instance_groups:
   - scripts/configure-HA-hosts.sh
   - scripts/go_log_level.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -465,6 +470,7 @@ instance_groups:
   environment_scripts:
   - scripts/go_log_level.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
@@ -539,6 +545,7 @@ instance_groups:
   - scripts/configure-HA-hosts.sh
   - scripts/go_log_level.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -611,6 +618,7 @@ instance_groups:
   environment_scripts:
   - scripts/go_log_level.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/patches/fix_haproxy_fd_requirements.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
@@ -678,6 +686,7 @@ instance_groups:
   environment_scripts:
   - scripts/go_log_level.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -738,6 +747,7 @@ instance_groups:
   - scripts/configure-HA-hosts.sh
   - scripts/nginx_log_level.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/patches/fix_blobstore_send_timeout.sh
   - scripts/patches/fix_nodejs_buildpack.sh
   - scripts/forward_logfiles.sh
@@ -837,6 +847,7 @@ instance_groups:
       properties.route_registrar.routes: '[{"name": "api", "port": ((CC_PORT_PUBLIC_INSECURE)), "tls_port": ((CC_PORT_PUBLIC_TLS)), "server_cert_domain_san": "api-set", "tags": {"component": "CloudController"}, "uris": ["api.((DOMAIN))"], "registration_interval": "10s"}]'
 - name: cc-worker
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/cc_worker_disable_credhub.sh
   - scripts/patches/fix_monit_rsyslog.sh
@@ -884,6 +895,7 @@ instance_groups:
   environment_scripts:
   - scripts/configure-HA-hosts.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/chown_vcap_store.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_chown_blobstore_packages.sh
@@ -933,6 +945,7 @@ instance_groups:
       properties.route_registrar.routes: '[{"name":"blobstore", "port":8080, "tags":{"component":"blobstore"}, "uris":["blobstore.((DOMAIN))"], "registration_interval":"10s"}]'
 - name: cc-clock
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/cc_clock_wait_for_api_ready.sh
   - scripts/patches/cc_clock_disable_credhub.sh
@@ -981,6 +994,7 @@ instance_groups:
         pod-security-policy: privileged
 - name: log-cache-scheduler
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   - scripts/patches/fix_logcache_certs_forwarder.sh
@@ -1049,6 +1063,7 @@ instance_groups:
         ]
 - name: doppler
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -1240,6 +1255,7 @@ instance_groups:
   environment_scripts:
   - scripts/configure-HA-hosts.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -1307,6 +1323,7 @@ instance_groups:
   environment_scripts:
   - scripts/go_log_level.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
@@ -1364,6 +1381,7 @@ instance_groups:
   environment_scripts:
   - scripts/go_log_level.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -1420,6 +1438,7 @@ instance_groups:
   environment_scripts:
   - scripts/go_log_level.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
@@ -1477,6 +1496,7 @@ instance_groups:
   environment_scripts:
   - scripts/go_log_level.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   - scripts/patches/nfsbroker_cert_prop.sh
@@ -1775,6 +1795,7 @@ instance_groups:
   - scripts/configure-HA-hosts.sh
   - scripts/credhub_log_level.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -1833,6 +1854,7 @@ instance_groups:
       properties.route_registrar.routes: '[{"name":"credhub", "tls_port":8844, "server_cert_domain_san":"credhub-set", "tags":{"component":"credhub"}, "uris":["credhub.((DOMAIN))"], "registration_interval":"10s"}]'
 - name: autoscaler-postgres
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/chown_vcap_store.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
@@ -1870,6 +1892,7 @@ instance_groups:
   environment_scripts:
   - scripts/configure-HA-hosts.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -1911,6 +1934,7 @@ instance_groups:
       properties.route_registrar.routes: '[{"name":"autoscalerapiserver", "port":7106, "tags":{"component":"autoscalerapiserver"}, "uris":["autoscaler.((DOMAIN))"], "registration_interval":"10s"}]'
 - name: autoscaler-metrics
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
@@ -1936,6 +1960,7 @@ instance_groups:
           internal: 7103
 - name: autoscaler-scalingengine
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
@@ -1961,6 +1986,7 @@ instance_groups:
           internal: 7104
 - name: autoscaler-scheduler
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
@@ -1986,6 +2012,7 @@ instance_groups:
           internal: 7102
 - name: autoscaler-operator
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
@@ -2008,6 +2035,7 @@ instance_groups:
   environment_scripts:
   - scripts/configure-HA-hosts.sh
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   post_config_scripts:
@@ -2051,6 +2079,7 @@ instance_groups:
       properties.route_registrar.routes: '[{"name":"autoscalerservicebroker", "port":7101, "tags":{"component":"autoscalerservicebroker"}, "uris":["autoscalerservicebroker.((DOMAIN))"], "registration_interval":"10s"}]'
 - name: autoscaler-eventgenerator
   scripts:
+  - scripts/set_vcap_limits.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
@@ -3678,16 +3707,6 @@ variables:
     secret: true
     description: PEM-encoded client key
     required: true
-- name: DIEGO_VCAP_HARD_NPROC
-  options:
-    description: The hard limit of the number of processes for the vcap user on the Diego cells.
-    internal: true
-    required: false
-- name: DIEGO_VCAP_SOFT_NPROC
-  options:
-    description: The soft limit of the number of processes for the vcap user on the Diego cells.
-    internal: true
-    required: false
 - name: DISABLE_CUSTOM_BUILDPACKS
   options:
     default: false
@@ -4456,3 +4475,13 @@ variables:
     default: false
     description: Whether or not to use privileged containers for staging tasks.
     required: true
+- name: VCAP_HARD_NPROC
+  options:
+    description: The hard limit of the number of processes for the vcap user.
+    internal: true
+    required: false
+- name: VCAP_SOFT_NPROC
+  options:
+    description: The soft limit of the number of processes for the vcap user.
+    internal: true
+    required: false

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1532,6 +1532,7 @@ instance_groups:
   - scripts/configure-pz.sh
   scripts:
   - scripts/check_swapaccounting.sh
+  - scripts/set_vcap_limits.sh
   - scripts/configure-nested-net.sh
   - scripts/cleanup-garden-graph.sh
   - scripts/forward_logfiles.sh
@@ -3677,6 +3678,16 @@ variables:
     secret: true
     description: PEM-encoded client key
     required: true
+- name: DIEGO_VCAP_HARD_NPROC
+  options:
+    description: The hard limit of the number of processes for the vcap user on the Diego cells.
+    internal: true
+    required: false
+- name: DIEGO_VCAP_SOFT_NPROC
+  options:
+    description: The soft limit of the number of processes for the vcap user on the Diego cells.
+    internal: true
+    required: false
 - name: DISABLE_CUSTOM_BUILDPACKS
   options:
     default: false

--- a/container-host-files/etc/scf/config/scripts/set_vcap_limits.sh
+++ b/container-host-files/etc/scf/config/scripts/set_vcap_limits.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset
 
-if [ -z "${DIEGO_VCAP_HARD_NPROC:-}" ] && [ -z "${DIEGO_VCAP_SOFT_NPROC:-}" ]; then
+if [ -z "${VCAP_HARD_NPROC:-}" ] && [ -z "${VCAP_SOFT_NPROC:-}" ]; then
   exit 0
 fi
 
@@ -12,23 +12,23 @@ print_err() {
   echo -e "\e[31m## ${1}" >&2
 }
 
-if [ -n "${DIEGO_VCAP_HARD_NPROC:-}" ] && [ -z "${DIEGO_VCAP_SOFT_NPROC:-}" ]; then
-  print_err "DIEGO_VCAP_SOFT_NPROC must be set when DIEGO_VCAP_HARD_NPROC is set"
+if [ -n "${VCAP_HARD_NPROC:-}" ] && [ -z "${VCAP_SOFT_NPROC:-}" ]; then
+  print_err "VCAP_SOFT_NPROC must be set when VCAP_HARD_NPROC is set"
   exit 1
 fi
 
-if [ -n "${DIEGO_VCAP_SOFT_NPROC:-}" ] && [ -z "${DIEGO_VCAP_HARD_NPROC:-}" ]; then
-  print_err "DIEGO_VCAP_HARD_NPROC must be set when DIEGO_VCAP_SOFT_NPROC is set"
+if [ -n "${VCAP_SOFT_NPROC:-}" ] && [ -z "${VCAP_HARD_NPROC:-}" ]; then
+  print_err "VCAP_HARD_NPROC must be set when VCAP_SOFT_NPROC is set"
   exit 1
 fi
 
-if (( "${DIEGO_VCAP_SOFT_NPROC}" > "${DIEGO_VCAP_HARD_NPROC}" )); then
-  print_err "DIEGO_VCAP_SOFT_NPROC (${DIEGO_VCAP_SOFT_NPROC}) cannot be larger than DIEGO_VCAP_HARD_NPROC (${DIEGO_VCAP_HARD_NPROC})"
+if (( "${VCAP_SOFT_NPROC}" > "${VCAP_HARD_NPROC}" )); then
+  print_err "VCAP_SOFT_NPROC (${VCAP_SOFT_NPROC}) cannot be larger than VCAP_HARD_NPROC (${VCAP_HARD_NPROC})"
   exit 1
 fi
 
-echo "Setting hard nproc limit for vcap: ${DIEGO_VCAP_HARD_NPROC}"
-sed -i "s|\(vcap[ ]*hard[ ]*nproc[ ]*\)[0-9]*|\1${DIEGO_VCAP_HARD_NPROC}|" "${LIMITS_FILEPATH}"
+echo "Setting hard nproc limit for vcap: ${VCAP_HARD_NPROC}"
+sed -i "s|\(vcap[ ]*hard[ ]*nproc[ ]*\)[0-9]*|\1${VCAP_HARD_NPROC}|" "${LIMITS_FILEPATH}"
 
-echo "Setting soft nproc limit for vcap: ${DIEGO_VCAP_SOFT_NPROC}"
-sed -i "s|\(vcap[ ]*soft[ ]*nproc[ ]*\)[0-9]*|\1${DIEGO_VCAP_SOFT_NPROC}|" "${LIMITS_FILEPATH}"
+echo "Setting soft nproc limit for vcap: ${VCAP_SOFT_NPROC}"
+sed -i "s|\(vcap[ ]*soft[ ]*nproc[ ]*\)[0-9]*|\1${VCAP_SOFT_NPROC}|" "${LIMITS_FILEPATH}"

--- a/container-host-files/etc/scf/config/scripts/set_vcap_limits.sh
+++ b/container-host-files/etc/scf/config/scripts/set_vcap_limits.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+if [ -z "${DIEGO_VCAP_HARD_NPROC:-}" ] && [ -z "${DIEGO_VCAP_SOFT_NPROC:-}" ]; then
+  exit 0
+fi
+
+LIMITS_FILEPATH="/etc/security/limits.conf"
+
+print_err() {
+  echo -e "\e[31m## ${1}" >&2
+}
+
+if [ -n "${DIEGO_VCAP_HARD_NPROC:-}" ] && [ -z "${DIEGO_VCAP_SOFT_NPROC:-}" ]; then
+  print_err "DIEGO_VCAP_SOFT_NPROC must be set when DIEGO_VCAP_HARD_NPROC is set"
+  exit 1
+fi
+
+if [ -n "${DIEGO_VCAP_SOFT_NPROC:-}" ] && [ -z "${DIEGO_VCAP_HARD_NPROC:-}" ]; then
+  print_err "DIEGO_VCAP_HARD_NPROC must be set when DIEGO_VCAP_SOFT_NPROC is set"
+  exit 1
+fi
+
+if (( "${DIEGO_VCAP_SOFT_NPROC}" > "${DIEGO_VCAP_HARD_NPROC}" )); then
+  print_err "DIEGO_VCAP_SOFT_NPROC (${DIEGO_VCAP_SOFT_NPROC}) cannot be larger than DIEGO_VCAP_HARD_NPROC (${DIEGO_VCAP_HARD_NPROC})"
+  exit 1
+fi
+
+echo "Setting hard nproc limit for vcap: ${DIEGO_VCAP_HARD_NPROC}"
+sed -i "s|\(vcap[ ]*hard[ ]*nproc[ ]*\)[0-9]*|\1${DIEGO_VCAP_HARD_NPROC}|" "${LIMITS_FILEPATH}"
+
+echo "Setting soft nproc limit for vcap: ${DIEGO_VCAP_SOFT_NPROC}"
+sed -i "s|\(vcap[ ]*soft[ ]*nproc[ ]*\)[0-9]*|\1${DIEGO_VCAP_SOFT_NPROC}|" "${LIMITS_FILEPATH}"


### PR DESCRIPTION
## Description

This PR resolves https://github.com/SUSE/scf/issues/2100.
It enables changing the hard and soft limits for the max processes for the vcap user inside the container for each role.

They can be set by passing the `env.VCAP_HARD_NPROC` and `env.VCAP_SOFT_NPROC`  values during deployment.

## Test plan

- Deploy SCF without specifying `VCAP_HARD_NPROC` and `VCAP_SOFT_NPROC`, and:
  - Get a shell session to any container and:
    - `su vcap`
    - `ulimit -u` -> should return 4096 (the default value).
- Perform an upgrade setting only `VCAP_HARD_NPROC`:
  - The containers should error. Grab the logs of the failed container with `kubectl logs -n cf diego-cell-0 -c diego-cell -p`. The error should say `VCAP_SOFT_NPROC must be set when VCAP_HARD_NPROC is set`.
- Repeat the previous point, but setting only `VCAP_SOFT_NPROC`. A similar error should be raised.
- Perform an upgrade setting both `VCAP_HARD_NPROC` and `VCAP_SOFT_NPROC`, but set `VCAP_SOFT_NPROC` to a value higher than `VCAP_HARD_NPROC`. It should fail with `VCAP_SOFT_NPROC (<val>) cannot be larger than VCAP_HARD_NPROC (<val>)`.
- Perform an upgrade setting both `VCAP_HARD_NPROC` and `VCAP_SOFT_NPROC` to 8192, and:
  - Get a shell session to any container and:
    - `su vcap`
    - `ulimit -u` -> should return 8192 (the provided value).
    - `exit`.
    - `cat /etc/security/limits.conf`. Check that both the hard and soft limits were set accordingly.