### PR TITLE
[#Las6AWFG] Bump default for cluster version returned by the v2/info endpoint

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -4575,7 +4575,7 @@ variables:
   type: password
 - name: SUPPORT_ADDRESS
   options:
-    default: support@example.com
+    default: https://scc.suse.com
     description: Support contact information for the cluster
     required: true
 - name: SYNC_INTEGRATION_TESTS_FOCUS

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -3827,7 +3827,7 @@ variables:
     required: true
 - name: CLUSTER_BUILD
   options:
-    default: 2.0.2
+    default: 2.16.4
     description: "'build' attribute in the /v2/info endpoint"
     required: true
 - name: CLUSTER_DESCRIPTION


### PR DESCRIPTION
## Description

See https://trello.com/c/Las6AWFG/1080-cf-v2-info-metadata-is-inaccurate

## Test plan

  - Start a vagrant box.
  - Build SCF
  - Start cluster
  - Target cluster, then `cf curl v2/info` and check that the information is correct.
