### PR TITLE
Created and assigned separate service accounts for tests

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2458,7 +2458,7 @@ configuration:
         roles: [configgin-role, test-role]
         cluster-roles: [nonprivileged, test-cluster-role]
       tests-sits:
-        roles: [configgin-role, test-role]
+        roles: [configgin-role]
         cluster-roles: [nonprivileged, test-cluster-role]
       garden-runc:
         roles: [configgin-role]

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1797,7 +1797,7 @@ instance_groups:
             max: 1
           flight-stage: manual
           capabilities: []
-          service-account: tests
+          service-account: tests-brain
 - name: acceptance-tests
   type: bosh-task
   tags:
@@ -1843,7 +1843,7 @@ instance_groups:
             max: 1
           flight-stage: manual
           capabilities: []
-          service-account: tests
+          service-account: tests-sits
   configuration:
     templates:
       properties.sync_integration_tests.bbs.svc.name: diego-api-bbs
@@ -2454,7 +2454,10 @@ configuration:
       secret-generator:
         roles: [configgin-role, secrets-role]
         cluster-roles: [nonprivileged]
-      tests:
+      tests-brain:
+        roles: [configgin-role, test-role]
+        cluster-roles: [nonprivileged, test-cluster-role]
+      tests-sits:
         roles: [configgin-role, test-role]
         cluster-roles: [nonprivileged, test-cluster-role]
       garden-runc:

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2352,7 +2352,7 @@ configuration:
       - apiGroups: [""]
         resources: [configmaps, secrets]
         verbs: [create, get, list, patch, update, delete]
-      test-role:
+      test-role-brain:
       - apiGroups: [""]
         resources: [services]
         verbs: [create, get, delete]
@@ -2455,7 +2455,7 @@ configuration:
         roles: [configgin-role, secrets-role]
         cluster-roles: [nonprivileged]
       tests-brain:
-        roles: [configgin-role, test-role]
+        roles: [configgin-role, test-role-brain]
         cluster-roles: [nonprivileged, test-cluster-role]
       tests-sits:
         roles: [configgin-role]

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2374,6 +2374,10 @@ configuration:
       - apiGroups: [""]
         resources: ["secrets"]
         verbs: [get, list]
+      test-role-sits:
+      - apiGroups: [""]
+        resources: [pods/portforward]
+        verbs: [create]
     cluster-roles:
       node-reader-role:
       - apiGroups: [""]
@@ -2458,8 +2462,8 @@ configuration:
         roles: [configgin-role, test-role-brain]
         cluster-roles: [nonprivileged, test-cluster-role]
       tests-sits:
-        roles: [configgin-role]
-        cluster-roles: [nonprivileged, test-cluster-role]
+        roles: [configgin-role, test-role-sits]
+        cluster-roles: [nonprivileged]
       garden-runc:
         roles: [configgin-role]
         cluster-roles: [privileged, node-reader-role]


### PR DESCRIPTION
## Description

Fixed when a service account was referenced by more than one CF role, the SA definition was included in the Helm chart and not in the bosh-task Kube config file.

## Test plan

Build and check that `//output/kube/bosh-task/acceptance-tests-brain.yaml` and `//output/kube/bosh-task/sync-integration-tests.yaml` both include its own service account.

Check that the generated helm templates don't include test service accounts, roles, cluster roles, and bindings to these roles.