### PR TITLE
brains/010-insecure-registry: use TCP domain for TCP route

### DIFF
--- a/make/run
+++ b/make/run
@@ -46,7 +46,7 @@ kubectl get storageclass | grep --silent '(default)' 2>/dev/null || {
 }
 
 : "${TCP_DOMAIN:=tcp.${DOMAIN}}"
-: "${INSECURE_DOCKER_REGISTRIES:=\"insecure-registry.${DOMAIN}:20005\"}"
+: "${INSECURE_DOCKER_REGISTRIES:=\"insecure-registry.${TCP_DOMAIN}:20005\"}"
 
 helm_args=(
     --name "${NAMESPACE}"

--- a/make/upgrade
+++ b/make/upgrade
@@ -24,7 +24,7 @@ stampy "${GIT_ROOT}/scf_metrics.csv" "$0" make-run::upgrade start
 : "${DOMAIN:=cf-dev.io}"
 : "${TCP_DOMAIN:=tcp.${DOMAIN}}"
 : "${UAA_HOST:=uaa.${DOMAIN}}"
-: "${INSECURE_DOCKER_REGISTRIES:=\"insecure-registry.${DOMAIN}:20005\"}"
+: "${INSECURE_DOCKER_REGISTRIES:=\"insecure-registry.${TCP_DOMAIN}:20005\"}"
 
 UAA_CA_CERT="$(get_secret "${UAA_NAMESPACE}" "uaa" "INTERNAL_CA_CERT")"
 

--- a/src/scf-release/src/acceptance-tests-brain/test-resources/docker-uploader/manifest.yml
+++ b/src/scf-release/src/acceptance-tests-brain/test-resources/docker-uploader/manifest.yml
@@ -21,7 +21,7 @@ applications:
     mkdir certs
     &&
     openssl req -newkey rsa:4096 -nodes -sha256  -x509 -days 365
-    -subj /CN=insecure-registry.((domain))
+    -subj /CN=insecure-registry.((tcp-domain))
     -keyout certs/domain.key -out certs/domain.crt
     &&
     ./bin/registry serve ./config.yml

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/010_insecure_registry_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/010_insecure_registry_test.rb
@@ -65,7 +65,7 @@ at_exit do
         run "cf delete -f uploader"
     end
 end
-run "cf push -f manifest.yml --var domain=#{ENV['CF_DOMAIN']} --var tcp-domain=#{CF_TCP_DOMAIN}",
+run "cf push -f manifest.yml --var tcp-domain=#{CF_TCP_DOMAIN}",
     chdir: '/var/vcap/packages/docker-distribution/'
 
 run 'cf apps'

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/010_insecure_registry_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/010_insecure_registry_test.rb
@@ -27,7 +27,7 @@ run "cf bind-security-group #{CF_SEC_GROUP} #{$CF_ORG} #{$CF_SPACE} --lifecycle 
 
 REGISTRIES = {
     'secure-registry'   => "https://secure-registry.#{ENV['CF_DOMAIN']}",          # Router SSL cert
-    'insecure-registry' => "https://insecure-registry.#{ENV['CF_DOMAIN']}:20005",  # Self-signed SSL cert
+    'insecure-registry' => "https://insecure-registry.#{CF_TCP_DOMAIN}:20005",     # Self-signed SSL cert
 }
 
 at_exit do


### PR DESCRIPTION
We were incorrectly using `CF_DOMAIN` for the TCP route, which does not work on actual cloud deployments where the TCP port is on a different load balancer / IP address than the router.