### PR TITLE
Bump to stemcell

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -248,7 +248,7 @@ pipeline {
         )
         string(
             name: 'FISSILE_STEMCELL_VERSION',
-            defaultValue: '12SP3-28.g972190a-0.219',
+            defaultValue: '12SP3-32.g4dfa847-0.220',
             description: 'Fissile stemcell version used as docker image tag',
         )
         booleanParam(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -248,7 +248,7 @@ pipeline {
         )
         string(
             name: 'FISSILE_STEMCELL_VERSION',
-            defaultValue: '12SP3-32.g4dfa847-0.220',
+            defaultValue: '12SP3-34.gcdd8986-0.220',
             description: 'Fissile stemcell version used as docker image tag',
         )
         booleanParam(

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -26,7 +26,7 @@ export ISTIO_VERSION="1.0.5"
 export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$//')
 
 # Used in: .envrc
-export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-32.g37e6301-30.80}
+export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-36.g03b4653-30.80}
 
 # Used in: bin/generate-dev-certs.sh
 


### PR DESCRIPTION
## Description

Contains configgin change fixing system getting stuck in HA upgrade.
Ref: https://trello.com/c/DAAtVnaR/1052-14rc2-2161-cap-ha-upgrade-doppler-1-not-coming-up

## Test plan

Deploy 1.3.1 Release in HA mode.
Upgrade to chart build from this PR, still HA mode.
Doppler pods should come up with no problem.
