### PR TITLE
brains/minibroker-mongo: disable pod liveness probe

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/016_minibroker_mongodb_test.rb
@@ -4,6 +4,8 @@ require_relative 'minibroker_helper'
 
 tester = MiniBrokerTest.new('mongodb', '27017')
 tester.service_params = {
+    image: { debug: true },
+    livenessProbe: { enabled: false },
     mongodbDatabase: random_suffix('database'),
     mongodbUsername: random_suffix('user'),
     mongodbPassword: random_suffix('pass'),


### PR DESCRIPTION
## Description

On slow clusters, we could take too long to deploy the mongo pod; if kube happens to kill the pod at a bad time, we could end up with an unrecoverable state.

The proper fix is to change the mongodb helm chart to use an init container, instead of just running the initial db setup in a script.

This also enables extra logging, in case that helps.

## Test plan

The acceptance-tests-brain test `016_minibroker_mongodb_test` should be run a very slow cluster.