### PR TITLE
Adding a check for retrieving cf stats in the autoscaler test

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/018_autoscaler_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/018_autoscaler_test.rb
@@ -102,6 +102,7 @@ run "curl", "-X", "POST", "#{url}/stress_testers?vm=10&vm-bytes=100M"
 puts "Waiting for new instances to start..."
 STDOUT.flush
 run_with_retry 24, 5 do
+  run "cf", "app", app_name
   if get_count == 1
     # Force an error, i.e. a retry.
     raise RuntimeError, "no new instances"


### PR DESCRIPTION
## Description

This will provide more info whenever the autoscaler test is failing.

Original ref: https://github.com/SUSE/scf/pull/2364/commits/0986ccf71d5dadd547aaec4f49845178698ba2c4

## Test plan

Make sure the build is passing.