### PR TITLE
brains: add global timeout

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.rb
@@ -8,6 +8,8 @@ require_relative 'testutils'
 require 'json'
 require 'yaml'
 
+use_global_timeout
+
 login
 setup_org_space
 


### PR DESCRIPTION
## Description

This adds a helper function to trigger an exception some amount of time before the (expected) runner-triggered abort happens.  Ideally this should mean we do better at cleaning up any resources we create.

## Test plan

Run the NFS-persi tests somewhere slow.

Actually, I locally modified `000_cflogin_test.rb` to fail in the correct way (by making the timeout 10 seconds, and adding a 10 second sleep):

```
use_global_timeout
puts "Current time is #{DateTime.now.rfc3339}"
# existing test here
at_exit { puts "Exiting at #{DateTime.now.rfc3339}" }
puts "Starting to sleep at #{DateTime.now.rfc3339}"
sleep 10
```
Output:
```
FAILED: 000_cflogin_test.rb

Test output:
…
Current time is 2019-04-10T22:12:04+00:00
…
Starting to sleep at 2019-04-10T22:12:05+00:00
…
/var/vcap/packages/acceptance-tests-brain/test-scripts/000_cflogin_test.rb:16:in `sleep': timeout reached after 10 seconds (Timeout::Error)
        from /var/vcap/packages/acceptance-tests-brain/test-scripts/000_cflogin_test.rb:16:in `<main>'
Exiting at 2019-04-10T22:12:26+00:00
Tests complete: 0 Passed, 0 Skipped, 1 Failed
```