### PR TITLE
Add Helm labels to ingress templates

### DIFF
--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -11,6 +11,13 @@ type: kubernetes.io/tls
 metadata:
   name: "ingress-tls"
   namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: "ingress-tls"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
 data:
   tls.crt: {{ .Values.ingress.tls.crt | default "" | b64enc | quote }}
   tls.key: {{ .Values.ingress.tls.key | default "" | b64enc | quote }}
@@ -44,6 +51,13 @@ metadata:
     {{- end }}
     {{ $_ := set .Values.ingress.annotations "nginx.org/websocket-services" "router-gorouter-public" }}
 {{ toYaml .Values.ingress.annotations | indent 4 }}
+  labels:
+    app.kubernetes.io/component: "ingress"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
 spec:
   tls:
   - secretName: "ingress-tls"


### PR DESCRIPTION
## Description

According to https://helm.sh/docs/chart_best_practices/#standard-labels, it is recommended to label the objects with the Helm related labels.

Dependent on:
https://github.com/SUSE/uaa-fissile-release/pull/154

## Test plan

The labels should be applied correctly, similar to the rest of the CF roles.