### PR TITLE
Replacing minibroker repo with a curated repo

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -37,7 +37,7 @@ class MiniBrokerTest
     attr_lazy(:sec_group) { random_suffix('sec-group', 'CF_SEC_GROUP') }
     attr_lazy(:broker_name) { random_suffix('minibroker', 'CF_BROKER') }
     attr_lazy(:minibroker_repo) { ENV.fetch('MINIBROKER_REPO', 'https://minibroker-helm-charts.s3.amazonaws.com/minibroker-charts/') }
-    attr_lazy(:kubernetes_repo) { ENV.fetch('KUBERNETES_REPO', 'https://minibroker-helm-charts.s3.amazonaws.com/kubernetes-charts/') }
+    attr_lazy(:kubernetes_repo) { ENV.fetch('KUBERNETES_REPO', 'https://minibroker-charts.s3.amazonaws.com/kubernetes-charts/') }
     attr_lazy(:helm_release) { random_suffix('minibroker') }
     attr_lazy(:minibroker_namespace) { random_suffix('minibroker') }
     attr_lazy(:minibroker_pods_namespace) { random_suffix('minibroker-pod') }


### PR DESCRIPTION
## Description

This change is to replace minibroker Kubernetes repo with a curated repo where all known working versions of the minibroker databases are placed.

**Details:** https://trello.com/c/iIrYZZY7/1068-5-curate-minibroker-service-plans-that-work-with-cap

## Test plan

Make sure all minibroker brains tests are passing
