### PR TITLE
CAP-106 Don't use eirini service account for diego post-deployment-setup

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -9,8 +9,8 @@ set -o errexit -o nounset
 
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
-export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+332.g0d8469bb"
+export FISSILE_FLAVOR="checks"
+export FISSILE_VERSION="7.0.0+333.g3487c8c5"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2036,7 +2036,7 @@ instance_groups:
           capabilities: []
           memory: 256
           virtual-cpus: 1
-          service-account: eirini
+          service-account: '{{if .Values.enable.eirini}}eirini{{else}}default{{end}}'
 - name: credhub-user
   if_feature: credhub
   environment_scripts:


### PR DESCRIPTION
Requires a bump to fissile to pass through a templated service account name without trying to validate it at build time.
