### PR TITLE
Brain tests - don't wait for namespace deletion

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -97,13 +97,12 @@ class MiniBrokerTest
                     end
                     run "helm delete --purge #{helm_release}"
                     run "kubectl delete ClusterRoleBinding minibroker"
-                    [minibroker_namespace, minibroker_pods_namespace].each do |ns|
-                        loop do
-                            status = run_with_status "kubectl get namespace #{ns} >/dev/null 2>/dev/null"
-                            break unless status.success?
-                            _ = run_with_status "kubectl delete namespace #{ns}"
-                        end
-                    end
+
+                    # Delete the Minibroker underlying resources namespace.
+                    run "kubectl delete namespace #{minibroker_pods_namespace} --wait=false"
+
+                    # Delete the Minibroker namespace.
+                    run "kubectl delete namespace #{minibroker_namespace} --wait=false"
                 end
             end
 


### PR DESCRIPTION
## Description

The Minibroker related namespace deletion can happen on the background. In some cases, waiting for the namespace to be deleted can cause the tests to timeout.

## Test plan

Brain tests should pass on CI.
