### PR TITLE
Remove all references to cflinuxfs2

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -188,7 +188,6 @@ properties:
       lifecycle_bundles:
         'buildpack/sle15':      "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
         'buildpack/sle12':      "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
-        'buildpack/cflinuxfs2': "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
         'buildpack/cflinuxfs3': "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
         docker:                 "docker_app_lifecycle/docker_app_lifecycle.tgz"
     droplets:
@@ -261,8 +260,6 @@ properties:
         ports: "53"
         protocol: udp
     stacks:
-    - name: "cflinuxfs2"
-      description: "Cloud Foundry Linux-based filesystem"
     - name: "cflinuxfs3"
       description: "Cloud Foundry Linux-based filesystem"
     - name: "sle12"
@@ -348,7 +345,6 @@ properties:
       preloaded_rootfses:
       - "sle15:/var/vcap/packages/sle15/rootfs.tar"
       - "sle12:/var/vcap/packages/cf-sle12/rootfs.tar"
-      - "cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs.tar"
       - "cflinuxfs3:/var/vcap/packages/cflinuxfs3/rootfs.tar"
     route_emitter:
       local_mode: true
@@ -372,7 +368,7 @@ properties:
     listen_address: 0.0.0.0:7777
     listen_network: tcp
   grootfs:
-    # Garden should at least be able to cache the cflinuxfs2 rootfs
+    # Garden should at least be able to cache the cflinuxfs3 rootfs
     # to avoid copy operations on every garden healthcheck from rep
     # when there is no app running with the healthcheck rootfs.
     reserved_space_for_other_jobs_in_mb: 3000

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -23,10 +23,6 @@ releases:
   version: "9.0"
   url: "https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=9.0"
   sha1: "6971d973abb4710428784d91834850171e93ca20"
-- name: cflinuxfs2
-  url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.281.0"
-  version: "1.281.0"
-  sha1: "1bdcf24c1fb9baf324aebab8ba28f8e64b846305"
 - name: cflinuxfs3
   url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs3-release?v=0.92.0"
   version: "0.92.0"
@@ -1854,8 +1850,6 @@ instance_groups:
                   topologyKey: "beta.kubernetes.io/os"
   - name: groot-btrfs
     release: groot-btrfs
-  - name: cflinuxfs2-rootfs-setup
-    release: cflinuxfs2
   - name: cflinuxfs3-rootfs-setup
     release: cflinuxfs3
   - name: cf-sle12-setup
@@ -2888,7 +2882,6 @@ configuration:
     properties.cf-usb.mysql_address: 'mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))'
     properties.cf-usb.mysql_password: "((CF_USB_DATABASE_PASSWORD))"
     properties.cf.insecure_api_url: http://api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):9022 # For post-deployment-setup, because cf cli has no client certs.
-    properties.cflinuxfs2-rootfs.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))((#ROOTFS_TRUSTED_CERTS))\n((/ROOTFS_TRUSTED_CERTS))((INTERNAL_CA_CERT))"'
     properties.cflinuxfs3-rootfs.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))((#ROOTFS_TRUSTED_CERTS))\n((/ROOTFS_TRUSTED_CERTS))((INTERNAL_CA_CERT))"'
     properties.containers.trusted_ca_certificates: '((#TRUSTED_CERTS))[((TRUSTED_CERTS))]((/TRUSTED_CERTS))'
     properties.copilot.client_ca_file: ((INTERNAL_CA_CERT))

--- a/make/tar-sources
+++ b/make/tar-sources
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset
 
-DIRECTORY_BLACKLIST=".*-buildpack|cflinuxfs2|cflinuxfs3|sle12|sle15|opensuse42|opensuse15|busybox|golang.*"
+DIRECTORY_BLACKLIST=".*-buildpack|cflinuxfs3|sle12|sle15|opensuse42|opensuse15|busybox|golang.*"
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 BASEDIR="$FISSILE_WORK_DIR/compilation"


### PR DESCRIPTION
## Description
cflinuxfs2 is no longer supported upstream and is removed. This PR removes it from scf.

## Test plan

Wait for CI to build this PR. Deploy it on some k8s cluster and run `cf stacks`. There should be no cflinuxfs2 listed.
