### PR TITLE
role-manifest: fix diego-api readiness probe

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -568,7 +568,8 @@ instance_groups:
           healthcheck:
             readiness:
               command:
-              - head -c0 </dev/tcp/${HOSTNAME}/8889
+              # See BOSH property diego.bbs.health_addr
+              - curl --fail http://$(jq -r .health_address /var/vcap/jobs/bbs/config/bbs.json)/ping
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Description

We need to be checking the health check port for bbs, instead of the actual listen port (which wouldn't be active when we don't have the lock).

## Test plan

1. Deploy SCF with >1 diego-api instances
2. See that both are Ready
