### PR TITLE
Reduce disk used by nfs testing

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_server_kube.yaml
+++ b/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_server_kube.yaml
@@ -80,7 +80,7 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: "50G"
+          storage: "5G"
 ---
 apiVersion: "v1"
 items:


### PR DESCRIPTION
## Description

https://trello.com/c/UL1n6gO0/1007-nfs-persi-brain-failing-on-nightly-caasp3

Apparently ECP CaaSP3 does not have enough disk to satisfy the test server's request.
As really do not need that much, reduced the claim to improve chances of having it satisfied.

## Test plan

Pass the jenkins CI.
Pass the ECP CaaSP3 CI.
