### PR TITLE
 Ensure authorize-internal-ca as a second job in the list

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+264.ge67442aa"
+export FISSILE_VERSION="7.0.0+266.g7c235963"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1057,6 +1057,8 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
+  - name: authorize-internal-ca
+    release: scf
   - name: wait-for-api
     release: scf
     # This job contains a pre-start script whose prupose is to delay
@@ -1066,8 +1068,6 @@ instance_groups:
     # has not even started them yet then the two roles can get into a
     # conflict wrt database access and state which blocks the entire
     # system from coming up.
-  - name: authorize-internal-ca
-    release: scf
   - name: cloud_controller_clock
     release: capi
     properties:
@@ -1113,9 +1113,9 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: log-cache-scheduler-properties
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
-  - name: authorize-internal-ca
+  - name: log-cache-scheduler-properties
     release: scf
   - name: log-cache-scheduler
     release: log-cache
@@ -1667,9 +1667,9 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: get-kubectl
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
-  - name: authorize-internal-ca
+  - name: get-kubectl
     release: scf
   - name: wait-for-uaa
     release: scf

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1960,6 +1960,7 @@ instance_groups:
   - scripts/chown_vcap_store.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
+  - scripts/patches/fix_postgres_prestart.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -159,7 +159,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: patch-properties
     release: scf-helper
@@ -488,7 +488,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: cf-usb
     release: cf-usb
@@ -545,7 +545,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: bbs
     release: diego
@@ -611,7 +611,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: patch-properties
     release: scf-helper
@@ -662,7 +662,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: bpm
     release: bpm
@@ -735,7 +735,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: wait-for-uaa
     release: scf
@@ -801,7 +801,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: bpm
     release: bpm
@@ -866,7 +866,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: patch-properties
     release: scf-helper
@@ -961,7 +961,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: cloud_controller_worker
     release: capi
@@ -1179,7 +1179,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: log-cache-gateway
     release: log-cache
@@ -1370,7 +1370,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: loggregator_trafficcontroller
     release: loggregator
@@ -1435,7 +1435,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: auctioneer
     release: diego
@@ -1495,7 +1495,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: tps
     release: capi
@@ -1549,7 +1549,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: ssh_proxy
     release: diego
@@ -1609,7 +1609,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: nfsbroker
     release: nfs-volume
@@ -1778,7 +1778,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: acceptance-tests-brain
     release: scf
@@ -1800,7 +1800,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: acceptance-tests
     release: scf
@@ -1826,7 +1826,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: cf-cli-6-linux
     release: cf-cli
@@ -1877,7 +1877,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: uaa-create-user
     release: scf
@@ -2040,7 +2040,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: metricscollector
     release: app-autoscaler
@@ -2065,7 +2065,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: scalingengine
     release: app-autoscaler
@@ -2090,7 +2090,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: scheduler
     release: app-autoscaler
@@ -2115,7 +2115,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: operator
     release: app-autoscaler
@@ -2139,7 +2139,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: servicebroker
     release: app-autoscaler
@@ -2180,7 +2180,7 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
-  - name: authorize-internal-ca
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
   - name: eventgenerator
     release: app-autoscaler

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -157,7 +157,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -191,7 +191,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: route_registrar
     release: routing
@@ -231,7 +231,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: scheduler
     release: cf-syslog-drain
@@ -281,7 +281,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: adapter
     release: cf-syslog-drain
@@ -336,7 +336,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: nats
     release: nats
@@ -390,7 +390,7 @@ instance_groups:
   - scripts/patches/enable_mysql_galera_bootstrap.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: patch-properties
     release: scf-helper
@@ -486,7 +486,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -543,7 +543,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -609,7 +609,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -660,7 +660,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -733,7 +733,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -799,7 +799,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -864,7 +864,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -959,7 +959,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -1007,7 +1007,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: blobstore
     release: capi
@@ -1055,7 +1055,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: wait-for-api
     release: scf
@@ -1111,7 +1111,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: log-cache-scheduler-properties
     release: scf
@@ -1177,7 +1177,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -1368,7 +1368,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -1433,7 +1433,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -1493,7 +1493,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -1547,7 +1547,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -1607,7 +1607,7 @@ instance_groups:
   - scripts/patches/nfsbroker_cert_prop.sh
   - scripts/patches/nfsbroker_ctl.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -1665,7 +1665,7 @@ instance_groups:
   - scripts/patches/nfs-volume-nfsv3driver-libdir.sh
   - scripts/patches/fix_garden_logdir.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: get-kubectl
     release: scf
@@ -1776,7 +1776,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -1798,7 +1798,7 @@ instance_groups:
   scripts:
   - scripts/cf_acceptance_tests_suites.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -1824,7 +1824,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -1875,7 +1875,7 @@ instance_groups:
 - name: post-deployment-setup
   type: bosh-task
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -1904,7 +1904,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: credhub
     release: credhub
@@ -1961,7 +1961,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: postgres
     release: postgres
@@ -1999,7 +1999,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: apiserver
     release: app-autoscaler
@@ -2038,7 +2038,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -2063,7 +2063,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -2088,7 +2088,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -2113,7 +2113,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -2137,7 +2137,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -2178,7 +2178,7 @@ instance_groups:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: authorize-internal-ca
     release: scf
@@ -2203,7 +2203,7 @@ instance_groups:
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
-  - name: global-properties # needs to be first so images use it for processing monit templates
+  - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
   - name: loggr-expvar-forwarder
     release: loggregator-agent

--- a/container-host-files/etc/scf/config/scripts/patches/fix_postgres_prestart.sh
+++ b/container-host-files/etc/scf/config/scripts/patches/fix_postgres_prestart.sh
@@ -1,0 +1,29 @@
+#! /usr/bin/env bash
+
+set -e
+
+PATCH_DIR=/var/vcap/jobs-src/postgres/templates
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+patch -d "$PATCH_DIR" --force -p0 <<'PATCH'
+--- pre-start.sh.erb	2019-04-02 12:36:41.627306990 -0700
++++ pre-start.sh.erb	2019-04-02 13:51:25.937193032 -0700
+@@ -53,7 +53,8 @@
+   chmod -R 600 ${PG_CERTS_DIR}/*
+   chown -R vcap:vcap ${PG_CERTS_DIR}/*
+ 
+-  sysctl -w "kernel.shmmax=284934144"
++  # Disabled, fails in container
++  #sysctl -w "kernel.shmmax=284934144"
+ }
+ 
+ main
+PATCH
+
+touch "${SENTINEL}"
+
+exit 0


### PR DESCRIPTION
## Description

This PR ensure that authorize-internal-ca runs as a second job right after the global-properties.
This relies on the ordering being preserved when passed to Fissile.
https://github.com/cloudfoundry-incubator/fissile/pull/485 ensures the order of execution of pre-start scripts is preserved.

## Test plan

Blocked by https://github.com/cloudfoundry-incubator/fissile/pull/485.