### PR TITLE
Brains - minibroker nightly fails

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
@@ -14,6 +14,7 @@ MiniBrokerTest.new('redis', '6379').run_test do |tester|
 
     run "cf push #{CF_APP} --no-start -p #{resource_path('cf-redis-example-app')}"
     run "cf bind-service #{CF_APP} #{tester.service_instance}"
+    run "cf restage #{CF_APP}"
     run "cf start #{CF_APP}"
     app_guid = capture("cf app #{CF_APP} --guid")
     puts "# app GUID: #{app_guid}"

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
@@ -35,7 +35,7 @@ MiniBrokerTest.new('redis', '6379').run_test do |tester|
     run "echo '#{domain_info.to_json}' | jq -C ."
     app_domain = domain_info['entity']['name']
 
-    run "curl -v -X PUT http://#{app_host}.#{app_domain}/hello -d data=success"
-    output = capture("curl -v http://#{app_host}.#{app_domain}/hello")
+    run "curl -L -v -X PUT http://#{app_host}.#{app_domain}/hello -d data=success"
+    output = capture("curl -L -v http://#{app_host}.#{app_domain}/hello")
     fail "Incorrect output: got #{output.inspect}" unless output == 'success'
 end

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
@@ -12,29 +12,47 @@ MiniBrokerTest.new('redis', '6379').run_test do |tester|
         end
     end
 
+    # Create an app bound to the service under test, and start it.
     run "cf push #{CF_APP} --no-start -p #{resource_path('cf-redis-example-app')}"
     run "cf bind-service #{CF_APP} #{tester.service_instance}"
-    run "cf restage #{CF_APP}"
     run "cf start #{CF_APP}"
+
+    # Wait for the app to be staged and started.
     app_guid = capture("cf app #{CF_APP} --guid")
     puts "# app GUID: #{app_guid}"
+    STDOUT.flush
     run_with_retry 60, 10 do
         app_info = JSON.load capture("cf curl '/v2/apps/#{app_guid}'")
+        puts "# app info: #{app_info}"
+        STDOUT.flush
         break if app_info['entity']['state'] == 'STARTED'
     end
 
+    # Determine the endpoint the app will be listening on for requests.
     route_mappings = JSON.load capture("cf curl '/v2/apps/#{app_guid}/route_mappings'")
     run "echo '#{route_mappings.to_json}' | jq -C ."
+    STDOUT.flush
+
     route_url = route_mappings['resources'].map{ |resource| resource['entity']['route_url'] }.reject(&:nil?).reject(&:empty?).first
     puts "# Route URL: #{route_url}"
+    STDOUT.flush
+
     route_info = JSON.load capture("cf curl #{route_url}")
     run "echo '#{route_info.to_json}' | jq -C ."
+    STDOUT.flush
+
     app_host = route_info['entity']['host']
     domain_url = route_info['entity']['domain_url']
+
     domain_info = JSON.load capture("cf curl #{domain_url}")
     run "echo '#{domain_info.to_json}' | jq -C ."
+    STDOUT.flush
+
     app_domain = domain_info['entity']['name']
 
+    # Check with the app at its endpoint that it is able to use the
+    # service it was bound to. By setting and then retrieving a data
+    # point.
     run "curl -L -v -X PUT http://#{app_host}.#{app_domain}/hello -d data=success"
     output = capture("curl -L -v http://#{app_host}.#{app_domain}/hello")
     fail "Incorrect output: got #{output.inspect}" unless output == 'success'

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
@@ -51,12 +51,12 @@ tester.run_test do |tester|
     app_domain = domain_info['entity']['name']
     app_url = "http://#{app_host}.#{app_domain}"
 
-    run "curl -v --fail #{app_url}/"
-    run "curl -v --fail -X POST #{app_url}/todos --data text='hello'"
-    run "curl #{app_url}/todos"
-    todos = JSON.load capture("curl #{app_url}/todos")
+    run "curl -L -v --fail #{app_url}/"
+    run "curl -L -v --fail -X POST #{app_url}/todos --data text='hello'"
+    run "curl -L #{app_url}/todos"
+    todos = JSON.load capture("curl -L #{app_url}/todos")
     run "echo '#{todos.to_json}' | jq -C ."
     todo_id = todos.first['id']
