### PR TITLE
role-manifest: allow configgin-roles to patch statefulsets

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -27,7 +27,7 @@ export ISTIO_VERSION="1.0.5"
 export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$//')
 
 # Used in: .envrc
-export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-30.g9c91e77-30.80}
+export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-32.g37e6301-30.80}
 
 # Used in: bin/generate-dev-certs.sh
 

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2342,7 +2342,7 @@ configuration:
         verbs: [get]
       - apiGroups: [apps]
         resources: [statefulsets]
-        verbs: [get]
+        verbs: [get, patch]
       secrets-role:
       - apiGroups: [""]
         resources: [configmaps, secrets]


### PR DESCRIPTION
## Description

This is to implement restarting dependent pods on exported BOSH property change.

See also:
https://github.com/cloudfoundry-incubator/configgin/pull/97
https://github.com/cloudfoundry-incubator/fissile/pull/470
https://github.com/SUSE/uaa-fissile-release/pull/153

## Test plan

1. Deploy SCF
2. Upgrade with `make/upgrade --values /dev/shm/foo.yaml` where the YAML file has:
```yaml
bosh:
  instance_groups:
  - name: doppler
    jobs:
    - name: doppler
      properties:
        doppler:
          grpc_port: 8081
```
3. Manually delete the `doppler` pod. (The `doppler` that comes up will be broken, that's okay)
4. Check that `log-api` restarted on its own.
