### PR TITLE
CAP-99 Provide a mechanism to set -flakeAttempts when running CATS

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1886,6 +1886,7 @@ instance_groups:
           flight-stage: manual
   configuration:
     templates:
+      properties.acceptance_tests.flake_attempts: '"((ACCEPTANCE_TEST_FLAKE_ATTEMPTS))"'
       properties.acceptance_tests.nodes: '"((ACCEPTANCE_TEST_NODES))"'
       scf.cats-suites: '"((CATS_SUITES))"'
 - name: sync-integration-tests
@@ -3066,6 +3067,12 @@ configuration:
     # Really a loggregator_agent job property
     properties.zone: '"((KUBE_AZ))"'
 variables:
+- name: ACCEPTANCE_TEST_FLAKE_ATTEMPTS
+  options:
+    default: 3
+    description: >
+      The number of times Ginkgo will run a test before treating it as a failure.
+      Individual failed runs will still be reported in the test output.
 - name: ACCEPTANCE_TEST_NODES
   options:
     default: 4

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1918,6 +1918,7 @@ instance_groups:
       properties.sync_integration_tests.config.cf_admin_password: '"((CLUSTER_ADMIN_PASSWORD))"((#INTERNAL_CA_CERT_KEY))((/INTERNAL_CA_CERT_KEY))'
       properties.sync_integration_tests.config.cf_api: api.((DOMAIN))
       properties.sync_integration_tests.config.cf_apps_domain: ((DOMAIN))
+      properties.sync_integration_tests.setup.flake_attempts: "'((SYNC_INTEGRATION_TESTS_FLAKE_ATTEMPTS))'"
       properties.sync_integration_tests.setup.focus: "'((SYNC_INTEGRATION_TESTS_FOCUS))'"
       properties.sync_integration_tests.setup.nodes: "'((SYNC_INTEGRATION_TESTS_NODES))'"
       properties.sync_integration_tests.setup.skip: "'((SYNC_INTEGRATION_TESTS_SKIP))'"
@@ -3071,7 +3072,7 @@ variables:
   options:
     default: 3
     description: >
-      The number of times Ginkgo will run a test before treating it as a failure.
+      The number of times Ginkgo will run a CATS test before treating it as a failure.
       Individual failed runs will still be reported in the test output.
 - name: ACCEPTANCE_TEST_NODES
   options:
@@ -4693,6 +4694,12 @@ variables:
     default: https://scc.suse.com
     description: Support contact information for the cluster
     required: true
+- name: SYNC_INTEGRATION_TESTS_FLAKE_ATTEMPTS
+  options:
+    default: 3
+    description: >
+      The number of times Ginkgo will run a SITS test before treating it as a failure.
+      Individual failed runs will still be reported in the test output.
 - name: SYNC_INTEGRATION_TESTS_FOCUS
   options:
     description: >

--- a/src/scf-release/jobs/acceptance-tests/spec
+++ b/src/scf-release/jobs/acceptance-tests/spec
@@ -29,6 +29,9 @@ properties:
   acceptance_tests.nodes:
     default: 4
     description: The number of parallel test executors to spawn. The larger the number the higher the stress on the system.
+  acceptance_tests.flake_attempts:
+    default: 1
+    description: The number of times Ginkgo will run a test before treating it as a failure.
   acceptance_tests.verbose:
     default: false
     description: Whether to pass the -v flag to cf-acceptance-tests

--- a/src/scf-release/jobs/acceptance-tests/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests/templates/run.erb
@@ -32,6 +32,7 @@ echo "Running acceptance tests..."
 
 EXITSTATUS=0
 
+flakeAttempts=<%= properties.acceptance_tests.flake_attempts %>
 nodes=<%= properties.acceptance_tests.nodes %>
 
 skips=
@@ -48,7 +49,7 @@ fi
 
 set +e
 bin/test -r $noColorFlag -slowSpecThreshold=120 -randomizeAllSpecs $verbose \
-  -nodes=$nodes -skipPackage=helpers $skips -keepGoing "${focus[@]}" \
+  -flakeAttempts=$flakeAttempts -nodes=$nodes -skipPackage=helpers $skips -keepGoing "${focus[@]}" \
   > >( tee /var/vcap/sys/log/acceptance_tests.log ) \
   2> /var/vcap/sys/log/acceptance_tests.err.log
 EXITSTATUS=$?

