### PR TITLE
Update testbrain to allow skipping tests and skip credhub test

### DIFF
--- a/src/scf-release/packages/kubectl/packaging
+++ b/src/scf-release/packages/kubectl/packaging
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=v1.9.6
+VERSION=v1.13.2
 
 echo Retrieving kubetcl ${VERSION}
 

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
@@ -174,3 +174,19 @@ def cf_curl(*args)
     output = capture('cf', 'curl', *args)
     JSON.parse output
 end
+
+def statefulset_ready(namespace, statefulset, sleep_duration=5)
+    begin
+        output = capture("kubectl get statefulset --namespace #{namespace} #{statefulset} --no-headers")
+        return false if output.empty?
+        _, ready, _ = output.split # Columns: NAME, READY, AGE.
+        return true if /([1-9]|[1-9][0-9]|[1-9][0-9][0-9])\/\1/.match(ready)
+        return false
+    rescue RuntimeError
+        return false
+    end
+end
+
+def exit_skipping_test()
+    Process.exit 99
+end


### PR DESCRIPTION
## Description

Updates the `testbrain` and skips credhub test if credhub is not enabled. Also, updates the kubectl version.

## Test plan

Run credhub brain test without having it enabled. It should be skipped.