### PR TITLE
Bump product version.

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -34,7 +34,7 @@ export GOLANG_VERSION=1.7
 
 # Used in: make/include/versioning
 
-export PRODUCT_VERSION="1.3.2"
+export PRODUCT_VERSION="1.4"
 export CF_VERSION="6.10.0"
 
 # Show versions, if called on its own.


### PR DESCRIPTION
## Description

Ref: https://trello.com/c/Zq4jVCv8/1022-14rc1-wrong-app-version-132

Fixes the bug where our charts shows 1.3.2 as app version instead of 1.4

## Test plan

Build the charts from the branch, then check the `appVersion` in `Chart.yaml`.
