### PR TITLE
Bumping cf-smoke-tests-release to 40.0.46

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -16,9 +16,9 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.17.0
   sha1: 04cbfafa0a2c11b133da20de8282595c98bc0049
 - name: cf-smoke-tests
-  version: 40.0.44
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=40.0.44
-  sha1: 4f230c07e61bc01d374f9c56eb18dcdb84e29714
+  version: 40.0.46
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=40.0.46
+  sha1: f1614779126730c88e0400a9e9482e6202aaff71
 - name: cf-syslog-drain
   version: "8.1"
   url: "https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=8.1"


### PR DESCRIPTION
## Description

Bumping the smoke-tests in order to get the following fixes:

1. [Defer cleanup so orgs do not leak](https://github.com/cloudfoundry/cf-smoke-tests/commit/f1e1d5cf45236de28c9599c3008066580acd865c)

2. [Proper setup and clean test resources](https://github.com/cloudfoundry/cf-smoke-tests/commit/e260f73b675b9225e299384ab6c9e889743de80c)

## Test plan

Check whether now smoke-tests are failing or not.

**Details:** https://trello.com/c/OYBbILIr/1067-cf-smoke-tests-fail-intermittently-with-no-api-endpoint-set-error

