### PR TITLE
Jenkins: Grab and dump logs to s3 on failed runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -872,10 +872,8 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
             script {
                 if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME == 'master') {
                     writeFile(file: 'build.log', text: getBuildLog())
-                    sh """ 
-                         bin/clean-jenkins-log
-                         container-host-files/opt/scf/bin/klog.sh -f ${jobBaseName()}-${BUILD_NUMBER}-scf
-                       """
+                    sh 'bin/clean-jenkins-log'
+                    sh 'container-host-files/opt/scf/bin/klog.sh -f ${jobBaseName()}-${BUILD_NUMBER}-scf'
                     withAWS(region: params.S3_REGION) {
                         withCredentials([usernamePassword(
                             credentialsId: params.S3_CREDENTIALS,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -882,7 +882,8 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
                         )]) {
                             script {
                                 def prefix = distPrefix()
-                                def subdir = "${params.S3_PREFIX}${distSubDir()}${prefix}${env.BUILD_TAG}/"
+                                prefix = prefix.substring(0, prefix.length() - 1)
+                                def subdir = "${params.S3_PREFIX}${distSubDir()}${prefix}/${env.BUILD_TAG}/"
                                 s3Upload(
                                     file: 'cleaned-build.log',
                                     bucket: "${params.S3_LOG_BUCKET}",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -882,6 +882,7 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
                         )]) {
                             script {
                                 def prefix = distPrefix()
+                                // Trimming trailing "-" from path as distPrefix() returns "PR-${CHANGE_ID}-".
                                 prefix = prefix.substring(0, prefix.length() - 1)
                                 def subdir = "${params.S3_PREFIX}${distSubDir()}${prefix}/${env.BUILD_TAG}/"
                                 s3Upload(

--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -21,7 +21,13 @@ if [ "$1" == "-f" ]; then
   FORCE=1
 fi
 
-NS=${1-scf}
+# read namespace val from args if provided
+if [ ! -z "$2" ]; then
+  NS=$2
+else
+  NS=${1-scf}
+fi 
+
 DONE="${KLOG}/${NS}/done"
 
 if [ "${FORCE}" == "1" ] ; then
@@ -72,6 +78,8 @@ if [ ! -f "${DONE}" ]; then
 
   kubectl get all --export=true --namespace "${NS}" --output=yaml > "${KLOG}/${NS}/resources.yaml"
   kubectl get events --export=true --namespace "${NS}" --output=yaml > "${KLOG}/${NS}/events.yaml"
+
+  tar -zcf klog.tar.gz "${KLOG}"
 
   touch "${DONE}"
 fi

--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -21,8 +21,7 @@ if [ "$1" == "-f" ]; then
   FORCE=1
 fi
 
-NS=${1-scf} 
-
+NS=${1-scf}
 DONE="${KLOG}/${NS}/done"
 
 if [ "${FORCE}" == "1" ] ; then

--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -21,12 +21,7 @@ if [ "$1" == "-f" ]; then
   FORCE=1
 fi
 
-# read namespace val from args if provided
-if [ ! -z "$2" ]; then
-  NS=$2
-else
-  NS=${1-scf}
-fi 
+NS=${1-scf} 
 
 DONE="${KLOG}/${NS}/done"
 


### PR DESCRIPTION
## Description

- Modified `Jenkinsfile` to execute the `klog.sh` script
- Modified `s3` bucket path to accommodate `klogs`
- Modified `klog.sh` to support args from Jenkins

## Test plan

- Introduce failures in tests and trigger build
- Check whether `klog.sh` was triggered even if the build failed
- Verify if both build logs and klogs were dumped in correct s3 buckets

e.g: `https://s3.console.aws.amazon.com/s3/buckets/cap-jenkins-log/prs/PR-2170-jenkins-scf-PR-2170-6/`
