### PR TITLE
Reverting ruby-buildpack bump

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -100,9 +100,9 @@ releases:
   version: "1.6.34.1"
   sha1: "4678ec944bcc72ff7eca7396d58b452779381b41"
 - name: ruby-buildpack
-  url: "https://s3.amazonaws.com/suse-final-releases/ruby-buildpack-release-1.7.41.1.tgz"
-  version: "1.7.41.1"
-  sha1: "e91c6727dc923cbbb450e49087a3d0b21952406b"
+  url: "https://s3.amazonaws.com/suse-final-releases/ruby-buildpack-release-1.7.40.1.tgz"
+  version: "1.7.40.1"
+  sha1: "c4eb8eca89fe0b31c3523fb7d95a632d64f80511"
 - name: staticfile-buildpack
   url: "https://s3.amazonaws.com/suse-final-releases/staticfile-buildpack-release-1.4.43.1.tgz"
   version: "1.4.43.1"


### PR DESCRIPTION
This reverts commit 75ade779a8bdd4b8ba1264e6a579601e2436c223.

## Description

The bump is making the  build unstable by introducing failures in brains(possibly CATs) while staging Dora app.

## Test plan

Make sure brains and CATs are passing.
