### PR TITLE
[WIP] Add Eirini extensions and Eirini persi broker

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -180,6 +180,10 @@ instance_groups:
             ha: 1
           memory: 256
           virtual-cpus: 2
+        ports:
+        - name: broker
+          protocol: TCP
+          internal: 8999
   - name: eirini-extensions
     release: eirini
     properties:
@@ -1631,6 +1635,7 @@ instance_groups:
           protocol: TCP
           internal: 8080
 - name: nfs-broker
+  unless_feature: eirini
   environment_scripts:
   - scripts/go_log_level.sh
   scripts:
@@ -2869,14 +2874,15 @@ configuration:
     properties.diego.ssh_proxy.uaa.url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST))
     properties.diego.ssh_proxy.uaa_secret: '"((UAA_CLIENTS_DIEGO_SSH_PROXY_SECRET))"'
     properties.domain: '"((DOMAIN))"'
-
     properties.eirini-extensions.kube_service_host: "((KUBERNETES_SERVICE_HOST))"
     properties.eirini-extensions.kube_service_port: "((KUBERNETES_SERVICE_PORT))"
     properties.eirini-extensions.namespace: "((EIRINI_KUBE_NAMESPACE))"
-    properties.eirini-extensions.operator_webhook_host: "eirini-eirini-extensions.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"
+    properties.eirini-persi-broker.auth_password: '"((EIRINI_PERSI_NFS_BROKER_PASSWORD))"'
     properties.eirini-persi-broker.kube_service_host: "((KUBERNETES_SERVICE_HOST))"
     properties.eirini-persi-broker.kube_service_port: "((KUBERNETES_SERVICE_PORT))"
     properties.eirini-persi-broker.namespace: "((EIRINI_KUBE_NAMESPACE))"
+    properties.eirini-persi-broker.service_plans: '[{"id" :"default-storageclass", "name":"default", "description":"Eirini persistence broker", "free": true, "kube_storage_class": "((KUBERNETES_STORAGE_CLASS_PERSISTENT))", "default_size": "1Gi" }]'
+    properties.eirini-persi-broker.url: 'http://eirini-eirini-persi-broker.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8999'
 
     properties.fissile.monit.password: '"((MONIT_PASSWORD))"'
     properties.garden.apparmor_profile: '"((GARDEN_APPARMOR_PROFILE))"' # Quoting needed to pass through empty string
@@ -4034,6 +4040,12 @@ variables:
   options:
     default: 'eirini'
     description: "The namespace used by Eirini for deploying applications."
+- name: EIRINI_PERSI_NFS_BROKER_PASSWORD
+  options:
+    description: Basic auth password to verify on incoming Service Broker requests
+    secret: true
+    required: true
+  type: password
 - name: ENABLE_SECURITY_EVENT_LOGGING
   options:
     default: 'false'

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2877,6 +2877,7 @@ configuration:
     properties.eirini-extensions.kube_service_host: "((KUBERNETES_SERVICE_HOST))"
     properties.eirini-extensions.kube_service_port: "((KUBERNETES_SERVICE_PORT))"
     properties.eirini-extensions.namespace: "((EIRINI_KUBE_NAMESPACE))"
+    properties.eirini-extensions.operator_webhook_host: "((EIRINI_EIRINI_EXTENSIONS_SERVICE_HOST))"
     properties.eirini-persi-broker.auth_password: '"((EIRINI_PERSI_NFS_BROKER_PASSWORD))"'
     properties.eirini-persi-broker.kube_service_host: "((KUBERNETES_SERVICE_HOST))"
     properties.eirini-persi-broker.kube_service_port: "((KUBERNETES_SERVICE_PORT))"
@@ -4024,6 +4025,10 @@ variables:
   options:
     default: 'splatform/eirini-cert-copier:1.0.0.4.gd8e7208'
     description: "The docker image used by Eirini to register the image registry CA cert with Docker, on each Kubernetes node"
+- name: EIRINI_EIRINI_EXTENSIONS_SERVICE_HOST
+  options:
+    type: environment
+    description: "The Eirini extensions service ClusterIP"
 - name: EIRINI_FLUENTD_IMAGE
   options:
     default: 'eirini/loggregator-fluentd:0.1.0'

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -4028,7 +4028,7 @@ variables:
 - name: EIRINI_EIRINI_EXTENSIONS_SERVICE_HOST
   options:
     type: environment
