### PR TITLE
Portable accounted swap check on kube-ready-state-check.sh

### DIFF
--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -78,12 +78,16 @@ function having_category() {
 
 echo "Testing $(green "${category}")"
 
-# swap accounting in /proc/cmdline
+# swap should be accounted
 if having_category node ; then
-    grep -wq "swapaccount=1" /proc/cmdline
-    status "swapaccount enable"
+    # https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt - section 2.4.
+    dir="/sys/fs/cgroup/memory"
+    test -e "${dir}/memory.memsw.usage_in_bytes" && test -e "${dir}/memory.memsw.limit_in_bytes"
+    status "swap should be accounted"
+fi
 
-    # docker info should not show aufs
+# docker info should not show aufs
+if having_category node ; then
     docker info 2> /dev/null | grep -vwq "Storage Driver: aufs"
     status "docker info should not show aufs"
 fi


### PR DESCRIPTION
## Description

`swapaccount=1` on the `/proc/cmdline` is not a definitive check for swap being accounted. According to https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt, section 2.4:

```
When swap is accounted, following files are added.
 - memory.memsw.usage_in_bytes.
 - memory.memsw.limit_in_bytes.
```

This refactor makes the check portable. E.g. on Minikube swap is accounted, but no `swapaccount` is passed to the boot parameters.

## Test plan

Run the script on a system with accounted swap disabled, then run on a system with accounted swap enabled.
