### PR TITLE
Added ability to override the standard timeout for brain tests via environment variable `TIMEOUT`.

### DIFF
--- a/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
@@ -48,13 +48,7 @@ for i in "${ASSETS}/plugins/"*; do
 done
 shopt -u nullglob
 
-PARAM=""
-
-if [ -n "${TIMEOUT}" ]; then
-    PARAM="${PARAM} --timeout ${TIMEOUT}"
-else
-    PARAM="${PARAM} --timeout 600"
-fi
+PARAM="--timeout ${TIMEOUT:-600}"
 
 if [[ "${VERBOSE}" == "true" || "${VERBOSE}" == "1" ]]; then
     PARAM="${PARAM} --verbose"

--- a/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests-brain/templates/run.erb
@@ -48,7 +48,13 @@ for i in "${ASSETS}/plugins/"*; do
 done
 shopt -u nullglob
 
-PARAM="--timeout 600"
+PARAM=""
+
+if [ -n "${TIMEOUT}" ]; then
+    PARAM="${PARAM} --timeout ${TIMEOUT}"
+else
+    PARAM="${PARAM} --timeout 600"
+fi
 
 if [[ "${VERBOSE}" == "true" || "${VERBOSE}" == "1" ]]; then
     PARAM="${PARAM} --verbose"


### PR DESCRIPTION
## Description

See https://trello.com/c/QeitO7T1/1086-all-minibroker-tests-will-fail-on-gke-and-possibly-other-platforms-due-to-timing-issue-in-brains-minibrokerhelperrb-library

This is a supporting change, not a fix.
It enables us to tailor the brain test timeout to the environment a cluster is running in.

## Test plan

  - Check PR out
  - Build SCF in Vagrant
  - Start cluster
  - Run brain tests with a command like
    > make/tests acceptance-tests-brain env.**TIMEOUT=2400**
  - Check the log output for the test to contain a line like
    > testbrain run **--timeout 2400** /var/vcap/packages/acceptance-tests-brain/test-scripts

Important parts highlighted.



