### PR TITLE
Wait for Minibroker service resources

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -156,6 +156,7 @@ class MiniBrokerTest
                 raise "Failed to create service instance #{service_instance} after #{elapsed} seconds."
             end
             run "cf service #{service_instance}"
+            wait_for_namespace wait_for_namespace
 
             yield self
 

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -118,6 +118,7 @@ class MiniBrokerTest
                 --set kube.registry.hostname=index.docker.io
                 --set kube.organization=splatform
                 --set image=minibroker:latest
+                --set imagePullPolicy=Always
             ))
             wait_for_namespace minibroker_namespace
 

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -156,7 +156,7 @@ class MiniBrokerTest
                 raise "Failed to create service instance #{service_instance} after #{elapsed} seconds."
             end
             run "cf service #{service_instance}"
-            wait_for_namespace wait_for_namespace
+            wait_for_namespace minibroker_pods_namespace
 
             yield self
 


### PR DESCRIPTION
## Description

- Force the Minibroker image to be downloaded, even if the tag `latest` is already cached (it may have changed).
- Wait for the underlying Minibroker resources to be ready.

## Test plan

Brain tests should pass on Jenkins and Concourse.
