### PR TITLE
CF bump 7.9

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -36,7 +36,7 @@ export GOLANG_VERSION=1.7
 # Used in: make/include/versioning
 
 export PRODUCT_VERSION="1.4"
-export CF_VERSION="7.6.0"
+export CF_VERSION="7.9.0"
 
 # Show versions, if called on its own.
 # # ## ### ##### ######## ############# #####################

--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -37,9 +37,9 @@ properties:
     # include_v3: false
 
     # timeouts
-    default_timeout:   300 # 5 minutes
-    cf_push_timeout:   300 # 5 minutes
-    long_curl_timeout: 300 # 5 minutes
+    default_timeout:   600 # 10 minutes
+    cf_push_timeout:   600 # 10 minutes
+    long_curl_timeout: 600 # 10 minutes
   acceptance_tests_brain:
     user: admin
     org: test-brain-org

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1464,7 +1464,8 @@ instance_groups:
       properties.proxy_port: 8083 # log-cache-cf-auth-proxy
       properties.route_registrar.routes: >
         [{ "name": "log-cache-reverse-proxy",
-           "port": 8083,
+           "tls_port": 8083,
+           "server_cert_domain_san": "log-cache",
            "tags": { "component":"log-cache" },
            "uris": ["log-cache.((DOMAIN))", "*.log-cache.((DOMAIN))"],
            "registration_interval": "20s" }

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -16,13 +16,13 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.15.0
   sha1: 0764d9d6aae7cefd10019437ed83e7715e614633
 - name: cf-smoke-tests
-  version: 40.0.46
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=40.0.46
-  sha1: f1614779126730c88e0400a9e9482e6202aaff71
+  version: 40.0.50
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=40.0.50
+  sha1: d47f4c14d18611025290d9f5e85ae0945fcc986e
 - name: cf-syslog-drain
-  version: "9.0"
-  url: "https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=9.0"
-  sha1: "6971d973abb4710428784d91834850171e93ca20"
+  version: "9.1"
+  url: "https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=9.1"
+  sha1: "9dd7916e3855a4f9c26bf8a6a610db37addc546c"
 - name: cflinuxfs2
   url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.281.0"
   version: "1.281.0"
@@ -32,25 +32,25 @@ releases:
   version: "0.92.0"
   sha1: "99e27f5a2d8b998f45eb5cf0d3cc1600171141a2"
 - name: credhub
-  version: 2.1.2
-  url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.1.2
-  sha1: 754a24dbffe8bc5efce7e698d935b5f4df541f38
+  version: 2.1.4
+  url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.1.4
+  sha1: 415badd88a1567e05e0c157b9ec43b7fe86c44e6
 - name: diego
-  version: 2.28.0
-  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.28.0
-  sha1: 81cee8de9de5bb561a0f8c79f21a1c4256cdc74e
+  version: 2.30.0
+  url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.30.0
+  sha1: 7bbe97d294ec26c0603e13755c07cc4bc2a23070
 - name: garden-runc
-  version: 1.18.3
-  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.18.3
-  sha1: 1aa15e644c6c0c6c7ec072bf668fe5d9bcc4c632
+  version: 1.19.1
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.1
+  sha1: 9fca045a0a90cf38cf79feabcc582efd5a20538e
 - name: loggregator
   version: "105.0"
   url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=105.0
   sha1: d0bed91335aaac418eb6e8b2be13c6ecf4ce7b90
 - name: log-cache
-  version: 2.1.1
-  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.1.1
-  sha1: 44ae08bc307bcfc82b755196331050939cb935a6
+  version: 2.2.0
+  url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.2.0
+  sha1: 1ebecd0adbfc50fdd61309e129b0292deb7e7b24
 - name: mapfs
   version: "1.1.0"
   url: "https://bosh.io/d/github.com/cloudfoundry/mapfs-release?v=1.1.0"
@@ -72,9 +72,9 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.184.0
   sha1: f35eb9884e1c097ff21843e6f2d0eebd22ac2073
 - name: statsd-injector
-  version: 1.7.0
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.7.0
-  sha1: 8540d6da3ac0108bf40f547c229fb189961099b5
+  version: 1.8.0
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.8.0
+  sha1: 8b7b7ee31d71175759c0e6e3e8980c1ffbef94d3
 - name: loggregator-agent
   version: "3.7"
   url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=3.7"
@@ -303,7 +303,7 @@ instance_groups:
           healthcheck:
             readiness:
               command:
-              - curl --silent --fail --head http://${HOSTNAME}:8080/health
+              - curl --silent --fail --head http://localhost:8080/health
         ports:
         - name: sched-health
           protocol: TCP
@@ -353,7 +353,7 @@ instance_groups:
           healthcheck:
             readiness:
               command:
-              - curl --silent --fail --head http://${HOSTNAME}:8080/health
+              - curl --silent --fail --head http://localhost:8080/health
         ports:
         - name: adapter
           protocol: TCP
@@ -2963,6 +2963,8 @@ configuration:
     properties.eirini-persi-broker.namespace: "((EIRINI_KUBE_NAMESPACE))"
     properties.eirini-persi-broker.service_plans: '((EIRINI_PERSI_PLANS))'
     properties.eirini-persi-broker.url: 'http://eirini-eirini-persi-broker.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8999'
+    properties.external_cert: '"((LOG_CACHE_CF_AUTH_PROXY_EXTERNAL_CERT))"'
+    properties.external_key: '"((LOG_CACHE_CF_AUTH_PROXY_EXTERNAL_CERT_KEY))"'
     properties.fissile.monit.password: '"((MONIT_PASSWORD))"'
     properties.garden.apparmor_profile: '"((GARDEN_APPARMOR_PROFILE))"' # Quoting needed to pass through empty string
     properties.garden.btrfs-active: "((^GARDEN_DISABLE_BTRFS))true((/GARDEN_DISABLE_BTRFS))"
@@ -4453,6 +4455,20 @@ variables:
   options:
     secret: true
     description: PEM-encoded key.
+    required: true
+- name: LOG_CACHE_CF_AUTH_PROXY_EXTERNAL_CERT
+  options:
+    secret: true
+    ca: INTERNAL_CA_CERT
+    alternative_names:
+    - log-cache
+    description: The TLS cert for the auth proxy.
+    required: true
+  type: certificate
+- name: LOG_CACHE_CF_AUTH_PROXY_EXTERNAL_CERT_KEY
+  options:
+    secret: true
+    description: The TLS key for the auth proxy.
     required: true
 - name: LOG_CACHE_TO_LOGGREGATOR_AGENT_CERT
   options:


### PR DESCRIPTION
## Description

Here are the changes in submodules:
```
cf-smoke-tests, 40.0.46 -> 40.0.50
cf-syslog-drain, 9.0 -> 9.1
credhub, 2.1.2 -> 2.1.4
diego, 2.28.0 -> 2.30.0
garden-runc, 1.18.3 -> 1.19.1
log-cache, 2.1.1 -> 2.2.0
statsd-injector, 1.7.0 -> 1.8.0
```

**Notes:**
- Added cert LOG_CACHE_CF_AUTH_PROXY_EXTERNAL_CERT.
- Limited the cf-syslog-drain health endpoint to localhost to match [upstream](https://github.com/cloudfoundry/cf-syslog-drain-release/releases/tag/v9.1).
- Updated CATs to `cf7.9`.
- Fixed issue related to TLS communication between `gorouter` and `log-cache`.
- Increased timeouts for CATs.  

## Test plan

Make sure the build is passing.
