### PR TITLE
[#UcByaqlM] [CAP-259] Force abort on errors within AZ and PZ handling.

### DIFF
--- a/container-host-files/etc/scf/config/scripts/configure-az.sh
+++ b/container-host-files/etc/scf/config/scripts/configure-az.sh
@@ -23,7 +23,7 @@ else
     # the diego-cell instance group.
 
     QUERY="jsonpath={.metadata.labels.${AZ_LABEL_NAME}}"
-    NODE_AZ=$("${kubectl}" get node "${node}" -o "${QUERY}" || true)
+    NODE_AZ=$("${kubectl}" get node "${node}" -o "${QUERY}")
 
     if test -z "${NODE_AZ}"
     then

--- a/container-host-files/etc/scf/config/scripts/configure-pz.sh
+++ b/container-host-files/etc/scf/config/scripts/configure-pz.sh
@@ -23,7 +23,7 @@ else
     # the diego-cell instance group.
 
     QUERY="jsonpath={.metadata.labels.${PZ_LABEL_NAME}}"
-    NODE_PZ=$("${kubectl}" get node "${node}" -o "${QUERY}" || true)
+    NODE_PZ=$("${kubectl}" get node "${node}" -o "${QUERY}")
 
     if test -z "${NODE_PZ}"
     then


### PR DESCRIPTION
## Description

See [CAP-259](https://jira.suse.com/browse/CAP-259)

## Notes

  - We only have to remove the `|| true` masking the error. The script runs in a context which aborts on error.
  - Rebased to head of dev. Collapsed the various back and forth in the history.

## Test plan

In the original submission it was `missing privileges of node-reader service account` which should have triggered the error.

Tested in local vagrant with
- Intentionally crippled `node-reader` account. (See the `verbs` of `node-reader-role` to `delete` (Cannot make it empty, that is rejected by `fissile`. Using `delete`, an irrelevant verb here, to get around that))
- Inserted `false`.
