### PR TITLE
bin/common/versions.sh: bump fissile

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+289.g3280187b"
+export FISSILE_VERSION="7.0.0+298.gbac350b1"
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"
 export KUBECTL_VERSION="1.9.6"


### PR DESCRIPTION
## Description

This picks up fissile with a modified readiness probe to not emit as much (typically) useless and misleading output.

## Test plan

Just the normal CI is fine; the fissile change should just outright fail to run if it's that bad.
