### PR TITLE
prep for next CAP release v1.4.1

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -35,7 +35,7 @@ export GOLANG_VERSION=1.7
 
 # Used in: make/include/versioning
 
-export PRODUCT_VERSION="1.4"
+export PRODUCT_VERSION="1.4.1"
 export CF_VERSION="7.11.0"
 
 # Show versions, if called on its own.


### PR DESCRIPTION
## Description

Bumped version number for next CAP release associated with this scf build

## Test plan

n/a. need to find the appVersion entry too since that ties into the helm chart