-    description: "The Eirini extensions service ClusterIP"
+    description: "The Eirini extensions service ClusterIP (automatically set by Kubernetes)"
 - name: EIRINI_FLUENTD_IMAGE
   options:
     default: 'eirini/loggregator-fluentd:0.1.0'

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -4053,6 +4053,7 @@ variables:
 - name: EIRINI_PERSI_PLANS
   options:
     description: "Array of plans that the Eirini persi broker will expose to Cloud Foundry."
+    default: '[]'
     example: |
       - id: "dafault-storageclass"
         name: "default"

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2882,9 +2882,8 @@ configuration:
     properties.eirini-persi-broker.kube_service_host: "((KUBERNETES_SERVICE_HOST))"
     properties.eirini-persi-broker.kube_service_port: "((KUBERNETES_SERVICE_PORT))"
     properties.eirini-persi-broker.namespace: "((EIRINI_KUBE_NAMESPACE))"
-    properties.eirini-persi-broker.service_plans: '[{"id" :"default-storageclass", "name":"default", "description":"Eirini persistence broker", "free": true, "kube_storage_class": "((KUBERNETES_STORAGE_CLASS_PERSISTENT))", "default_size": "1Gi" }]'
+    properties.eirini-persi-broker.service_plans: '((EIRINI_PERSI_PLANS))'
     properties.eirini-persi-broker.url: 'http://eirini-eirini-persi-broker.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8999'
-
     properties.fissile.monit.password: '"((MONIT_PASSWORD))"'
     properties.garden.apparmor_profile: '"((GARDEN_APPARMOR_PROFILE))"' # Quoting needed to pass through empty string
     properties.garden.btrfs-active: "((^GARDEN_DISABLE_BTRFS))true((/GARDEN_DISABLE_BTRFS))"
@@ -4051,6 +4050,16 @@ variables:
     secret: true
     required: true
   type: password
+- name: EIRINI_PERSI_PLANS
+  options:
+    description: "Array of plans that the Eirini persi broker will expose to Cloud Foundry."
+    example: |
+      - id: "dafault-storageclass"
+        name: "default"
+        description: "Eirini persistence broker"
+        free: true
+        kube_storage_class: "persistent"
+        default_size: "1Gi"
 - name: ENABLE_SECURITY_EVENT_LOGGING
   options:
     default: 'false'

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -168,6 +168,34 @@ instance_groups:
     release: scf
   - name: patch-properties
     release: scf-helper
+  - name: eirini-persi-broker
+    release: eirini
+    properties:
+      bosh_containerization:
+        pod-security-policy: privileged
+        run:
+          scaling:
+            min: 1
+            max: 1
+            ha: 1
+          memory: 256
+          virtual-cpus: 2
+  - name: eirini-extensions
+    release: eirini
+    properties:
+      bosh_containerization:
+        pod-security-policy: privileged
+        run:
+          scaling:
+            min: 1
+            max: 1
+            ha: 1
+          memory: 256
+          virtual-cpus: 2
+        ports:
+        - name: webhook
+          protocol: TCP
+          internal: 2999
   - name: opi
     release: eirini
     properties:
@@ -2841,6 +2869,15 @@ configuration:
     properties.diego.ssh_proxy.uaa.url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST))
     properties.diego.ssh_proxy.uaa_secret: '"((UAA_CLIENTS_DIEGO_SSH_PROXY_SECRET))"'
     properties.domain: '"((DOMAIN))"'
+
+    properties.eirini-extensions.kube_service_host: "((KUBERNETES_SERVICE_HOST))"
+    properties.eirini-extensions.kube_service_port: "((KUBERNETES_SERVICE_PORT))"
+    properties.eirini-extensions.namespace: "((EIRINI_KUBE_NAMESPACE))"
+    properties.eirini-extensions.operator_webhook_host: "eirini-eirini-extensions.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"
+    properties.eirini-persi-broker.kube_service_host: "((KUBERNETES_SERVICE_HOST))"
+    properties.eirini-persi-broker.kube_service_port: "((KUBERNETES_SERVICE_PORT))"
+    properties.eirini-persi-broker.namespace: "((EIRINI_KUBE_NAMESPACE))"
+
     properties.fissile.monit.password: '"((MONIT_PASSWORD))"'
     properties.garden.apparmor_profile: '"((GARDEN_APPARMOR_PROFILE))"' # Quoting needed to pass through empty string
     properties.garden.btrfs-active: "((^GARDEN_DISABLE_BTRFS))true((/GARDEN_DISABLE_BTRFS))"

