### PR TITLE
Fix kube ready state check

### DIFF
--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -88,16 +88,16 @@ if having_category node ; then
     status "docker info should not show aufs"
 fi
 
-# kube-dns shows 4/4 ready
+# kube-dns shows all pods ready
 if having_category kube ; then
     kubectl get pods --namespace=kube-system --selector k8s-app=kube-dns 2> /dev/null | grep -Eq '([0-9])/\1 *Running'
-    status "kube-dns should be running (show 4/4 ready)"
+    status "all kube-dns pods should be running (show N/N ready)"
 fi
 
-# tiller-deploy shows 4/4 ready
+# tiller-deploy shows all pods ready
 if having_category kube ; then
     kubectl get pods --namespace=kube-system --selector name=tiller 2> /dev/null | grep -Eq '([0-9])/\1 *Running'
-    status "tiller should be running (1/1 ready)"
+    status "all tiller pods should be running (N/N ready)"
 fi
 
 # ntp or systemd-timesyncd is installed and running

--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -114,7 +114,7 @@ fi
 
 # At least one storage class exists in K8s
 if having_category kube ; then
-    test ! "$(kubectl get storageclasses 2>&1 | grep "No resources found.")"
+    test ! "$(kubectl get storageclasses 2>&1 | grep -e "No resources found." -e "Unable to connect to the server")"
     status "A storage class should exist in K8s"
 fi
 

--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -88,6 +88,12 @@ if having_category node ; then
     status "docker info should not show aufs"
 fi
 
+# kube auth
+if having_category kube ; then
+    kubectl auth can-i get pods --namespace=kube-system 2>&1>/dev/null
+    status "authenticate with kubernetes cluster"
+fi
+
 # kube-dns shows all pods ready
 if having_category kube ; then
     kubectl get pods --namespace=kube-system --selector k8s-app=kube-dns 2> /dev/null | grep -Eq '([0-9])/\1 *Running'

--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -90,7 +90,7 @@ fi
 
 # kube auth
 if having_category kube ; then
-    kubectl auth can-i get pods --namespace=kube-system 2>&1>/dev/null
+    kubectl auth can-i get pods --namespace=kube-system &> /dev/null
     status "authenticate with kubernetes cluster"
 fi
 


### PR DESCRIPTION
## Description

This addresses the following issues (esp. when run in the pipeline):

- auth test will fail for nonauth, and log respectively (currently the first test just failed for noauth, saying you need to have 4/4 kube-dns pods)

- remove explicit pod numbers from status messages, as 1. they were wrong, 2. we don't check for a pod number, but only if requested ones are ready - therefore "N/N"

- storage class test passed, when kube couldn't authenticate - now fails here as well

## Test plan

run "./kube-ready-state-check.sh kube" (didn't verified for e.g. AWS/EKS)