### PR TITLE
Add garden job to diego-cell instance group

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/diego-cell.yaml
@@ -1,0 +1,52 @@
+# Enable BPM on garden.
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/bpm?
+  value:
+    enabled: true
+
+# Add bosh_containerization properties.
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/bosh_containerization?
+  value:
+    run:
+      memory: 4096
+      virtual-cpus: 2
+      healthcheck:
+        garden:
+          readiness:
+            handler:
+              exec:
+                command: ['sh', '-c', 'ss -nltp | grep "LISTEN.*:17019"']
+          liveness:
+            handler:
+              exec:
+                command: ['sh', '-c', 'ss -nltp | grep "LISTEN.*:17019"']
+
+
+# Temporarily remove garden network_plugin.
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/network_plugin
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/network_plugin_extra_args
+
+# Selectively remove jobs temporarily.
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs2-rootfs-setup
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=rep
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=cfdot
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=route_emitter
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=garden-cni
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=netmon
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=silk-daemon
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=silk-cni

--- a/deploy/helm/scf/assets/operations/temporary/remove_roles.yaml
+++ b/deploy/helm/scf/assets/operations/temporary/remove_roles.yaml
@@ -24,8 +24,6 @@
 - type: remove
   path: /instance_groups/name=doppler
 - type: remove
-  path: /instance_groups/name=diego-cell
-- type: remove
   path: /instance_groups/name=log-api
 - type: remove
   path: /instance_groups/name=credhub


### PR DESCRIPTION
## Description

Adding `diego-cell` instance group with `garden` only.

## Test plan

With Minikube, it will require the use of the openSUSE Minikube image that currently only works with Virtualbox vm-driver.

1. Start Minikube with `--iso-url=https://github.com/f0rmiga/opensuse-minikube-image/releases/download/v0.1.0/minikube-openSUSE.x86_64-1.0.0.iso`.
2. Deploy the lastest master of `cf-operator`.
3. Deploy SCF.
