### PR TITLE
Bump fissile to include support for imagename config variables

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+317.g8bc11764"
+export FISSILE_VERSION="7.0.0+329.g262f5ace"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -4144,6 +4144,7 @@ variables:
   options:
     default: 'splatform/eirini-cert-copier:1.0.0.4.gd8e7208'
     description: "The docker image used by Eirini to register the image registry CA cert with Docker, on each Kubernetes node"
+    imagename: true
 - name: EIRINI_EIRINI_EXTENSIONS_SERVICE_HOST
   options:
     type: environment
@@ -4152,10 +4153,12 @@ variables:
   options:
     default: 'eirini/loggregator-fluentd:0.1.0'
     description: "The docker image used by Eirini to consume Kubernetes container logs"
+    imagename: true
 - name: EIRINI_IMAGE
   options:
     default: 'eirini/recipe:ci-24.0.0'
     description: "Docker Image used for staging apps deployed using Eirini"
+    imagename: true
 - name: EIRINI_KUBE_HEAPSTER_ADDRESS
   options:
     default: 'http://heapster.kube-system/apis/metrics/v1alpha1'


### PR DESCRIPTION
This commit also marks the 3 eirini image variables with the `imagename` attribute, but given that the current default values include the org name, it will have no effect right now.

The fissile bump also includes a bug fix for setting `FISSILE_SIZING_xxx_COUNT` correctly when `config.HA` is `true`.
