### PR TITLE
Bump CAPI to 1.79.0

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -4,9 +4,9 @@ releases:
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=1.0.0"
   sha1: "42b95d4a0d6d15dd0b0ead62418ffb56208e2307"
 - name: capi
-  version: "1.78.0+dev.4"
-  url: "https://s3.amazonaws.com/cap-experiments/capi-6e4864e.tgz"
-  sha1: "e45c1a4d93f12a325e04d103cbd9a3ff6fa8a38a"
+  version: "1.79.0"
+  url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.79.0"
+  sha1: "85d0765ad9815962e46fc99712294c21514e6f7f"
 - name: cf-cli
   version: 1.11.0
   url: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.11.0

--- a/tooling/lib/releases_diff.rb
+++ b/tooling/lib/releases_diff.rb
@@ -1,6 +1,8 @@
 require 'fileutils'
 require 'yaml'
 
+FISSILE_LIGHT_OPINIONS = ENV["FISSILE_LIGHT_OPINIONS"]
+
 class ReleasesDiff
     # Path to the partial manifest relative to the root of the source tree
     attr_accessor :manifest_path
@@ -32,8 +34,6 @@ class ReleasesDiff
 
         # Path to the current partial manifest
         @current_src_path=File.join(ReleasesDiff.git_root, current_manifest_path)
-
-        FISSILE_LIGHT_OPINIONS = ENV["FISSILE_LIGHT_OPINIONS"]
 
         FileUtils.mkdir_p temp_work_dir
         system("  cat #{FISSILE_LIGHT_OPINIONS}   #{@current_src_path}                              > #{@current_manifest}")
@@ -97,7 +97,7 @@ class ReleasesDiff
         system("env -u FISSILE_LIGHT_OPINIONS -u FISSILE_DARK_OPINIONS -u FISSILE_ROLE_MANIFEST fissile validate --light-opinions #{@empty_opinions_path} --dark-opinions #{@empty_opinions_path} --role-manifest #{@current_manifest}", out: @output, err: @output)
     end
 
-    # Converts releases information into a map that only contains the information 
+    # Converts releases information into a map that only contains the information
     # we need for calculating differences
     def get_releases_info(manifest, final_releases_dir)
         result = {}
@@ -156,8 +156,8 @@ class ReleasesDiff
 
         old_releases.each do |release_name, release|
             next unless current_releases.key?(release_name)
-            @output.puts "  #{release_name} (#{release[:version]})" if release[:version] == current_releases[release_name][:version]            
-        end  
+            @output.puts "  #{release_name} (#{release[:version]})" if release[:version] == current_releases[release_name][:version]
+        end
     end
 
     # Prints changed releases on stdout and details into a report file


### PR DESCRIPTION
## Description

- Bumped CAPI from version 1.78.0+dev.4 to 1.79.0.
- Fixed `dynamic constant assignment (SyntaxError)` on the `releases_diff.rb`.

## Release changelog

- `cc.default_stack` changed from `cflinuxfs2` to `cflinuxfs3`.
- `cc.stacks` changed from `cflinuxfs2` to `cflinuxfs3`.

Both changes are overridden at our `opinions.yml` and `role-manifest.yml`.

## Test plan

All tests should pass.