--- a/make/run-eirini
+++ b/make/run-eirini
@@ -4,4 +4,12 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-${GIT_ROOT}/make/run --set "enable.eirini=true"
+source "${GIT_ROOT}/make/include/defaults"
+
+${GIT_ROOT}/make/run --set "enable.eirini=true" \
+                     --set "env.EIRINI_PERSI_PLANS[0].id=default-storageclass" \
+                     --set "env.EIRINI_PERSI_PLANS[0].description=Eirini persistence broker" \
+                     --set "env.EIRINI_PERSI_PLANS[0].free=true" \
+                     --set "env.EIRINI_PERSI_PLANS[0].kube_storage_class=${STORAGE_CLASS}" \
+                     --set "env.EIRINI_PERSI_PLANS[0].default_size=1Gi" \
+                     --set "env.EIRINI_PERSI_PLANS[0].name=default"

--- a/src/scf-release/jobs/configure-scf/spec
+++ b/src/scf-release/jobs/configure-scf/spec
@@ -80,3 +80,5 @@ properties:
     default: "admin"
   eirini-persi-broker.auth_password:
     description: "basic auth password to verify on incoming Service Broker requests"
+  eirini-persi-broker.service_plans:
+    description: 'Broker service plans'

--- a/src/scf-release/jobs/configure-scf/spec
+++ b/src/scf-release/jobs/configure-scf/spec
@@ -73,3 +73,10 @@ properties:
     description: "Eirini's image registry public address"
   scf.eirini.enabled:
     description: "Whether Eirini is enabled or not"
+  eirini-persi-broker.url:
+    description: 'Internal URL of the Persi NFS broker'
+  eirini-persi-broker.auth_username:
+    description: "basic auth username to verify on incoming Service Broker requests"
+    default: "admin"
+  eirini-persi-broker.auth_password:
+    description: "basic auth password to verify on incoming Service Broker requests"

--- a/src/scf-release/jobs/configure-scf/templates/run.erb
+++ b/src/scf-release/jobs/configure-scf/templates/run.erb
@@ -109,6 +109,7 @@ status "Setting of external proxies complete."
 BROKER_URL='<%= p("eirini-persi-broker.url") %>'
 BROKER_USERNAME='<%= p("eirini-persi-broker.auth_username") %>'
 BROKER_PASSWORD='<%= p("eirini-persi-broker.auth_password") %>'
+BROKER_PLANS='<%= p("eirini-persi-broker.service_plans") %>'
 BROKER_NAME='eirini-persi-broker'
 
 <% else %>
@@ -120,22 +121,25 @@ BROKER_NAME='persi-nfs-broker'
 
 <% end %>
 
-status "Waiting for persi $BROKER_NAME to be available..."
+# If we are using eirini-persi, configure the broker only if plans were defined
+if [ "$BROKER_NAME" != "eirini-persi-broker" ] || [ "$BROKER_PLANS" != "[]" ]; then
+   status "Waiting for persi $BROKER_NAME to be available..."
 
-CATALOG_REQUEST=(
-   curl "${SILENT}"
-   --connect-timeout 5
-   --fail
-   --header 'Accept: application/json'
-   --header 'X-Broker-API-Version: 2.14'
-   -u "${BROKER_USERNAME}:${BROKER_PASSWORD}"
-   "${BROKER_URL}/v2/catalog"
-)
-retry 240 30s "${CATALOG_REQUEST[@]}"
+   CATALOG_REQUEST=(
+      curl "${SILENT}"
+      --connect-timeout 5
+      --fail
+      --header 'Accept: application/json'
+      --header 'X-Broker-API-Version: 2.14'
+      -u "${BROKER_USERNAME}:${BROKER_PASSWORD}"
+      "${BROKER_URL}/v2/catalog"
+   )
+   retry 240 30s "${CATALOG_REQUEST[@]}"
 
-cf create-service-broker "$BROKER_NAME" "$BROKER_USERNAME" "$BROKER_PASSWORD" "$BROKER_URL" || cf update-service-broker "$BROKER_NAME" "$BROKER_USERNAME" "$BROKER_PASSWORD" "$BROKER_URL"
+   cf create-service-broker "$BROKER_NAME" "$BROKER_USERNAME" "$BROKER_PASSWORD" "$BROKER_URL" || cf update-service-broker "$BROKER_NAME" "$BROKER_USERNAME" "$BROKER_PASSWORD" "$BROKER_URL"
 
