### PR TITLE
Remove Eirini release as submodule (and use a final release instead)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -24,7 +24,6 @@ export FISSILE_DOCKER_REPO=${FISSILE_DOCKER_REPO:-'fissile-stemcell-opensuse'}
 # This is a comma separated list of paths to the local repositories
 # of all the releases that make up SCF
 FISSILE_RELEASE=""
-FISSILE_RELEASE="${FISSILE_RELEASE},${PWD}/src/eirini-release"
 FISSILE_RELEASE="${FISSILE_RELEASE},${PWD}/src/scf-release"
 
 export FISSILE_RELEASE="${FISSILE_RELEASE#,}"

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,6 +25,3 @@
 [submodule "src/scf-release/src/acceptance-tests-brain/test-resources/rails-example"]
 	path = src/scf-release/src/acceptance-tests-brain/test-resources/rails-example
 	url = https://github.com/scf-samples/rails-example.git
-[submodule "src/eirini-release"]
-	path = src/eirini-release
-	url = https://github.com/SUSE/eirini-bosh-release.git

--- a/Makefile
+++ b/Makefile
@@ -166,11 +166,7 @@ uaa-helm: ${FISSILE_BINARY}
 scf-release:
 	make/bosh-release src/scf-release
 
-eirini-release:
-	make/bosh-release src/eirini-release
-
 releases: \
-	eirini-release \
 	scf-release \
 	uaa-releases \
 	${NULL}

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -147,6 +147,10 @@ releases:
   version: "2.26.0"
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=2.26.0"
   sha1: "f6a6598fbbac233f94c4a0cfe914970ec34db7b3"
+- name: "eirini"
+  version: "0.0.3"
+  url: "https://s3.amazonaws.com/suse-final-releases/eirini-release-0.0.3.tgz"
+  sha1: "96be6dc9e88e32dbdcf58bb6dae5154771911e50"
 
 instance_groups:
 - name: eirini


### PR DESCRIPTION
## Description

Consumes https://github.com/cloudfoundry-community/eirini-bosh-release and remove the eirini submodule. Tested locally with my vagrant box and I can push apps and access them as usual. After merging this, automation will take care of bumps

## Test plan

- make vagrant-prep
- make run-eirini
- .... see if eirini is up, push an app and see if works
