### PR TITLE
Add nats bosh_containerization properties

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/nats.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/nats.yaml
@@ -1,0 +1,24 @@
+# Add bosh_containerization properties.
+- type: replace
+  path: /instance_groups/name=nats/jobs/name=nats/properties/bosh_containerization?
+  value:
+    ports:
+    - name: nats
+      protocol: TCP
+      internal: 4222
+    - name: nats-routes
+      protocol: TCP
+      internal: 4223
+    run:
+      memory: 128
+      virtual-cpus: 2
+      healthcheck:
+        nats:
+          readiness:
+            handler:
+              exec:
+                command: ['sh', '-c', 'ss -nltp | grep "LISTEN.*:4222" && ss -nltp | grep "LISTEN.*:4223"']
+          liveness:
+            handler:
+              exec:
+                command: ['sh', '-c', 'ss -nltp | grep "LISTEN.*:4222" && ss -nltp | grep "LISTEN.*:4223"']


### PR DESCRIPTION
## Description

Added the ports, and readiness and liveness probes.

## Test plan

Nats should become ready and live only after it's appropriately listening on ports 4222 and 4223.