### PR TITLE
Brain Minibroker install rely on Helm --wait

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -111,6 +111,7 @@ class MiniBrokerTest
             run "helm init --client-only"
             run(*%W(helm upgrade #{helm_release} minibroker
                 --install
+                --wait
                 --repo #{minibroker_repo}
                 --devel
                 --reset-values
@@ -123,7 +124,6 @@ class MiniBrokerTest
                 --set image=minibroker:latest
                 --set imagePullPolicy=Always
             ))
-            wait_for_namespace minibroker_namespace
 
             broker_url = "http://#{helm_release}-minibroker.#{minibroker_namespace}.svc.cluster.local"
             run "cf create-service-broker #{broker_name} user pass #{broker_url}"


### PR DESCRIPTION
## Description

Rely on Helm's `--wait` for the Minibroker installation on the brain test.

## Test plan

Brain tests should pass on CI.
