### PR TITLE
Reduced Autoscaler database disk size

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2016,7 +2016,7 @@ instance_groups:
           - path: /var/vcap/store
             type: persistent
             tag: postgres-data
-            size: 100
+            size: 5
           memory: 1024
           virtual-cpus: 2
         ports:


### PR DESCRIPTION
## Description

App Autoscaler Postgres instance doesn't need 100 GB. Reducing it to 5.

## Test plan

Not applicable.