-    run "curl -v --fail #{app_url}/todos/#{todo_id}"
-    run "curl -v --fail -X DELETE #{app_url}/todos/#{todo_id}"
+    run "curl -L -v --fail #{app_url}/todos/#{todo_id}"
+    run "curl -L -v --fail -X DELETE #{app_url}/todos/#{todo_id}"
 end

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
@@ -22,6 +22,7 @@ tester.run_test do |tester|
         end
     end
 
+    # Create an app bound to the service under test, and start it.
     run 'cf', 'push', CF_APP,
         '--no-start',
         '-p', resource_path('rails-example'),
@@ -29,28 +30,43 @@ tester.run_test do |tester|
         '-m', '256M',
         '-c', 'bundle exec rake db:migrate && bundle exec rails s -p $PORT'
     run "cf bind-service #{CF_APP} #{tester.service_instance}"
-    run "cf restage #{CF_APP}"
     run "cf start #{CF_APP}"
+
+    # Wait for the app to be staged and started.
     app_guid = capture("cf app #{CF_APP} --guid")
     puts "# app GUID: #{app_guid}"
+    STDOUT.flush
     run_with_retry 60, 10 do
         app_info = JSON.load capture("cf curl '/v2/apps/#{app_guid}'")
+        puts "# app info: #{app_info}"
+        STDOUT.flush
         break if app_info['entity']['state'] == 'STARTED'
     end
 
+    # Determine the endpoint the app will be listening on for requests.
     route_mappings = JSON.load capture("cf curl '/v2/apps/#{app_guid}/route_mappings'")
     run "echo '#{route_mappings.to_json}' | jq -C ."
+    STDOUT.flush
+
     route_url = route_mappings['resources'].map{ |resource| resource['entity']['route_url'] }.reject(&:nil?).reject(&:empty?).first
     puts "# Route URL: #{route_url}"
+    STDOUT.flush
+
     route_info = JSON.load capture("cf curl #{route_url}")
     run "echo '#{route_info.to_json}' | jq -C ."
+    STDOUT.flush
+
     app_host = route_info['entity']['host']
     domain_url = route_info['entity']['domain_url']
     domain_info = JSON.load capture("cf curl #{domain_url}")
     run "echo '#{domain_info.to_json}' | jq -C ."
+    STDOUT.flush
+
     app_domain = domain_info['entity']['name']
     app_url = "http://#{app_host}.#{app_domain}"
 
+    # Check with the app at its endpoint that it is able to use the
+    # service it was bound to.
     run "curl -L -v --fail #{app_url}/"
     run "curl -L -v --fail -X POST #{app_url}/todos --data text='hello'"
     run "curl -L #{app_url}/todos"

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
@@ -29,6 +29,7 @@ tester.run_test do |tester|
         '-m', '256M',
         '-c', 'bundle exec rake db:migrate && bundle exec rails s -p $PORT'
     run "cf bind-service #{CF_APP} #{tester.service_instance}"
+    run "cf restage #{CF_APP}"
     run "cf start #{CF_APP}"
     app_guid = capture("cf app #{CF_APP} --guid")
     puts "# app GUID: #{app_guid}"

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
@@ -51,12 +51,12 @@ tester.run_test do |tester|
     app_domain = domain_info['entity']['name']
     app_url = "http://#{app_host}.#{app_domain}"
 
-    run "curl -v --fail #{app_url}/"
-    run "curl -v --fail -X POST #{app_url}/todos --data text='hello'"
-    run "curl #{app_url}/todos"
-    todos = JSON.load capture("curl #{app_url}/todos")
+    run "curl -L -v --fail #{app_url}/"
+    run "curl -L -v --fail -X POST #{app_url}/todos --data text='hello'"
+    run "curl -L #{app_url}/todos"
+    todos = JSON.load capture("curl -L #{app_url}/todos")
     run "echo '#{todos.to_json}' | jq -C ."
     todo_id = todos.first['id']
