### PR TITLE
Check fissile with storage class changes.

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="checks"
-export FISSILE_VERSION="7.0.0+278.gc111037e"
+export FISSILE_VERSION="7.0.0+291.g23ee88ba"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -9,8 +9,8 @@ set -o errexit -o nounset
 
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
-export FISSILE_FLAVOR="checks"
-export FISSILE_VERSION="7.0.0+292.g80d42a64"
+export FISSILE_FLAVOR="develop"
+export FISSILE_VERSION="7.0.0+293.g41077246"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -9,8 +9,9 @@ set -o errexit -o nounset
 
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
-export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+289.g3280187b"
+export FISSILE_FLAVOR="checks"
+export FISSILE_VERSION="7.0.0+278.gc111037e"
+
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"
 export KUBECTL_VERSION="1.9.6"

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="checks"
-export FISSILE_VERSION="7.0.0+291.g23ee88ba"
+export FISSILE_VERSION="7.0.0+292.g80d42a64"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"

--- a/make/assets/nfs-provisioner/claim.yaml
+++ b/make/assets/nfs-provisioner/claim.yaml
@@ -2,11 +2,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: nfsclaim
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "nfspersist"
 spec:
   accessModes:
     - ReadWriteMany
   resources:
     requests:
       storage: 1Mi
+  storageClassName: "nfspersist"


### PR DESCRIPTION
## Description

Ref https://trello.com/c/rhJZ3Rqm/1036-dont-use-deprecated-storage-class-key-in-helm-templates
This PR pulls in fissile https://github.com/cloudfoundry-incubator/fissile/pull/492

## Test plan

Build images with the changed fissile. Compare the generated helm chart against a saved helm chart generated by an older fissile. See how the `storage-class` annotations are gone, and `storageClassName` keys have appeared. Stand up a cluster to see that the storage classes still work. Possibly run the various test suites.
