### PR TITLE
SATS -> BRAIN on Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,7 +170,7 @@ pipeline {
         booleanParam(
             name: 'TEST_BRAIN',
             defaultValue: true,
-            description: 'Run SATS (SCF Acceptance Tests)',
+            description: 'Run BRAIN tests (SCF Acceptance Tests)',
         )
         booleanParam(
             name: 'TEST_SITS',


### PR DESCRIPTION
## Description

Left over? SATS is not used to reference BRAIN tests.

## Test plan

Not applicable.
