### PR TITLE
bump istio from 1.0.5 to 1.1.5

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -21,7 +21,7 @@ export UBUNTU_VERSION="14.04"
 
 # Used in: make/install-istio
 
-export ISTIO_VERSION="1.0.5"
+export ISTIO_VERSION="1.1.5"
 
 # For stampy we need the major+minor+patch as a separate value.
 export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$//')

--- a/make/include/defaults
+++ b/make/include/defaults
@@ -34,6 +34,7 @@ export UAA_CLIENT_ID=cf
 
 : "${ISTIO_NAMESPACE:=istio-system}"
 : "${ISTIO_HELM_RELEASE:=istio}"
+: "${ISTIO_INIT_HELM_RELEASE:=istio-init}"
 
 : "${NGINX_INGRESS_CHART:=suse/nginx-ingress}"
 : "${NGINX_INGRESS_NAMESPACE:=nginx-ingress}"

--- a/make/istio/run
+++ b/make/istio/run
@@ -16,11 +16,36 @@ if [ ! -d "$istio_path" ]; then
     | tar zx -C "${istio_path}" --strip-components=1
 fi
 
+istio_init_chart="${istio_path}/install/kubernetes/helm/istio-init"
+istio_chart="${istio_path}/install/kubernetes/helm/istio"
 
-chart="${istio_path}/install/kubernetes/helm/istio"
+# Install all the Istio Custom Resource Definitions.
+istio_init_args=(
+  "${ISTIO_INIT_HELM_RELEASE}"
+  --namespace "${ISTIO_NAMESPACE}"
+  --timeout 900 
+)
+helm upgrade --install --wait "${istio_init_args[@]}" "${istio_init_chart}"
 
 # Install the Istio Helm chart.
-args=(
+# Create kiali secret.
+kiali_username_encoded=$(echo -n "${KIALI_USERNAME:-admin}" | base64)
+kiali_passphrase_encoded=$(echo -n "${KIALI_PASSPHRASE:-admin}" | base64)
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kiali
+  namespace: ${ISTIO_NAMESPACE}
+  labels:
+    app: kiali
+type: Opaque
+data:
+  username: ${kiali_username_encoded}
+  passphrase: ${kiali_passphrase_encoded}
+EOF
+
+istio_args=(
   "${ISTIO_HELM_RELEASE}"
   --namespace "${ISTIO_NAMESPACE}"
   --timeout 1800
@@ -28,12 +53,12 @@ args=(
 
 values=(
   --set "gateways.istio-ingressgateway.type=NodePort"
-  --set "gateways.istio-egressgateway.enabled=false"
   --set "tracing.enabled=true"
   --set "grafana.enabled=true"
+  --set "kiali.enabled=true"
 )
 
-helm upgrade --install "${args[@]}" "${chart}" "${values[@]}"
+helm upgrade --install "${istio_args[@]}" "${istio_chart}" "${values[@]}"
 
 path_with_istio="PATH=\"${istio_path}/bin:\${PATH}\""
 printf "Done. You might want to 'export %s' to get Istio binaries onto your \$PATH.\\n" "${path_with_istio}"

--- a/make/istio/stop
+++ b/make/istio/stop
@@ -7,8 +7,12 @@ source "${GIT_ROOT}/make/include/has_namespace"
 source "${GIT_ROOT}/make/include/has_release"
 source "${GIT_ROOT}/make/include/defaults"
 
-printf "Stopping and cleaning up %s release...\\n" "${ISTIO_HELM_RELEASE}"
+printf "Stopping and cleaning up %s release...\\n" "${ISTIO_INIT_HELM_RELEASE}"
+if has_release "${ISTIO_INIT_HELM_RELEASE}"; then
+  helm delete --purge "${ISTIO_INIT_HELM_RELEASE}"
+fi
 
+printf "Stopping and cleaning up %s release...\\n" "${ISTIO_HELM_RELEASE}"
 if has_release "${ISTIO_HELM_RELEASE}"; then
   helm delete --purge "${ISTIO_HELM_RELEASE}"
 fi


### PR DESCRIPTION
## Description

bump istio from 1.0.5 to 1.1.5 as 1.1.x have changed a lot from 1.0.x

## Test plan

- `make istio-run` to set up istio.
If installation complete, you'll get a deployment like below.
```
vagrant@vagrant-kube:~/scf> k get pod -n istio-system
kubectl get pod -n istio-system
NAME                                      READY   STATUS      RESTARTS   AGE
grafana-77b49c55db-db62p                  1/1     Running     0          2m45s
istio-citadel-6f958bff99-lzxkz            1/1     Running     0          2m45s
istio-galley-55b7cbc6f4-mclp2             1/1     Running     0          2m45s
istio-ingressgateway-99dfd95c6-t65l5      1/1     Running     0          2m45s
istio-init-crd-10-mkkcr                   0/1     Completed   0          2m51s
istio-init-crd-11-bd2mp                   0/1     Completed   0          2m51s
istio-pilot-65fb95dbd4-d8bgj              2/2     Running     0          2m45s
istio-policy-6f768c5f7-kwxb7              2/2     Running     2          2m45s
istio-sidecar-injector-847bcc5744-jvprf   1/1     Running     0          2m45s
istio-telemetry-75d8b767dc-2fq7l          2/2     Running     2          2m45s
istio-tracing-595796cf54-pgbbw            1/1     Running     0          2m45s
kiali-5c584d45f6-4rfpj                    1/1     Running     0          2m45s
prometheus-5fffdf8848-mvq6n               1/1     Running     0          2m45s
```
- `make istio-stop` to remove all istio resources.