### PR TITLE
Set AZ_LABEL_NAME to failure-domain.beta.kubernetes.io/zone

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -3288,12 +3288,8 @@ variables:
   type: password
 - name: AZ_LABEL_NAME
   options:
-    default: ''
-    description: The name of the metadata label to query on worker
-      nodes to get AZ information. When set, the cells will query
-      their worker node for AZ information and inject the result into
-      cloudfoundry via the KUBE_AZ parameter. When left to the default
-      no custom AZ processing is done.
+    default: 'failure-domain.beta.kubernetes.io/zone'
+    description: The name of the metadata label to query on worker nodes to get AZ information.
     internal: true
 - name: BBS_ACTIVE_KEY_PASSPHRASE
   options:


### PR DESCRIPTION
This is the predefined (well-known) label reserved for this purpose:
https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone

Test show that kube installations provided by public cloud providers already set this label on their nodes.
