### PR TITLE
Bump fissile, revert change 'storageclass annotation to key'.

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,8 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+315.g9326d8e1"
+export FISSILE_VERSION="7.0.0+317.g8bc11764"
+
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"
 export KUBECTL_VERSION="1.9.6"


### PR DESCRIPTION
## Description

The defered changes for https://trello.com/c/rhJZ3Rqm/1036-dont-use-deprecated-storage-class-key-in-helm-templates were merged into SCF anyway, due to us having merged them into fissile develop and later fissile changes on top then going into SCF, bringing these with them.

This PR bumps fissile to a version where the storage class work has been reverted.

This should fix https://trello.com/c/bfWaFSwT/1072-14rc3-uaa-upgrade-failed

## Test plan

Testing upgrades.