-    run "curl -v --fail #{app_url}/todos/#{todo_id}"
-    run "curl -v --fail -X DELETE #{app_url}/todos/#{todo_id}"
+    run "curl -L -v --fail #{app_url}/todos/#{todo_id}"
+    run "curl -L -v --fail -X DELETE #{app_url}/todos/#{todo_id}"
 end

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
@@ -22,6 +22,7 @@ tester.run_test do |tester|
         end
     end
 
+    # Create an app bound to the service under test, and start it.
     run 'cf', 'push', CF_APP,
         '--no-start',
         '-p', resource_path('rails-example'),
@@ -29,28 +30,43 @@ tester.run_test do |tester|
         '-m', '256M',
         '-c', 'bundle exec rake db:migrate && bundle exec rails s -p $PORT'
     run "cf bind-service #{CF_APP} #{tester.service_instance}"
-    run "cf restage #{CF_APP}"
     run "cf start #{CF_APP}"
+
+    # Wait for the app to be staged and started.
     app_guid = capture("cf app #{CF_APP} --guid")
     puts "# app GUID: #{app_guid}"
+    STDOUT.flush
     run_with_retry 60, 10 do
         app_info = JSON.load capture("cf curl '/v2/apps/#{app_guid}'")
+        puts "# app info: #{app_info}"
+        STDOUT.flush
         break if app_info['entity']['state'] == 'STARTED'
     end
 
+    # Determine the endpoint the app will be listening on for requests.
     route_mappings = JSON.load capture("cf curl '/v2/apps/#{app_guid}/route_mappings'")
     run "echo '#{route_mappings.to_json}' | jq -C ."
+    STDOUT.flush
+
     route_url = route_mappings['resources'].map{ |resource| resource['entity']['route_url'] }.reject(&:nil?).reject(&:empty?).first
     puts "# Route URL: #{route_url}"
+    STDOUT.flush
+
     route_info = JSON.load capture("cf curl #{route_url}")
     run "echo '#{route_info.to_json}' | jq -C ."
+    STDOUT.flush
+
     app_host = route_info['entity']['host']
     domain_url = route_info['entity']['domain_url']
     domain_info = JSON.load capture("cf curl #{domain_url}")
     run "echo '#{domain_info.to_json}' | jq -C ."
+    STDOUT.flush
+
     app_domain = domain_info['entity']['name']
     app_url = "http://#{app_host}.#{app_domain}"
 
+    # Check with the app at its endpoint that it is able to use the
+    # service it was bound to.
     run "curl -L -v --fail #{app_url}/"
     run "curl -L -v --fail -X POST #{app_url}/todos --data text='hello'"
     run "curl -L #{app_url}/todos"

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
@@ -29,6 +29,7 @@ tester.run_test do |tester|
         '-m', '256M',
         '-c', 'bundle exec rake db:migrate && bundle exec rails s -p $PORT'
     run "cf bind-service #{CF_APP} #{tester.service_instance}"
+    run "cf restage #{CF_APP}"
     run "cf start #{CF_APP}"
     app_guid = capture("cf app #{CF_APP} --guid")
     puts "# app GUID: #{app_guid}"

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
@@ -22,6 +22,7 @@ tester.run_test do |tester|
 
     run "cf push #{CF_APP} --no-start -p #{resource_path('python-mongodb-blog')}"
     run "cf bind-service #{CF_APP} #{tester.service_instance}"
+    run "cf restage #{CF_APP}"
     run "cf start #{CF_APP}"
     app_guid = capture("cf app #{CF_APP} --guid")
     puts "# app GUID: #{app_guid}"

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
@@ -20,31 +20,48 @@ tester.run_test do |tester|
         end
     end
 
+    # Create an app bound to the service under test, and start it.
     run "cf push #{CF_APP} --no-start -p #{resource_path('python-mongodb-blog')}"
     run "cf bind-service #{CF_APP} #{tester.service_instance}"
-    run "cf restage #{CF_APP}"
     run "cf start #{CF_APP}"
+
+    # Wait for the app to be staged and started.
     app_guid = capture("cf app #{CF_APP} --guid")
     puts "# app GUID: #{app_guid}"
