### PR TITLE
Brains minibroker - remove confusing output

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -91,7 +91,7 @@ class MiniBrokerTest
                 end
             end
 
-            run "kubectl get namespace #{minibroker_namespace} || kubectl create namespace #{minibroker_namespace}"
+            run "kubectl get namespace #{minibroker_namespace} 2> /dev/null || kubectl create namespace #{minibroker_namespace}"
             run "helm init --client-only"
             run(*%W(helm upgrade #{helm_release} minibroker
                 --install


### PR DESCRIPTION
## Description

If the namespace doesn't exist, it prints an error before creating a new namespace. It is not the desired behavior.

## Test plan

`Error from server (NotFound): namespaces "minibroker-..." not found` should not be shown.