### PR TITLE
Fix NODE_AZ query in case the label contains dots

### DIFF
--- a/container-host-files/etc/scf/config/scripts/configure-az.sh
+++ b/container-host-files/etc/scf/config/scripts/configure-az.sh
@@ -22,8 +22,8 @@ else
     # information available to the container, scripts, and binaries of
     # the diego-cell instance group.
 
-    QUERY="jsonpath={.metadata.labels.${AZ_LABEL_NAME}}"
-    NODE_AZ=$("${kubectl}" get node "${node}" -o "${QUERY}")
+    # Note that $AZ_LABEL_NAME may contain dots, which is why we use go-template instead of jsonpath here:
+    NODE_AZ=$("${kubectl}" get node "${node}" -o "go-template={{index .metadata.labels \"${AZ_LABEL_NAME}\"}}")
 
     if test -z "${NODE_AZ}"
     then


### PR DESCRIPTION
E.g. `-o 'jsonpath={.metadata.labels.foo\.bar}}'`
or `-o "jsonpath={.metadata.labels['foo\.bar']}"`

Even the [bracket] version requires the dot to be backslash-escaped.