+    STDOUT.flush
     loop do
         app_info = JSON.load capture("cf curl '/v2/apps/#{app_guid}'")
+        puts "# app info: #{app_info}"
+        STDOUT.flush
         break if app_info['entity']['state'] == 'STARTED'
         sleep 10
     end
 
+    # Determine the endpoint the app will be listening on for requests.
     route_mappings = JSON.load capture("cf curl '/v2/apps/#{app_guid}/route_mappings'")
     run "echo '#{route_mappings.to_json}' | jq -C ."
+    STDOUT.flush
+
     route_url = route_mappings['resources'].map{ |resource| resource['entity']['route_url'] }.reject(&:nil?).reject(&:empty?).first
     puts "# Route URL: #{route_url}"
+    STDOUT.flush
+
     route_info = JSON.load capture("cf curl #{route_url}")
     run "echo '#{route_info.to_json}' | jq -C ."
+    STDOUT.flush
+
     app_host = route_info['entity']['host']
     domain_url = route_info['entity']['domain_url']
+
     domain_info = JSON.load capture("cf curl #{domain_url}")
     run "echo '#{domain_info.to_json}' | jq -C ."
+    STDOUT.flush
+
     app_domain = domain_info['entity']['name']
     app_url = "http://#{app_host}.#{app_domain}"
 
+    # Check with the app at its endpoint that it is able to use the
+    # service it was bound to.
     title = random_suffix('desired-title')
     body = random_suffix('desired-body')
     run "cf env #{CF_APP}"

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
@@ -48,7 +48,7 @@ tester.run_test do |tester|
     title = random_suffix('desired-title')
     body = random_suffix('desired-body')
     run "cf env #{CF_APP}"
-    run "curl -v --fail -X POST #{app_url}/post/new --data 'post[title]=#{title}' --data 'post[body]=#{body}'"
-    run "curl #{app_url} | grep -F '#{title}'"
-    run "curl #{app_url} | grep -F '#{body}'"
+    run "curl -L -v --fail -X POST #{app_url}/post/new --data 'post[title]=#{title}' --data 'post[body]=#{body}'"
+    run "curl -L #{app_url} | grep -F '#{title}'"
+    run "curl -L #{app_url} | grep -F '#{body}'"
 end

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
@@ -65,7 +65,7 @@ tester.run_test do |tester|
     title = random_suffix('desired-title')
     body = random_suffix('desired-body')
     run "cf env #{CF_APP}"
-    run "curl -L -v --fail -X POST #{app_url}/post/new --data 'post[title]=#{title}' --data 'post[body]=#{body}'"
+    _ = run_with_status "curl -L -v --fail -X POST #{app_url}/post/new --data 'post[title]=#{title}' --data 'post[body]=#{body}'"
     run "curl -L #{app_url} | grep -F '#{title}'"
     run "curl -L #{app_url} | grep -F '#{body}'"
 end

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -135,7 +135,7 @@ class MiniBrokerTest
             run "jq -C . #{tmpdir}/service-params.json"
             started_service_creation = Process.clock_gettime(Process::CLOCK_MONOTONIC)
             run "cf create-service #{service_type} #{service_plan_id} #{service_instance} -c #{tmpdir}/service-params.json"
-            status = wait_for_async_service_operation(service_instance, 10)
+            status = wait_for_async_service_operation(service_instance, 30)
             unless status[:success]
                 failed_service_creation = Process.clock_gettime(Process::CLOCK_MONOTONIC)
                 elapsed = failed_service_creation - started_service_creation


### PR DESCRIPTION
## Description

Minibroker tests are failing on nightly CI runs.
https://ci.howdoi.website/teams/main/pipelines/Nightly-cap-qa-deployment-NoCats-develop/jobs/Nightly-cap-qa-deployment-NoCats-develop-SA/builds/2

This PR attempts to solve the issues by:
- Raising the number of retries before timing out on the wait on service creation.
- Performing a `cf restage` after binding the service to the app.
- Adding `-L` to follow any redirection the `curl` assertions shall perform.

## Test plan

Jenkins CI should pass, as well as the Concourse CI that performs the nightly builds.