### PR TITLE
Rebase UAA OAuth client configs

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -519,10 +519,10 @@ properties:
         scope: openid,cloud_controller.read,cloud_controller.write,cloud_controller.admin
       tcp_emitter:
         authorities: routing.routes.write,routing.routes.read
-        authorized-grant-types: client_credentials,refresh_token
+        authorized-grant-types: client_credentials
       tcp_router:
         authorities: routing.routes.read
-        authorized-grant-types: client_credentials,refresh_token
+        authorized-grant-types: client_credentials
     user:
       authorities:
       - openid

--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -457,7 +457,7 @@ properties:
         authorities: cloud_controller.read,cloud_controller.write,cloud_controller.admin
         authorized-grant-types: client_credentials
       cc-service-dashboards:
-        scope: cloud_controller.write,openid,cloud_controller.read,cloud_controller_service_permissions.read
+        scope: cloud_controller_service_permissions.read,openid
         authorities: clients.read,clients.write,clients.admin
         authorized-grant-types: client_credentials
       cc_routing:
@@ -469,11 +469,14 @@ properties:
       cf:
         access-token-validity: 600
         authorities: uaa.none
-        authorized-grant-types: implicit,password,refresh_token
-        autoapprove: true
+        authorized-grant-types: password,refresh_token
         override: true
         refresh-token-validity: 2592000
+        # We don't want scope perm.admin because it's for the perm service
+        # (https://github.com/cloudfoundry-incubator/perm) which is deprecated
+        # as it doesn't work with PXC
         scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor
+        secret: ''
       cf_smoke_tests:
         authorities: cloud_controller.admin
         authorized-grant-types: client_credentials
@@ -481,10 +484,6 @@ properties:
         authorities: cloud_controller.admin,usb.management.admin
         authorized-grant-types: client_credentials
         scope: usb.management.admin
-      cloud_controller:
-        authorized-grant-types: client_credentials
-        authorities: scim.read,scim.write,password.write
-        access-token-validity: 604800
       cloud_controller_username_lookup:
         authorities: scim.userids
         authorized-grant-types: client_credentials
@@ -496,15 +495,12 @@ properties:
         authorized-grant-types: client_credentials
         override: true
       gorouter:
-        authorities: clients.read,clients.write,clients.admin,route.admin,route.advertise,routing.routes.read
-        authorized-grant-types: client_credentials,refresh_token
-        scope: openid,cloud_controller_service_permissions.read
-      login:
-        authorities: oauth.login,scim.write,clients.read,notifications.write,critical_notifications.write,emails.write,scim.userids,password.write
-        authorized-grant-types: authorization_code,client_credentials,refresh_token
-        autoapprove: true
-        override: true
-        scope: openid,oauth.approvals
+        authorities: routing.routes.read
+        authorized-grant-types: client_credentials
+        #scope: openid,cloud_controller_service_permissions.read
+      routing_api_client:
+        authorities: routing.routes.write,routing.routes.read,routing.router_groups.read
+        authorized-grant-types: client_credentials
       scf_auto_config:
         access-token-validity: 600
         # Due to CAPS-969, our UAA clients are missing `autoapprove` and `redirect-uri` configs

--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -493,7 +493,7 @@ properties:
         authorized-grant-types: client_credentials
       doppler:
         authorities: uaa.resource
-        authorized-grant-types: authorization_code,refresh_token
+        authorized-grant-types: client_credentials
         override: true
       gorouter:
         authorities: clients.read,clients.write,clients.admin,route.admin,route.advertise,routing.routes.read

--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -456,12 +456,12 @@ properties:
         # Requires read-only admin to look up stats, and write admin to do scaling
         authorities: cloud_controller.read,cloud_controller.write,cloud_controller.admin
         authorized-grant-types: client_credentials
-      cc_routing:
-        authorities: routing.router_groups.read
-        authorized-grant-types: client_credentials
       cc-service-dashboards:
         scope: cloud_controller.write,openid,cloud_controller.read,cloud_controller_service_permissions.read
         authorities: clients.read,clients.write,clients.admin
+        authorized-grant-types: client_credentials
+      cc_routing:
+        authorities: routing.router_groups.read
         authorized-grant-types: client_credentials
       cc_service_key_client:
         authorities: credhub.read,credhub.write
@@ -496,6 +496,12 @@ properties:
         authorities: clients.read,clients.write,clients.admin,route.admin,route.advertise,routing.routes.read
         authorized-grant-types: client_credentials,refresh_token
         scope: openid,cloud_controller_service_permissions.read
+      login:
+        authorities: oauth.login,scim.write,clients.read,notifications.write,critical_notifications.write,emails.write,scim.userids,password.write
+        authorized-grant-types: authorization_code,client_credentials,refresh_token
+        autoapprove: true
+        override: true
+        scope: openid,oauth.approvals
       scf_auto_config:
         access-token-validity: 600
         # Due to CAPS-969, our UAA clients are missing `autoapprove` and `redirect-uri` configs
@@ -503,12 +509,6 @@ properties:
         # cloud_controller.admin is needed for scf-helper-release/scf-set-proxy job
         authorities: scim.read,scim.write,clients.admin,cloud_controller.admin
         authorized-grant-types: client_credentials
-      login:
-        authorities: oauth.login,scim.write,clients.read,notifications.write,critical_notifications.write,emails.write,scim.userids,password.write
-        authorized-grant-types: authorization_code,client_credentials,refresh_token
-        autoapprove: true
-        override: true
-        scope: openid,oauth.approvals
       ssh-proxy:
         authorized-grant-types: authorization_code
         autoapprove: true

--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -436,7 +436,7 @@ properties:
     skip_cert_verify_external: false
   set_kernel_parameters: false
   smoke_tests:
