### PR TITLE
Replace combination of build-time symlinks and runtime moves with build time moves.

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -9,8 +9,9 @@ set -o errexit -o nounset
 
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
-export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+227.g89b5d91"
+export FISSILE_FLAVOR="checks"
+export FISSILE_VERSION="7.0.0+242.gd0301ba"
+
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"
 export KUBECTL_VERSION="1.9.6"

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -9,8 +9,8 @@ set -o errexit -o nounset
 
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
-export FISSILE_FLAVOR="checks"
-export FISSILE_VERSION="7.0.0+243.g6a73892"
+export FISSILE_FLAVOR="develop"
+export FISSILE_VERSION="7.0.0+244.gdce85469"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="checks"
-export FISSILE_VERSION="7.0.0+242.gd0301ba"
+export FISSILE_VERSION="7.0.0+243.g6a73892"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"


### PR DESCRIPTION
Ref https://trello.com/c/H2AXtiHz/974-packages-mv-should-happen-at-build-time

Fissile PR brought in here: https://github.com/cloudfoundry-incubator/fissile/pull/477