### PR TITLE
brains: minibroker: if failing to show logs, show the pod

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -52,9 +52,12 @@ class MiniBrokerTest
 
     def print_all_container_logs_in_namespace(ns)
         capture("kubectl get pods --namespace #{ns} --output name").split.each do |pod|
+            failed = false
             capture("kubectl get --namespace #{ns} #{pod} --output jsonpath='{.spec.containers[*].name}'").split.each do |container|
-                run "kubectl logs --namespace #{ns} #{pod} --container #{container}"
+                status = run_with_status("kubectl logs --namespace #{ns} #{pod} --container #{container}")
+                failed ||= !status.success?
             end
+            run "kubectl describe --namespace #{ns} #{pod}" if failed
         end
     end
 


### PR DESCRIPTION
## Description

If we could not get the logs out of a container for some reason when logging failures (e.g. ContainerCreating), describe the pod so that we might have a chance to diagnose the error.

In rare cases (less rare on terrible hardware), we can end up with the test failing while the pod isn't ready (e.g. because it hasn't managed to pull the image yet).  When we try to get the logs, it could give us useless errors:

> Error from server (BadRequest): container "mariadb" in pod "erstwhile-squid-mariadb-slave-0" is waiting to start: PodInitializing

In this case, try running a `kubectl describe`, in the hopes that we will get the relevant event logs to help us troubleshoot the problem.
## Test plan

1. Run the minibroker brain tests on a really slow machine