### PR TITLE
Fix for credhub brain test being skipped on CI

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
@@ -62,7 +62,7 @@ def run(*args)
     end
 end
 
-# Run the given command line, and return the stadandard output.
+# Run the given command line, and return the standard output.
 # If errexit is set, an error is raised on failure.
 def capture(*args)
     _print_command(*args)

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
@@ -190,8 +190,6 @@ def statefulset_ready(namespace, statefulset)
       '--namespace', namespace,
       statefulset,
     )
-    puts "status: #{status.success?}"
-    puts "stdout: #{stdout}"
     return status.success? && stdout == '"true"'
 end
 


### PR DESCRIPTION
## Description

Credhub brain test was being skipped on CI due to output discrepancy from kubectl versions used on Vagrant for development and on CI.

The fix uses kubectl `--output go-template=` to accomplish portability.

## Test plan

Credhub brain test should not be skipped on CI.