### PR TITLE
Add proper database command

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/database.yaml
@@ -103,10 +103,36 @@
     bpm:
       processes:
       - name: mariadb_ctrl
-        executable: /bin/sh
+        executable: /bin/bash
         args:
           - -c
-          - "/var/vcap/jobs/mysql/bin/mariadb_ctl start; while true; do sleep 60; done"
+          - |
+            wait_for_file() {
+              local file_path="$1"
+              local timeout="${2:-30}"
+              until [[ -f "${file_path}" ]] || [[ $((timeout--)) == 0 ]]; do sleep 1; done
+              if [[ "${timeout}" == 0 ]]; then return 1; fi
+              return 0
+            }
+
+            /var/vcap/jobs/mysql/bin/mariadb_ctl start
+
+            pid_file="/var/vcap/sys/run/mysql/mysql.pid"
+            log_file="/var/vcap/sys/log/mysql/mariadb_ctrl.combined.log"
+
+            wait_for_file "${pid_file}" || {
+              echo "${pid_file} did not get created"
+              exit 1
+            }
+
+            wait_for_file "${log_file}" || {
+              echo "${log_file} did not get created"
+              exit 1
+            }
+
+            tail \
+              --pid $(cat "${pid_file}") \
+              --follow "${log_file}"
         limits:
           open_files: 1048576
         persistent_disk: true


### PR DESCRIPTION
## Description

It starts the database and tails the combined logs, waiting for the pid to exit.

## Test plan

- When using `kubectl log ...` with the database, it should tail the combined logs.
- When killing the database with `kill -SIGTERM $(cat /var/vcap/sys/run/mysql/mysql.pid)` inside the database container, it should restart the container.
