### PR TITLE
Fix the IP address cf-dev.io A record resolves to

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ a working system.
       `wicked ifreload all` and wait for wicked to apply the changes.
     - `VAGRANT_DHCP`: Set this to any value when using virtual networking (as opposed to bridged networking)
       in order to let your VM receive an IP via DHCP in the virtual network. If this environment variable is
-      unset, the VM will instead obtain the IP 192.168.77.77.
+      unset, the VM will instead obtain the IP cf-dev.io points to.
 
 
 **Note:** If every role does not go green in `pod-status --watch` refer to [Troubleshooting](#troubleshooting)
@@ -241,10 +241,10 @@ The way the vagrant box is created is by making a network with a static IP on th
 This means that you cannot connect to it from some other box.
 
 ```bash
-# Attach to the endpoint (self-signed certs in dev mode requires skipping validation)
-# cf-dev.io simply resolves to the static IP 192.168.77.77 that vagrant provisions
-# This DNS resolution may fail on certain DNS providers that block resolution to 192.168.*
-# Unless you've changed the default credentials in the configuration it's admin/changeme
+# Attach to the endpoint (self-signed certs in dev mode requires skipping validation).
+# cf-dev.io resolves to the static IP that vagrant provisions.
+# This DNS resolution may fail on certain DNS providers that block resolution to 192.168.0.0/16.
+# Unless you've changed the default credentials in the configuration, it is admin/changeme.
 cf api --skip-ssl-validation https://api.cf-dev.io
 cf login -u admin -p changeme
 ```
@@ -446,7 +446,7 @@ and execute the following commands:
 make smoke
 make brain
 make scaler-smoke
-make cats 
+make cats
 ```
 
 #### How do I run a subset of SCF acceptance tests?
@@ -510,7 +510,7 @@ You can access any URL or endpoint that references this address from your host.
 ### How do I connect to the Cloud Foundry database?
 
 1. Use the role manifest to expose the port for the mysql proxy role
-2. The MySQL instance is exposed at `192.168.77.77:3306`.
+2. The MySQL instance is exposed at `cf-dev.io:3306`.
 3. The default username is: `root`.
 4. You can find the password in the kubernetes secret.
 
@@ -608,7 +608,7 @@ __Note:__ Because this process involves downloading and compiling release(s), it
 
 1. In the manifest, update the version and SHA of the release(s)
 
-1. Compare the BOSH releases 
+1. Compare the BOSH releases
 
 
     ```bash
@@ -775,16 +775,17 @@ docker run -d --name nfs \
 
 ### Allow access to the NFS server
 
-- Security group JSON file (nfs-sg.json)
+- Security group JSON file (nfs-sg.json). Replace `<destination_ip>` by the
+  address returned from the command `getent hosts "cf-dev.io" | awk 'NR=1{print $1}'`:
 ```json
 [
     {
-        "destination": "192.168.77.77",
+        "destination": "<destination_ip>",
         "protocol": "tcp",
         "ports": "111,662,875,892,2049,32803"
     },
     {
-        "destination": "192.168.77.77",
+        "destination": "<destination_ip>",
         "protocol": "udp",
         "ports": "111,662,875,892,2049,32769"
     }
@@ -816,7 +817,8 @@ cf push pora --no-start
 cf enable-service-access persi-nfs
 
 # Create a service and bind it
-cf create-service persi-nfs Existing myVolume -c '{"share":"192.168.77.77/exports/foo"}'
+EXTERNAL_IP=$(getent hosts "cf-dev.io" | awk 'NR=1{print $1}')
+cf create-service persi-nfs Existing myVolume -c "{\"share\":\"${EXTERNAL_IP}/exports/foo\"}"
 cf bind-service pora myVolume -c '{"uid":"1000","gid":"1000"}'
 
 # Start the app

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ This means that you cannot connect to it from some other box.
 # Attach to the endpoint (self-signed certs in dev mode requires skipping validation).
 # cf-dev.io resolves to the static IP that vagrant provisions.
 # This DNS resolution may fail on certain DNS providers that block resolution to 192.168.0.0/16.
-# Unless you've changed the default credentials in the configuration, it is admin/changeme.
+# Unless you changed the default credentials in the configuration, it is admin/changeme.
 cf api --skip-ssl-validation https://api.cf-dev.io
 cf login -u admin -p changeme
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+require 'resolv'
+
 def base_net_config
   base_config = {
     use_dhcp_assigned_default_route: true
@@ -9,10 +11,10 @@ def base_net_config
     if ENV.include? "VAGRANT_DHCP"
       # Use dhcp if VAGRANT_DHCP is set. This only applies to NAT networking, as
       # bridged networking uses type: bridged (even though the virtual interface still
-      # gets its IP from dhcp). If not using dhcp, the VM will use the 192.168.77.77 IP.
+      # gets its IP from dhcp). If not using dhcp, the VM will use the IP cf-dev.io points to.
       base_config[:type] = "dhcp"
     else
-      base_config[:ip] = "192.168.77.77"
+      base_config[:ip] = Resolv.getaddress "cf-dev.io"
     end
   end
   base_config

--- a/make/deploy-mysql
+++ b/make/deploy-mysql
@@ -15,10 +15,6 @@ USB_PLUGIN_LOCATION="https://github.com/SUSE/cf-usb-plugin/releases/download/1.0
 SUSE_REPO="https://kubernetes-charts.suse.com"
 MYSQL_CHART="suse/cf-usb-sidecar-mysql"
 
-# For vagrant the external IP is a fixed value.
-# dig cf-dev.io (We need IP for the ASG later)
-DB_EXTERNAL_IP=192.168.77.77
-
 NFS_SCLASS="nfspersist"
 
 PASS="$(kubectl --namespace "${NAMESPACE}" get secrets secrets -o jsonpath='{.data.cluster-admin-password}' | base64 -d)"
@@ -37,7 +33,7 @@ cf auth admin "${PASS}"
 $(dirname $0)/nfs-storageclass
 $(dirname $0)/usb-plugin
 $(dirname $0)/helm-suse-repository
-$(dirname $0)/asg                  k8s-mysql-sidecar-net "${DB_EXTERNAL_IP}/32" "5432,30306"
+$(dirname $0)/asg                  k8s-mysql-sidecar-net "${VAGRANT_EXTERNAL_IP}/32" "5432,30306"
 
 if ! helm search  "${MYSQL_CHART}" ; then
     prtinf "%sThe required sidecar chart ${MYSQL_CHART} is missing%s" "\033\[0;31;1m" "\033\[0m"
@@ -94,7 +90,7 @@ COMMON_SIDECAR_PARAMS=(
 MYSQL_SIDECAR_PARAMS=(
   --set "env.SERVICE_TYPE=mysql"
   --set "env.SERVICE_LOCATION=http://cf-usb-sidecar-mysql.mysql-sidecar:8081"
-  --set "env.SERVICE_MYSQL_HOST=${DB_EXTERNAL_IP}"
+  --set "env.SERVICE_MYSQL_HOST=${VAGRANT_EXTERNAL_IP}"
   --set "env.SERVICE_MYSQL_PORT=30306"
   --set "env.SERVICE_MYSQL_USER=root"
   --set "env.SERVICE_MYSQL_PASS=password"

--- a/packer/http/docker.conf
+++ b/packer/http/docker.conf
@@ -1,3 +1,3 @@
 # This file is uploaded via packer, but only after the first stage setup is done
-# (because otherwise 192.168.77.77 isn't a valid address to listen on)
+# (because otherwise the IP address cf-dev.io points to isn't a valid address to listen on).
 DOCKER_OPTS="--insecure-registry=0.0.0.0/0 --host=unix:///var/run/docker.sock --storage-driver=overlay2 --default-ulimit nofile=100000"

--- a/packer/scripts/create-kube-certs.sh
+++ b/packer/scripts/create-kube-certs.sh
@@ -4,9 +4,11 @@ set -o errexit -o xtrace
 
 export PATH="${PATH}:/usr/local/bin/"
 
+CF_DEV_IO_IP=$(getent hosts "cf-dev.io" | awk 'NR=1{print $1}')
+
 mkdir -p /run/certstrap
 certstrap --depot-path "/run/certstrap" init --common-name "CA.kube.vagrant" --passphrase "" --years 10
-certstrap --depot-path "/run/certstrap" request-cert --common-name "apiserver" --passphrase "" --ip 127.0.0.1,192.168.77.77,172.17.0.1,10.254.0.1 --domain kubernetes.default.svc,kubernetes.default,kubernetes,localhost
+certstrap --depot-path "/run/certstrap" request-cert --common-name "apiserver" --passphrase "" --ip 127.0.0.1,${CF_DEV_IO_IP},172.17.0.1,10.254.0.1 --domain kubernetes.default.svc,kubernetes.default,kubernetes,localhost
 certstrap --depot-path "/run/certstrap" sign "apiserver" --CA "CA.kube.vagrant" --passphrase ""
 certstrap --depot-path "/run/certstrap" request-cert --common-name "kubelet" --passphrase "" --ip 127.0.0.1
 certstrap --depot-path "/run/certstrap" sign "kubelet" --CA "CA.kube.vagrant" --passphrase ""

--- a/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_mount.json
+++ b/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_mount.json
@@ -1,3 +1,3 @@
 {
-    "share" : "192.168.47.109/exports/foo"
+    "share" : "<EXTERNAL_IP>/exports/foo"
 }

--- a/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_mount.json
+++ b/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_mount.json
@@ -1,3 +1,3 @@
 {
-    "share" : "192.168.77.77/exports/foo"
+    "share" : "192.168.47.109/exports/foo"
 }

--- a/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_secgroup.json
+++ b/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_secgroup.json
@@ -1,11 +1,11 @@
 [
     {
-        "destination": "192.168.77.77",
+        "destination": "192.168.47.109",
         "protocol": "tcp",
         "ports": "111,662,875,892,2049,32803"
     },
     {
-        "destination": "192.168.77.77",
+        "destination": "192.168.47.109",
         "protocol": "udp",
         "ports": "111,662,875,892,2049,32769"
     }

--- a/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_secgroup.json
+++ b/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_secgroup.json
@@ -1,11 +1,11 @@
 [
     {
-        "destination": "192.168.47.109",
+        "destination": "<EXTERNAL_IP>",
         "protocol": "tcp",
         "ports": "111,662,875,892,2049,32803"
     },
     {
-        "destination": "192.168.47.109",
+        "destination": "<EXTERNAL_IP>",
         "protocol": "udp",
         "ports": "111,662,875,892,2049,32769"
     }


### PR DESCRIPTION
## Description

The A record for cf-dev.io changed from 192.168.77.77 to 192.168.47.109. This PR minimizes the impact of subsequent changes to the records of cf-dev.io.

## Test plan

Vagrant should work again with cf-dev.io without any problems, as well as the updates to docs should work as expected.