### PR TITLE
CF Bump 7.11

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -36,7 +36,7 @@ export GOLANG_VERSION=1.7
 # Used in: make/include/versioning
 
 export PRODUCT_VERSION="1.4"
-export CF_VERSION="7.9.0"
+export CF_VERSION="7.11.0"
 
 # Show versions, if called on its own.
 # # ## ### ##### ######## ############# #####################

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1469,7 +1469,7 @@ instance_groups:
           healthcheck:
             readiness:
               command:
-              - curl --silent --fail --head http://${HOSTNAME}:8081/set-cookie
+              - curl --silent --fail --head --insecure https://${HOSTNAME}:8081/set-cookie
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -1504,7 +1504,12 @@ instance_groups:
           privileged: true
   configuration:
     templates:
-      properties.route_registrar.routes: '[{"name":"log-api", "port":8081, "uris":["doppler.((DOMAIN))"], "registration_interval":"10s"}, {"name":"loggregator_trafficcontroller", "port":8080, "uris":["loggregator.((DOMAIN))"], "registration_interval":"10s"}]'
+      properties.route_registrar.routes: >
+        [{ "name": "doppler",
+           "tls_port": 8081,
+           "registration_interval": "20s",
+           "server_cert_domain_san": "doppler",
+           "uris": ["doppler.((DOMAIN))", "*.doppler.((DOMAIN))"] }]
 - name: diego-brain
   unless_feature: eirini
   environment_scripts:
@@ -2319,6 +2324,8 @@ instance_groups:
   - name: loggregator_agent
     release: loggregator-agent
     properties:
+      grpc_port: 3459
+      disable_udp: true
       bosh_containerization:
         run:
           scaling:
@@ -2641,7 +2648,7 @@ configuration:
     properties.capi.tps.cc.client_key: '"((TPS_CC_CLIENT_CRT_KEY))"'
     properties.capi.tps.cc.internal_service_hostname: api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
     properties.capi.tps.log_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
-    properties.capi.tps.traffic_controller_url: ws://log-api-loggregator-trafficcontroller.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8081
+    properties.capi.tps.traffic_controller_url: wss://log-api-loggregator-trafficcontroller.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8081
     properties.capi.tps.watcher.locket.api_location: '"locket-locket.((KUBERNETES_NAMESPACE)):8891"'
     properties.cc.allow_app_ssh_access: ((ALLOW_APP_SSH_ACCESS))
     properties.cc.allowed_cors_domains: ((ALLOWED_CORS_DOMAINS))
@@ -2681,7 +2688,7 @@ configuration:
     properties.cc.internal_api_password: '"((INTERNAL_API_PASSWORD))"'
     properties.cc.internal_service_hostname: api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
     properties.cc.logging_level: '"((LOG_LEVEL))"'
-    properties.cc.loggregator.internal_url: http://log-api-loggregator-trafficcontroller.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8081
+    properties.cc.loggregator.internal_url: https://log-api-loggregator-trafficcontroller.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8081
     properties.cc.maximum_app_disk_in_mb: ((MAX_APP_DISK_IN_MB))
     properties.cc.maximum_health_check_timeout: ((MAX_HEALTH_CHECK_TIMEOUT))
     properties.cc.mutual_tls.ca_cert: '"((INTERNAL_CA_CERT))"'
@@ -3926,6 +3933,9 @@ variables:
   options:
     secret: true
     ca: INTERNAL_CA_CERT
+    alternative_names:
+    - "doppler"
+    - "log-api-loggregator-trafficcontroller.{{ .KUBERNETES_NAMESPACE }}.svc.{{ .KUBERNETES_CLUSTER_DOMAIN }}"
     description: TLS cert for outgoing dropsonde connection
     required: true
   type: certificate

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1,8 +1,8 @@
 releases:
 - name: bpm
-  version: "1.0.3"
-  url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.0.3"
-  sha1: "5116e990fe1572331dbaf79fa7c5559d0ce793a8"
+  version: "1.0.4"
+  url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.0.4"
+  sha1: "c2cceb2d1e271a2f7c5e7c563a7b26f919ebc17a"
 - name: capi
   version: "1.79.0"
   url: "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=1.79.0"
@@ -16,13 +16,13 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.15.0
   sha1: 0764d9d6aae7cefd10019437ed83e7715e614633
 - name: cf-smoke-tests
-  version: 40.0.50
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=40.0.50
-  sha1: d47f4c14d18611025290d9f5e85ae0945fcc986e
+  version: 40.0.51
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-smoke-tests-release?v=40.0.51
+  sha1: 143f79828dbc7eb06fd03b0080d569b63c9f1c36
 - name: cf-syslog-drain
-  version: "9.1"
-  url: "https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=9.1"
-  sha1: "9dd7916e3855a4f9c26bf8a6a610db37addc546c"
+  version: "10.0"
+  url: "https://bosh.io/d/github.com/cloudfoundry/cf-syslog-drain-release?v=10.0"
+  sha1: "6b5154a3709cf2d7ac29211b0b4584e4b21db562"
 - name: cflinuxfs2
   url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs2-release?v=1.281.0"
   version: "1.281.0"
@@ -32,9 +32,9 @@ releases:
   version: "0.96.0"
   sha1: "f1aacde1b94293e8fdd128dd77f759254e094252"
 - name: credhub
