### PR TITLE
Fixed Vagrantfile when VirtualBox is not installed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,8 +82,8 @@ Vagrant.configure(2) do |config|
 
     vb.customize ['modifyvm', :id, '--paravirtprovider', 'minimal']
 
-    default_machine_folder = `VBoxManage list systemproperties | grep "Default machine folder"`
-    vb_machine_folder = default_machine_folder.split(':')[1].strip()
+    default_machine_folder = `(which VBoxManage 1> /dev/null 2> /dev/null && (VBoxManage list systemproperties | grep "Default machine folder" | sed "s/Default machine folder://")) || echo "/tmp"`
+    vb_machine_folder = default_machine_folder.strip()
 
     # Create and attach a disk for Fissile cache.
     fissile_cache_disk_file = "disk_fissile_cache_#{SecureRandom.hex(16)}.vdi"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,12 +82,11 @@ Vagrant.configure(2) do |config|
 
     vb.customize ['modifyvm', :id, '--paravirtprovider', 'minimal']
 
-    default_machine_folder = `(which VBoxManage 1> /dev/null 2> /dev/null && (VBoxManage list systemproperties | grep "Default machine folder" | sed "s/Default machine folder://")) || echo "/tmp"`
-    vb_machine_folder = default_machine_folder.strip()
+    disks_folder = File.join(".vagrant", "disks")
 
     # Create and attach a disk for Fissile cache.
     fissile_cache_disk_file = "disk_fissile_cache_#{SecureRandom.hex(16)}.vdi"
-    fissile_cache_disk = File.join(vb_machine_folder, fissile_cache_disk_file)
+    fissile_cache_disk = File.join(disks_folder, fissile_cache_disk_file)
     unless File.exist?(fissile_cache_disk)
       vb.customize ['createhd', '--filename', fissile_cache_disk, '--format', 'VDI', '--size', FISSILE_CACHE_SIZE * 1024]
     end
@@ -101,7 +100,7 @@ Vagrant.configure(2) do |config|
 
     # Create and attach a disk for Kubernetes hostPath.
     k8s_hostPath_disk_file = "disk_k8s_hostPath_#{SecureRandom.hex(16)}.vdi"
-    k8s_hostPath_disk = File.join(vb_machine_folder, k8s_hostPath_disk_file)
+    k8s_hostPath_disk = File.join(disks_folder, k8s_hostPath_disk_file)
     unless File.exist?(k8s_hostPath_disk)
       vb.customize ['createhd', '--filename', k8s_hostPath_disk, '--format', 'VDI', '--size', KUBERNETES_HOSTPATH_SIZE * 1024]
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,7 +82,7 @@ Vagrant.configure(2) do |config|
 
     vb.customize ['modifyvm', :id, '--paravirtprovider', 'minimal']
 
-    disks_folder = File.join(".vagrant", "disks")
+    disks_folder = File.join(Dir.home, ".vagrant.d", "disks")
 
     # Create and attach a disk for Fissile cache.
     fissile_cache_disk_file = "disk_fissile_cache_#{SecureRandom.hex(16)}.vdi"


### PR DESCRIPTION
## Description

Use the vagrant directory to store the disk files.

## Test plan

Provision a Vagrant machine on a Linux host with libvirt, that doesn't have VirtualBox installed. And provision with VirtualBox as well to make sure it works as expected.
