### PR TITLE
Restart Docker daemon if it is not active during Vagrantfile provision

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -145,6 +145,11 @@ Vagrant.configure(2) do |config|
       fi
     fi
 
+    # Make sure Docker is running before running any scripts that rely on it.
+    if [ "$(systemctl is-active docker.service)" != active ]; then
+      systemctl restart docker.service
+    fi
+
     cd "${HOME}/scf"
     bash ${HOME}/scf/bin/common/install_tools.sh
     direnv exec ${HOME}/scf/bin/dev/install_tools.sh


### PR DESCRIPTION
## Description

During the Vagrant machine provisioning, if Docker is not active, restart it.

Resolves #2213 

## Test plan

- No expected behaviour change under normal circumstances.
- Should fix the issue seen on #2213.