### PR TITLE
Bump eirini to 0.0.4

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -148,9 +148,9 @@ releases:
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=2.26.0"
   sha1: "f6a6598fbbac233f94c4a0cfe914970ec34db7b3"
 - name: "eirini"
-  url: "https://s3.amazonaws.com/suse-final-releases/eirini-release-0.0.3.tgz"
-  version: "0.0.3"
-  sha1: "96be6dc9e88e32dbdcf58bb6dae5154771911e50"
+  url: "https://s3.amazonaws.com/suse-final-releases/eirini-release-0.0.4.tgz"
+  version: "0.0.4"
+  sha1: "c2766a1da006a7619852937fbf7ca94e99db1a97"
 
 instance_groups:
 - name: eirini


### PR DESCRIPTION
Bumps Eirini to the latest release (0.0.4) : https://github.com/cloudfoundry-community/eirini-bosh-release/releases/tag/0.0.4
