### PR TITLE
Reworked klog to continue on bad pods, containers.

### DIFF
--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -24,56 +24,107 @@ fi
 NS=${1-scf}
 DONE="${KLOG}/${NS}/done"
 
+# Prevent bail out
 if [ "${FORCE}" == "1" ] ; then
   rm -f "${DONE}" 2> /dev/null
 fi
 
-function get_phase() {
+# Bail out early when already done
+if [ -f "${DONE}" ]; then
+    printf "Already done\n"
+    exit
+fi
+
+function get_pod_phase() {
   kubectl get pod "${POD}" --namespace "${NS}" --output=jsonpath='{.status.phase}'
 }
 
 function check_for_log_dir() {
-  kubectl exec "${POD}" --namespace "${NS}" --container "${CONTAINER}" -- bash -c "[ -d /var/vcap/sys/log ]" 2> /dev/null
+  kubectl exec "${POD}" --namespace "${NS}" --container "${CONTAINER}" \
+    -- bash -c "[ -d /var/vcap/sys/log ]" \
+    2> /dev/null
 }
 
-if [ ! -f "${DONE}" ]; then
-  rm -rf "${KLOG:?}/${NS:?}"
-  NAMESPACE_DIR="${KLOG}/${NS}"
+function get_all_the_pods() {
+  kubectl get pods --namespace "${NS}" --output=jsonpath='{.items[*].metadata.name}'
+}
 
-  # Retrieving all the pods.
-  PODS=($(kubectl get pods --namespace "${NS}" --output=jsonpath='{.items[*].metadata.name}'))
+function get_containers_of_pod() {
+  kubectl get pods "${POD}" --namespace "${NS}" --output=jsonpath='{.spec.containers[*].name}'
+}
 
-  for POD in "${PODS[@]}"; do
-    POD_DIR="${NAMESPACE_DIR}/${POD}"
+function retrieve_container_cf_logs() {
+  # Get the CF logs inside the pod.
+  printf " CF"
+  kubectl cp --namespace "${NS}" --container "${CONTAINER}" \
+    "${POD}":/var/vcap/sys/log/ \
+    "${CONTAINER_DIR}/" \
+    2> /dev/null > /dev/null
+}
 
-    # Retrieving all the containers within a pod.
-    CONTAINERS=($(kubectl get pods "${POD}" --namespace "${NS}" --output=jsonpath='{.spec.containers[*].name}'))
+function retrieve_container_kube_logs() {
+  # Get the pod logs - previous may not be there if it was successful
+  # on the first run.  Unfortunately we can't get anything past the
+  # previous one.
+  printf " Kube"
+  kubectl logs "${POD}" --namespace "${NS}" --container "${CONTAINER}"            > "${CONTAINER_DIR}/kube.log"
+  kubectl logs "${POD}" --namespace "${NS}" --container "${CONTAINER}" --previous > "${CONTAINER_DIR}/kube-previous.log"
+}
 
-    # Iterate over containers and dump logs.
-    for CONTAINER in "${CONTAINERS[@]}"; do
+function get_pod_description() {
+  printf "  Descriptions ...\n"
+  kubectl describe pods "${POD}" --namespace "${NS}" > "${POD_DIR}/describe-pod.txt"
+}
 
-      CONTAINER_DIR="${POD_DIR}/${CONTAINER}"
-      mkdir -p ${CONTAINER_DIR}
+function get_all_resources() {
+  printf "Resources ...\n"
+  kubectl get all --export=true --namespace "${NS}" --output=yaml > "${KLOG}/${NS}/resources.yaml"
+}
 
-      # Get the CF logs inside the pod if there are any.
-      if [ "$(get_phase)" != 'Succeeded' ] && check_for_log_dir; then
-        kubectl cp --namespace "${NS}" --container "${CONTAINER}" "${POD}":/var/vcap/sys/log/ "${CONTAINER_DIR}/" 2> /dev/null
-      fi
+function get_all_events() {
+  printf "Events ...\n"
+  kubectl get events --export=true --namespace "${NS}" --output=yaml > "${KLOG}/${NS}/events.yaml"
+}
 
+rm -rf "${KLOG:?}/${NS:?}"
+NAMESPACE_DIR="${KLOG}/${NS}"
 
-      # Get the pod logs - previous may not be there if it was successful on the first run.
-      # Unfortunately we can't get anything past the previous one.
-      kubectl logs "${POD}" --namespace "${NS}" --container "${CONTAINER}" > "${CONTAINER_DIR}/kube.log"
-      kubectl logs "${POD}" --namespace "${NS}" --container "${CONTAINER}" --previous > "${CONTAINER_DIR}/kube-previous.log" 2> /dev/null || true
-    done
-    
-    kubectl describe pods "${POD}" --namespace "${NS}" > "${POD_DIR}/describe-pod.txt"
+# Iterate over pods and their containers ...
+PODS=($(get_all_the_pods))
+
+for POD in "${PODS[@]}"; do
+  POD_DIR="${NAMESPACE_DIR}/${POD}"
+  PHASE="$(get_pod_phase)"
+
+  printf "Pod \e[0;32m$POD\e[0m = $PHASE\n"
+
+  # Iterate over containers and dump logs.
+  CONTAINERS=($(get_containers_of_pod))
+  for CONTAINER in "${CONTAINERS[@]}"; do
+    printf "  - \e[0;32m${CONTAINER}\e[0m logs:"
+
+    CONTAINER_DIR="${POD_DIR}/${CONTAINER}"
+    mkdir -p ${CONTAINER_DIR}
+
+    # Get the CF logs only if there are any.
+    if [ "${PHASE}" != 'Succeeded' ] && check_for_log_dir; then
+      retrieve_container_cf_logs
+    fi
+
+    retrieve_container_kube_logs 2> /dev/null || true
+    printf "\n"
   done
 
-  kubectl get all --export=true --namespace "${NS}" --output=yaml > "${KLOG}/${NS}/resources.yaml"
-  kubectl get events --export=true --namespace "${NS}" --output=yaml > "${KLOG}/${NS}/events.yaml"
+  get_pod_description
+done
 
-  tar -zcf klog.tar.gz "${KLOG}"
+get_all_resources
+get_all_events
 
-  touch "${DONE}"
-fi
+printf "Packaging it all up ...\n"
+
+tar -zcf klog.tar.gz "${KLOG}"
+
+printf "\e[0;32mDone\e[0m\n"
+touch "${DONE}"
+exit

--- a/container-host-files/opt/scf/bin/klog.sh
+++ b/container-host-files/opt/scf/bin/klog.sh
@@ -24,12 +24,12 @@ fi
 NS=${1-scf}
 DONE="${KLOG}/${NS}/done"
 
-# Prevent bail out
+# Prevent bail out.
 if [ "${FORCE}" == "1" ] ; then
   rm -f "${DONE}" 2> /dev/null
 fi
 
-# Bail out early when already done
+# Bail out early when already done.
 if [ -f "${DONE}" ]; then
     printf "Already done\n"
     exit
@@ -53,8 +53,8 @@ function get_containers_of_pod() {
   kubectl get pods "${POD}" --namespace "${NS}" --output=jsonpath='{.spec.containers[*].name}'
 }
 
+# Get the CF logs inside the pod.
 function retrieve_container_cf_logs() {
-  # Get the CF logs inside the pod.
   printf " CF"
   kubectl cp --namespace "${NS}" --container "${CONTAINER}" \
     "${POD}":/var/vcap/sys/log/ \
@@ -62,10 +62,10 @@ function retrieve_container_cf_logs() {
     2> /dev/null > /dev/null
 }
 
+# Get the pod logs - Note that previous may not be there if it was
+# successful on the first run. Unfortunately we can't get anything
+# past the previous one.
 function retrieve_container_kube_logs() {
-  # Get the pod logs - previous may not be there if it was successful
-  # on the first run.  Unfortunately we can't get anything past the
-  # previous one.
   printf " Kube"
   kubectl logs "${POD}" --namespace "${NS}" --container "${CONTAINER}"            > "${CONTAINER_DIR}/kube.log"
   kubectl logs "${POD}" --namespace "${NS}" --container "${CONTAINER}" --previous > "${CONTAINER_DIR}/kube-previous.log"
@@ -89,7 +89,7 @@ function get_all_events() {
 rm -rf "${KLOG:?}/${NS:?}"
 NAMESPACE_DIR="${KLOG}/${NS}"
 
-# Iterate over pods and their containers ...
+# Iterate over pods and their containers.
 PODS=($(get_all_the_pods))
 
 for POD in "${PODS[@]}"; do


### PR DESCRIPTION
## Description

Ref: https://trello.com/c/omFBqdlS/1031-klogsh-should-not-error-out-when-containers-are-not-running

Moved all kube operations into functions with nice names.
Prevent abort when retrieving kube logs (`|| true`)
Added narrative output, let users see the script working instead of waiting a few minutes with no indication of operation.
Note: Hoisted determination of pod phase out of container loop, need this only per pod, not per container.

## Test plan

- Start a cluster where one or more pods are CrashLoopBackOff, or not fully started.
- Run klog.sh against the cluster.
- See it complete instead of aborting on the bad pods.
