### PR TITLE
Brain test runner - stream test output when --verbose is set

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -69,7 +69,6 @@ done
 
 CONFIG=$(mktemp)
 RELEASE="$(helm list --namespace "${NAMESPACE}" --short --max 1)"
-DOMAIN="$(helm get values "${RELEASE}" --all | ruby -ryaml -e 'puts (YAML.load(STDIN.read))["env"]["DOMAIN"]')"
 ruby "${GIT_ROOT}/bin/kube_overrides.rb" "${RELEASE}" "${TEST_FILE}" "$@" > "${CONFIG}"
 
 remove_test_config () { rm "${CONFIG}" ; }
@@ -100,7 +99,7 @@ stampy "${METRICS}" "$0" "make-tests::${POD_NAME}::log" end
 # First show the logs accumulated so far, then stream further logs in
 # a way which terminates when the pod (= testsuite) terminates.
 kubectl logs   --namespace "${NAMESPACE}" "${POD_NAME}"
-kubectl attach --namespace "${NAMESPACE}" "${POD_NAME}"
+kubectl attach --namespace "${NAMESPACE}" "${POD_NAME}" -c "${POD_NAME}"
 
 stampy "${METRICS}" "$0" "make-tests::${POD_NAME}::log" end
 stampy "${METRICS}" "$0" "make-tests::${POD_NAME}" end
@@ -108,4 +107,4 @@ stampy "${METRICS}" "$0" "make-tests::${POD_NAME}" end
 while [ -z "$(kubectl get pod --namespace "${NAMESPACE}" "${POD_NAME}" -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}')" ]; do
     sleep 1
 done
-exit $(kubectl get pod --namespace "${NAMESPACE}" "${POD_NAME}" -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}')
+exit "$(kubectl get pod --namespace "${NAMESPACE}" "${POD_NAME}" -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}')"

--- a/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
@@ -48,9 +48,13 @@ for i in "${ASSETS}/plugins/"*; do
 done
 shopt -u nullglob
 
-PARAM="--timeout 600 --verbose"
+PARAM="--timeout 600"
 
-if [ -n "${IN_ORDER}" ]; then
+if [[ "${VERBOSE}" == "true" || "${VERBOSE}" == "1" ]]; then
+    PARAM="${PARAM} --verbose"
+fi
+
+if [[ "${IN_ORDER}" == "true" || "${IN_ORDER}" == "1" ]]; then
     PARAM="${PARAM} --in-order"
 fi
 


### PR DESCRIPTION
## Description

- Update the submodule testbrain.
- Remove the default `--verbose` from the brain run template.
- Add a `VERBOSE` env var to handle verbosity.
- Small fixes to `make/tests` script.

## Test plan

- Run a specific test without passing `env.VERBOSE`:
    `make/tests acceptance-tests-brain env.INCLUDE="cflogin"`
    - It should not print the stdout and stderr from the test, but should show which test was run and if it passed or not.
- Run a specific test passing `env.VERBOSE`:
    `make/tests acceptance-tests-brain env.INCLUDE="cflogin" env.VERBOSE="true"`
    - It should stream the stdout and stderr from the test.
- Run a specific test WITHOUT passing `env.VERBOSE` again, but before, make a change to the test so it fails.
    - It should dump the output at the end of the test run.