### PR TITLE
Brain test NFS persi - Get more information out of it

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.rb
@@ -22,6 +22,9 @@ tmpdir = mktmpdir
 
 at_exit do
     set errexit: false do
+        # Status of the pods in the namespace
+        show_pods_for_namespace NS
+
         # See why pora failed to start
         run "cf logs #{APP_NAME} --recent"
 

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
@@ -145,11 +145,20 @@ def wait_for_namespace(namespace, sleep_duration=10)
             name, readiness, status, restarts, age = line.split
             next if status == 'Completed'
             next if status == 'Running' && /^(\d+)\/\1$/ =~ readiness
+            puts "# Waiting for: #{line}"
             ready = false
         end
         break if ready
         sleep sleep_duration
     end
+end
+
+# Show the status of a Kubernetes namespace
+def show_pods_for_namespace(namespace)
+  output = capture("kubectl get pods --namespace #{namespace} --no-headers")
+  output.each_line do |line|
+    puts "# Space: #{line}"
+  end
 end
 
 # Wait for a cf service asynchronous operation to complete.

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
@@ -155,10 +155,7 @@ end
 
 # Show the status of a Kubernetes namespace
 def show_pods_for_namespace(namespace)
-  output = capture("kubectl get pods --namespace #{namespace} --no-headers")
-  output.each_line do |line|
-    puts "# Space: #{line}"
-  end
+  run("kubectl get pods --namespace #{namespace} --no-headers")
 end
 
 # Wait for a cf service asynchronous operation to complete.


### PR DESCRIPTION
Ref: https://trello.com/c/UL1n6gO0/1007-nfs-persi-brain-failing-on-nightly-caasp3

Extended narrative tracing around the startup of the nfs-test-server pod.