-    user: 'admin'
+    client: cf_smoke_tests
     org: smoke-test-org
     space: smoke-test-space
     skip_ssl_validation: true
@@ -474,6 +474,9 @@ properties:
         override: true
         refresh-token-validity: 2592000
         scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor
+      cf_smoke_tests:
+        authorities: cloud_controller.admin
+        authorized-grant-types: client_credentials
       cf-usb:
         authorities: cloud_controller.admin,usb.management.admin
         authorized-grant-types: client_credentials

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1885,6 +1885,9 @@ instance_groups:
         run:
           capabilities: [ALL]
         pod-security-policy: privileged
+  configuration:
+    templates:
+      properties.smoke_tests.client_secret: ((UAA_CLIENTS_CF_SMOKE_TESTS_CLIENT_SECRET))
 - name: secret-generation
   type: bosh-task
   jobs:
@@ -2998,6 +3001,7 @@ configuration:
     properties.uaa.clients.cc_service_key_client.secret: '"((UAA_CLIENTS_CC_SERVICE_KEY_CLIENT_SECRET))"'
     properties.uaa.clients.cf-usb.secret: '"((UAA_CLIENTS_CF_USB_SECRET))"'
     properties.uaa.clients.cf.redirect-uri: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))/login
+    properties.uaa.clients.cf_smoke_tests.secret: ((UAA_CLIENTS_CF_SMOKE_TESTS_CLIENT_SECRET))
     properties.uaa.clients.cloud_controller.secret: ((UAA_CC_CLIENT_SECRET))
     properties.uaa.clients.cloud_controller_username_lookup.secret: '"((UAA_CLIENTS_CLOUD_CONTROLLER_USERNAME_LOOKUP_SECRET))"'
     properties.uaa.clients.credhub_user_cli.secret: '"((UAA_CLIENTS_CREDHUB_USER_CLI_SECRET))"'
@@ -4704,6 +4708,12 @@ variables:
   options:
     secret: true
     description: Used for fetching service key values from CredHub.
+    required: true
+  type: password
+- name: UAA_CLIENTS_CF_SMOKE_TESTS_CLIENT_SECRET
+  options:
+    secret: true
+    description: Client secret for the CF smoke tests job
     required: true
   type: password
 - name: UAA_CLIENTS_CF_USB_SECRET

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -3002,14 +3002,12 @@ configuration:
     properties.uaa.clients.cf-usb.secret: '"((UAA_CLIENTS_CF_USB_SECRET))"'
     properties.uaa.clients.cf.redirect-uri: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))/login
     properties.uaa.clients.cf_smoke_tests.secret: ((UAA_CLIENTS_CF_SMOKE_TESTS_CLIENT_SECRET))
-    properties.uaa.clients.cloud_controller.secret: ((UAA_CC_CLIENT_SECRET))
     properties.uaa.clients.cloud_controller_username_lookup.secret: '"((UAA_CLIENTS_CLOUD_CONTROLLER_USERNAME_LOOKUP_SECRET))"'
     properties.uaa.clients.credhub_user_cli.secret: '"((UAA_CLIENTS_CREDHUB_USER_CLI_SECRET))"'
     properties.uaa.clients.doppler.redirect-uri: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
     properties.uaa.clients.doppler.secret: '"((UAA_CLIENTS_DOPPLER_SECRET))"'
     properties.uaa.clients.gorouter.secret: '"((UAA_CLIENTS_GOROUTER_SECRET))"'
-    properties.uaa.clients.login.redirect-uri: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
-    properties.uaa.clients.login.secret: '"((UAA_CLIENTS_LOGIN_SECRET))"'
+    properties.uaa.clients.routing_api_client.secret: ((UAA_CLIENTS_ROUTING_API_CLIENT_SECRET))
     properties.uaa.clients.scf_auto_config.secret: '"((UAA_CLIENTS_SCF_AUTO_CONFIG_SECRET))"'
     properties.uaa.clients.ssh-proxy.redirect-uri: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))/login
     properties.uaa.clients.ssh-proxy.secret: '"((UAA_CLIENTS_DIEGO_SSH_PROXY_SECRET))"'
@@ -4687,12 +4685,6 @@ variables:
   options:
     description: The CA certificate for UAA
     secret: true
-- name: UAA_CC_CLIENT_SECRET
-  options:
-    secret: true
-    description: The password for UAA access by the Cloud Controller.
-    required: true
-  type: password
 - name: UAA_CLIENTS_CC_ROUTING_SECRET
   options:
     secret: true
@@ -4752,10 +4744,10 @@ variables:
     description: The password for UAA access by the gorouter.
     required: true
   type: password
-- name: UAA_CLIENTS_LOGIN_SECRET
+- name: UAA_CLIENTS_ROUTING_API_CLIENT_SECRET
   options:
     secret: true
-    description: The password for UAA access by the login client.
+    description: The OAuth client secret used by the routing-api.
     required: true
   type: password
 - name: UAA_CLIENTS_SCF_AUTO_CONFIG_SECRET


### PR DESCRIPTION
## Description

Our UAA OAuth clients configuration has diverged from upstream; sync up again.

## Test plan

This should pass CATS.

We will need a separate PR to ensure we do not diverge more from upstream in further CF bumps.

## Additional notes

A few of the differences are ignored:
- Upstream does not have `app_autoscaler` client (because that's not in cf-deployment)
- Upstream does not have `cf-usb` client
- Upstream does not have `scf_auto_config`
- Upstream does not have `credhub_user_cli` client
- Upstream _does_ have `credhub_admin_client` that we intentionally don't have
- We do not have `network-policy` (that's part of cf-networking)
- We do not have the `perm.admin` scope for the CF CLI (we never got that release, and it's already deprecated for being incompatible with PXC).