### PR TITLE
Minibroker Postgres brain test assertion cleanup

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/015_minibroker_postgres_test.rb
@@ -66,12 +66,9 @@ tester.run_test do |tester|
     app_domain = domain_info['entity']['name']
     app_url = "http://#{app_host}.#{app_domain}"
 
-    # Check with the app at its endpoint that it is able to use the
-    # service it was bound to.
-    run "curl -L -v --fail #{app_url}/"
+    # Assert
     run "curl -L -v --fail -X POST #{app_url}/todos --data text='hello'"
-    run "curl -L #{app_url}/todos"
-    todos = JSON.load capture("curl -L #{app_url}/todos")
+    todos = JSON.load capture("curl -L --fail #{app_url}/todos")
     run "echo '#{todos.to_json}' | jq -C ."
     todo_id = todos.first['id']
     run "curl -L -v --fail #{app_url}/todos/#{todo_id}"


### PR DESCRIPTION
## Description

Removed unnecessary calls on the Minibroker Postgres brain test, as well as added a missing `--fail` to the `/todos` call.

## Test plan

Should pass CI.