-status "$BROKER_NAME configuration complete."
+   status "$BROKER_NAME configuration complete."
+fi
 
 status "Remove temporary users"
 remove_temporary_users.rb "${API_ENDPOINT}" "${CURL_SKIP}"

--- a/src/scf-release/jobs/configure-scf/templates/run.erb
+++ b/src/scf-release/jobs/configure-scf/templates/run.erb
@@ -104,12 +104,23 @@ end %>
 
 status "Setting of external proxies complete."
 
+<% if p("scf.eirini.enabled") %>
 
-status "Waiting for persi NFS broker to be available..."
+BROKER_URL='<%= p("eirini-persi-broker.url") %>'
+BROKER_USERNAME='<%= p("eirini-persi-broker.auth_username") %>'
+BROKER_PASSWORD='<%= p("eirini-persi-broker.auth_password") %>'
+BROKER_NAME='eirini-persi-broker'
 
-NFS_BROKER_URL='<%= p("nfsbroker.url") %>'
-NFS_BROKER_USERNAME='<%= p("nfsbroker.username") %>'
-NFS_BROKER_PASSWORD='<%= p("nfsbroker.password") %>'
+<% else %>
+
+BROKER_URL='<%= p("nfsbroker.url") %>'
+BROKER_USERNAME='<%= p("nfsbroker.username") %>'
+BROKER_PASSWORD='<%= p("nfsbroker.password") %>'
+BROKER_NAME='persi-nfs-broker'
+
+<% end %>
+
+status "Waiting for persi $BROKER_NAME to be available..."
 
 CATALOG_REQUEST=(
    curl "${SILENT}"
@@ -117,14 +128,14 @@ CATALOG_REQUEST=(
    --fail
    --header 'Accept: application/json'
    --header 'X-Broker-API-Version: 2.14'
-   -u "${NFS_BROKER_USERNAME}:${NFS_BROKER_PASSWORD}"
-   "${NFS_BROKER_URL}/v2/catalog"
+   -u "${BROKER_USERNAME}:${BROKER_PASSWORD}"
+   "${BROKER_URL}/v2/catalog"
 )
 retry 240 30s "${CATALOG_REQUEST[@]}"
 
-cf create-service-broker persi-nfs-broker "$NFS_BROKER_USERNAME" "$NFS_BROKER_PASSWORD" "$NFS_BROKER_URL" || cf update-service-broker persi-nfs-broker "$NFS_BROKER_USERNAME" "$NFS_BROKER_PASSWORD" "$NFS_BROKER_URL"
+cf create-service-broker "$BROKER_NAME" "$BROKER_USERNAME" "$BROKER_PASSWORD" "$BROKER_URL" || cf update-service-broker "$BROKER_NAME" "$BROKER_USERNAME" "$BROKER_PASSWORD" "$BROKER_URL"
 
-status "Persi NFS configuration complete."
+status "$BROKER_NAME configuration complete."
 
 status "Remove temporary users"
 remove_temporary_users.rb "${API_ENDPOINT}" "${CURL_SKIP}"


### PR DESCRIPTION
## Description

* Adds eirini-extensions and eirini-persi-broker jobs to the eirini pod
* Disables nfs-persi and enables eirini-persi-broker in postdeployment steps if eirini is enabled

## Test plan

```
$> make vagrant-prep
$> make run-eirini
$> git clone https://github.com/scf-samples/dizzylizard.git
$> cd dizzylizard
$> cf push --no-start
$> cf service-brokers
# You should see eirini-persi
$> cf enable-service-access eirini-persi
$> cf marketplace -s eirini-persi 
# Default plan should be available, based on the storageclass used for install

# Each service corresponds to a volume mount for the app, in this case mounting 2 volumes:
$> cf create-service eirini-persi default eirini-persi-1
$> cf create-service eirini-persi default eirini-persi-2
$> cf bind-service dizzylizard eirini-persi-1
$> cf bind-service dizzylizard eirini-persi-2

$> cf start dizzylizard 
# If you ssh to the app you would see in the env VCAP_SERVICES 
# the paths in the container which gives you access to the volumes

$> kubectl get pvc -n eirini
# Verifies the Persistent volume claims are bound (similarly for deletion)
```
