### PR TITLE
CAP-335 Store list of all images inside the helm chart

### DIFF
--- a/bin/image-list.rb
+++ b/bin/image-list.rb
@@ -1,0 +1,22 @@
+require 'yaml'
+
+helm = ARGV[0]
+values = YAML.load_file(File.join(helm, 'values.yaml'))
+
+images = {}
+Dir.glob(File.join(helm, "templates", "*.yaml")).each do |file|
+  File.open(file).each do |line|
+    /^\s+image:.*kube.organization ?}}\/(.*?)"/.match(line) do |match|
+      images[match[1]] = true
+    end
+    # config variables with the imagename option may point to a bundled image
+    /^\s+value:.*kube.organization "\/" .Values.env.(\S+)/.match(line) do |match|
+      image = values['env'][match[1]]
+      images[image] = true unless image.empty? || image.include?("/")
+    end
+  end
+end
+
+File.open(File.join(helm, "imagelist.txt"), "w") do |file|
+  file.puts(images.keys.sort)
+end

--- a/make/kube
+++ b/make/kube
@@ -31,6 +31,7 @@ name: cf
 version: ${GIT_TAG}
 EOF
     cp chart-parts/* "${FISSILE_OUTPUT_DIR}/templates/"
+    ruby bin/image-list.rb "${FISSILE_OUTPUT_DIR}"
 elif [ "${BUILD_TARGET}" = "kube" ]; then
     # This is a small hack to make the output of make kube be compatible with K8s 1.6
     perl -p -i -e 's@extensions/v1beta1@batch/v1@' $(grep -rl 'kind: "Job"' "${FISSILE_OUTPUT_DIR}")


### PR DESCRIPTION
This makes is easy to copy them to a local registry to speed up upgrades, or to move them to an air-gapped installation.

## Test plan

Create a new helm chart and check that the `imagelist.txt` file exists inside the chart (next to the `values.yaml` file), and that it includes the names of all "local" images. Image names that include a registry hostname, or a repository organization will not be included.