### PR TITLE
role-manifest: autoscaler-postgres: limit to one replica

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2013,9 +2013,11 @@ instance_groups:
       bosh_containerization:
         run:
           scaling:
+            # The postgres-release BOSH release currently does not support HA; limit this to one replica.
+            # https://github.com/cloudfoundry/postgres-release#known-limitations
             min: 1
-            max: 3
-            ha: 2
+            max: 1
+            ha: 1
           volumes:
           - path: /var/vcap/store
             type: persistent


### PR DESCRIPTION
## Description

The postgres release doesn't currently support HA; limit it to one replica to avoid split-brain issues when scaling up (because they function as independent databases, rather than a cluster).

## Test plan

Run the cluster in HA mode and run the brain tests (in particular, `018_autoscaler`).