--- a/src/scf-release/jobs/acceptance-tests/templates/run.erb
+++ b/src/scf-release/jobs/acceptance-tests/templates/run.erb
@@ -2,7 +2,8 @@
 
 set -e -x
 
-export GOROOT=$(readlink -nf /var/vcap/packages/golang1.10)
+GOROOT=$(readlink -nf /var/vcap/packages/golang1.10)
+export GOROOT
 export PATH=${GOROOT}/bin:${PATH}
 
 export PATH=/var/vcap/packages/cli/bin:${PATH} # put the cli on the path
@@ -23,8 +24,8 @@ rm -rf /var/vcap/sys/log/acceptance_tests/*
 cd /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests
 
 echo '################################################################################################################'
-echo $(go version)
-echo CONFIG=$CONFIG
+go version
+echo CONFIG=${CONFIG}
 env | sort
 echo '################################################################################################################'
 
@@ -48,20 +49,21 @@ if test -n "${CATS_FOCUS:-}" ; then
 fi
 
 set +e
-bin/test -r $noColorFlag -slowSpecThreshold=120 -randomizeAllSpecs $verbose \
-  -flakeAttempts=$flakeAttempts -nodes=$nodes -skipPackage=helpers $skips -keepGoing "${focus[@]}" \
+# shellcheck disable=2065
+bin/test -r ${noColorFlag} -slowSpecThreshold=120 -randomizeAllSpecs ${verbose} \
+  -flakeAttempts=${flakeAttempts} -nodes=${nodes} -skipPackage=helpers ${skips} -keepGoing "${focus[@]}" \
   > >( tee /var/vcap/sys/log/acceptance_tests.log ) \
   2> /var/vcap/sys/log/acceptance_tests.err.log
 EXITSTATUS=$?
 set -e
 
-echo "Acceptance Tests Complete; exit status: $EXITSTATUS"
+echo "Acceptance Tests Complete; exit status: ${EXITSTATUS}"
 
 for i in /var/vcap/sys/log/acceptance_tests/*; do
-  if [ -e "$i" ]
+  if [ -e "${i}" ]
   then
-    mv $i $i.log # needed to make download-logs work
+    mv "${i}" "${i}.log" # needed to make download-logs work
   fi
 done
 
-exit $EXITSTATUS
+exit ${EXITSTATUS}

--- a/src/scf-release/jobs/sync-integration-tests/spec
+++ b/src/scf-release/jobs/sync-integration-tests/spec
@@ -16,6 +16,8 @@ templates:
   run.erb: bin/run
 
 properties:
+  sync_integration_tests.setup.flake_attempts:
+    description: The number of times Ginkgo will run a test before treating it as a failure.
   sync_integration_tests.setup.nodes:
     description: The number of parallel test executors to spawn.
   sync_integration_tests.setup.verbose:

--- a/src/scf-release/jobs/sync-integration-tests/templates/run.erb
+++ b/src/scf-release/jobs/sync-integration-tests/templates/run.erb
@@ -23,7 +23,7 @@ rm -rf "/var/vcap/sys/log/sync_integration_tests/*"
 cd "${GOPATH}/src/code.cloudfoundry.org/sync-integration-tests"
 
 echo '################################################################################################################'
-echo "$(go version)"
+go version
 echo "CONFIG=${CONFIG}"
 env | sort
 echo '################################################################################################################'
@@ -38,6 +38,7 @@ ginkgo_options=(
   -keepGoing
   -slowSpecThreshold='<%= p("sync_integration_tests.setup.slow_spec_threshold") %>'
   -nodes='<%= p("sync_integration_tests.setup.nodes") %>'
+  -flakeAttempts='<%= p("sync_integration_tests.setup.flake_attempts") %>'
 <% if_p("sync_integration_tests.setup.skip") do |skip| %>
   <%= "-skip='#{skip}'" if skip != "" %>
 <% end %>
@@ -54,4 +55,4 @@ ginkgo ${ginkgo_options[@]} \
   1> >( tee /var/vcap/sys/log/sync_integration_tests/out.log ) \
   2> >( tee /var/vcap/sys/log/sync_integration_tests/err.log )
 EXITSTATUS=$?
-exit $EXITSTATUS
+exit ${EXITSTATUS}


### PR DESCRIPTION
CATS often has random failures on Jenkins that are due to resource pressure and not reproducible. -flakeAttempts tells Gingko to retry failed tests multiple times before treating them as failures. Each
individual failed test will still be reported, just not reflected in the exit code.

[CAP-99]
