### PR TITLE
Brain tests - use KUBERNETES_STORAGE_CLASS_PERSISTENT as storage class

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.rb
@@ -12,7 +12,6 @@ login
 setup_org_space
 
 NS = ENV['KUBERNETES_NAMESPACE']
-SC = ENV['KUBERNETES_STORAGE_CLASS_PERSISTENT']
 
 APP_NAME = random_suffix('pora')
 SECGROUP = random_suffix('sg-nfs-test')
@@ -45,7 +44,7 @@ end
 # Replace the placeholder storage class for persistent volumes with
 # the actual class provided by the execution environment.
 SKUBEC = "#{tmpdir}/nfs_server_kube.yaml"
-run %Q@sed 's/storage-class: "persistent"/storage-class: "#{SC}"/' <#{resource_path('nfs_server_kube.yaml')} >#{SKUBEC}@
+run %Q@sed 's/storage-class: "persistent"/storage-class: "#{STORAGE_CLASS}"/' <#{resource_path('nfs_server_kube.yaml')} >#{SKUBEC}@
 
 set errexit: false do
     run "kubectl delete -n #{NS} -f #{SKUBEC}"

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/012_minibroker_redis_test.rb
@@ -2,7 +2,11 @@
 
 require_relative 'minibroker_helper'
 
-MiniBrokerTest.new('redis', '6379').run_test do |tester|
+tester = MiniBrokerTest.new('redis', '6379')
+tester.service_params = {
+    master: { persistence: { storageClass: STORAGE_CLASS } },
+}
+tester.run_test do |tester|
     CF_APP = random_suffix('app', 'CF_APP')
 
     at_exit do

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/014_minibroker_mariadb_test.rb
@@ -7,8 +7,10 @@ $DB_NAME = random_suffix('db')
 tester = MiniBrokerTest.new('mariadb', '3306')
 tester.service_params = {
     db: { name: $DB_NAME },
-    mariadbDatabase: $DB_NAME
     # Need "mariadbDatabase" key for compatibility with old minibroker.
+    mariadbDatabase: $DB_NAME,
+    master: { persistence: { storageClass: STORAGE_CLASS } },
+    slave: { persistence: { storageClass: STORAGE_CLASS } },
 }
 tester.run_test do |tester|
     CF_APP = random_suffix('app', 'CF_APP')

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
@@ -8,7 +8,8 @@ tester = MiniBrokerTest.new('postgresql', '5432')
 tester.service_params = {
     # Need "postgresDatabase" key for compatibility with old minibroker.
     postgresDatabase: $DB_NAME,
-    postgresqlDatabase: $DB_NAME
+    postgresqlDatabase: $DB_NAME,
+    persistence: { storageClass: STORAGE_CLASS },
 }
 tester.run_test do |tester|
     CF_APP = random_suffix('app', 'CF_APP')

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
@@ -7,6 +7,7 @@ tester.service_params = {
     mongodbDatabase: random_suffix('database'),
     mongodbUsername: random_suffix('user'),
     mongodbPassword: random_suffix('pass'),
+    persistence: { storageClass: STORAGE_CLASS },
 }
 tester.run_test do |tester|
     CF_APP = random_suffix('app', 'CF_APP')

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
@@ -10,6 +10,8 @@ require 'tmpdir'
 # Global options, similar to shopts.
 $opts = { errexit: true, xtrace: true }
 
+STORAGE_CLASS = ENV['KUBERNETES_STORAGE_CLASS_PERSISTENT']
+
 # Set global options.  If a block is given, the options are only active in that
 # block.
 def set(opts={})


### PR DESCRIPTION
## Description

Use `KUBERNETES_STORAGE_CLASS_PERSISTENT` environment variable on all brain tests that rely on storage classes.

## Test plan

Should pass Jenkins and Concourse on the various platforms we test.