-  version: 2.1.4
-  url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.1.4
-  sha1: 415badd88a1567e05e0c157b9ec43b7fe86c44e6
+  version: 2.2.0
+  url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.2.0
+  sha1: 09d519b5577c387b8c56c14c240c487484e9a1ca
 - name: diego
   version: 2.30.0
   url: https://bosh.io/d/github.com/cloudfoundry/diego-release?v=2.30.0
@@ -44,9 +44,9 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.19.1
   sha1: 9fca045a0a90cf38cf79feabcc582efd5a20538e
 - name: loggregator
-  version: "105.0"
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=105.0
-  sha1: d0bed91335aaac418eb6e8b2be13c6ecf4ce7b90
+  version: "105.2"
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=105.2
+  sha1: a1e3258786cb4826080d819c91dd049a06cd3476
 - name: log-cache
   version: 2.2.0
   url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.2.0
@@ -68,17 +68,17 @@ releases:
   version: 0.16.0
   sha1: eb53d366af2d6e49e8c2ac834191547b2ba44d30
 - name: routing
-  version: 0.184.0
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.184.0
-  sha1: f35eb9884e1c097ff21843e6f2d0eebd22ac2073
+  version: 0.187.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release?v=0.187.0
+  sha1: 50c7bb74ab094d93c0015f4617654335bad5ca7c
 - name: statsd-injector
-  version: 1.8.0
-  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.8.0
-  sha1: 8b7b7ee31d71175759c0e6e3e8980c1ffbef94d3
+  version: 1.9.0
+  url: https://bosh.io/d/github.com/cloudfoundry/statsd-injector-release?v=1.9.0
+  sha1: d78bb60685498f653bfe258eeac3f1f3da961a9f
 - name: loggregator-agent
-  version: "3.7"
-  url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=3.7"
-  sha1: "67bb1c20a4bb209a1f611ba041cbba8ad1158087"
+  version: "3.9"
+  url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=3.9"
+  sha1: "bf723af956a61c7b51db0ba535c871bad24dd289"
 - name: binary-buildpack
   url: "https://s3.amazonaws.com/suse-final-releases/binary-buildpack-release-1.0.32.1.tgz"
   version: "1.0.32.1"
@@ -2815,6 +2815,8 @@ configuration:
     properties.loggregator.ca_cert: ((INTERNAL_CA_CERT))
     properties.loggregator.cert: ((LOGGREGATOR_CLIENT_CERT))
     properties.loggregator.key: ((LOGGREGATOR_CLIENT_CERT_KEY))
+    properties.loggregator.outgoing_cert: ((LOGGREGATOR_OUTGOING_CERT))
+    properties.loggregator.outgoing_key: ((LOGGREGATOR_OUTGOING_CERT_KEY))
     properties.loggregator.tls.agent.cert: '"((LOGGREGATOR_AGENT_CERT))"'
     properties.loggregator.tls.agent.key: '"((LOGGREGATOR_AGENT_CERT_KEY))"'
     properties.loggregator.tls.ca_cert: '"((INTERNAL_CA_CERT))"'
@@ -3919,6 +3921,18 @@ variables:
   options:
     secret: true
     description: PEM-encoded client key for loggregator forwarder authentication
+    required: true
+- name: LOGGREGATOR_OUTGOING_CERT
+  options:
+    secret: true
+    ca: INTERNAL_CA_CERT
+    description: TLS cert for outgoing dropsonde connection
+    required: true
+  type: certificate
+- name: LOGGREGATOR_OUTGOING_CERT_KEY
+  options:
+    secret: true
+    description: TLS key for outgoing dropsonde connection
     required: true
 - name: LOG_CACHE_CERT
   options:

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1043,6 +1043,11 @@ instance_groups:
   - sequential-startup
   configuration:
     templates:
+      properties.cc.logcache.host: doppler-log-cache.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
+      properties.cc.logcache_tls.certificate: '"((LOG_CACHE_CERT))"'
+      properties.cc.logcache_tls.private_key: '"((LOG_CACHE_CERT_KEY))"'
+      properties.cc.logcache_tls.subject_name: "log-cache"
+      properties.cc.temporary_use_logcache: true
       properties.route_registrar.routes: '[{"name": "api", "port": 9022, "tls_port": 9024, "server_cert_domain_san": "api-set", "tags": {"component": "CloudController"}, "uris": ["api.((DOMAIN))"], "registration_interval": "10s"}]'
 - name: cc-worker
   scripts:
@@ -2324,8 +2329,6 @@ instance_groups:
   - name: loggregator_agent
     release: loggregator-agent
     properties:
-      grpc_port: 3459
-      disable_udp: true
       bosh_containerization:
         run:
           scaling:


### PR DESCRIPTION
## Description

Submodule changes:

```
bpm, 1.0.3 -> 1.04
cf-smoke-tests, 40.0.50 -> 40.0.51
cf-syslog-drain, 9.1 -> 10.0
credhub, 2.1.4 -> 2.2.0
loggregator, 105.0 -> 105.2
routing, 0.184.0 -> 0.187.0
statsd-injector, 1.8.0 -> 1.9.0
loggregator-agent, 3.7 -> 3.9
```
**Notes:**
- Made changes for enabling TLS between trafficcontroller and gorouter. Refer [this](https://github.com/cloudfoundry/loggregator-release/releases/tag/v105.1).
- Switched to using `log-cache` instead of `traffic_controller` for retrieving container metrics. Refer [this](https://github.com/cloudfoundry/loggregator-release/releases/tag/v105.0).

## Test plan

Make sure the build is passing.
