### PR TITLE
Vagrantfile: expose additional environments to the VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -201,7 +201,9 @@ Vagrant.configure(2) do |config|
   SHELL
 
   # Provision the custom config scripts and personal setup.
-  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+  config.vm.provision "shell", privileged: false, env: ENV.select { |e|
+    (!e.start_with? 'VAGRANT_OLD_ENV_') && (%w(FISSILE_ VAGRANT_ SCF_).any? { |prefix| e.start_with? prefix })
+  }, inline: <<-SHELL
     set -o errexit
 
     if [ -d "#{mounted_custom_setup_scripts}/provision.d" ]; then


### PR DESCRIPTION
## Description

This exposes all environment variables starting with `FISSILE_`, `SCF_`, and `VAGRANT_` to the VM.  This is useful for custom setup scripts.

`VAGRANT_OLD_ENV_` is skipped because vagrant puts all environment variables it starts with there.

## Test plan

```sh
host$ export SCF_BLAHBLAH=blah
host$ vagrant up
host$ vagrant ssh
vagrant$ echo $SCF_BLAHBLAH
```
