### PR TITLE
acceptance-tests-brain: wait for ready statefulsets better

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/011_nfspersi_test.rb
@@ -31,7 +31,7 @@ at_exit do
 
         # Delete the app, the associated service, block it from use again
         run "cf delete -f #{APP_NAME}"
-        run "cf delete-route '#{ENV['DOMAIN']}' --hostname #{APP_NAME}"
+        run "cf delete-route -f '#{ENV['DOMAIN']}' --hostname #{APP_NAME}"
         run "cf delete-service -f #{VOLUME_NAME}"
         run "cf disable-service-access persi-nfs"
 


### PR DESCRIPTION
## Description

When looking to see if StatefulSets are ready, we should fall back in the case where the readyReplicas count doesn't exist yet.

## Test plan

Run `011_nfspersi_test.rb` on a slow cluster (that should time out) and check for a (lack of) misleading lines:
> `error: error executing template "\"{{ eq .status.replicas .status.readyReplicas }}\"": template: output:1:4: executing "output" at <eq .status.replicas ...>: error calling eq: invalid type for comparison`
