### PR TITLE
ccdb migration squasher: fix ruby syntax error

### DIFF
--- a/container-host-files/etc/scf/config/scripts/patches/cc_migration_squash.sh
+++ b/container-host-files/etc/scf/config/scripts/patches/cc_migration_squash.sh
@@ -425,7 +425,7 @@ Sequel.migration do
     # Skip the squash-migration if we already have a users table
     # (which probably means this has data from before we did the
     # squashing).
-    break if tables.find { |t| t =~ /^users$/ }
+    next if tables.find { |t| t =~ /^users$/ }
     run 'ALTER DATABASE DEFAULT CHARACTER SET utf8;'
     create_table! :app_annotations do
       String :guid, null: false

--- a/tooling/helpers/0001-db-migration-add-script-to-squash-DB-migrations.patch
+++ b/tooling/helpers/0001-db-migration-add-script-to-squash-DB-migrations.patch
@@ -1093,7 +1093,7 @@ index 000000000..ca2509afd
 +                        # Skip the squash-migration if we already have a users table
 +                        # (which probably means this has data from before we did the
 +                        # squashing).
-+                        break if tables.find { |t| t =~ /^users$/ }
++                        next if tables.find { |t| t =~ /^users$/ }
 +                ENDSCRIPT
 +
 +                unless @default_charset.nil?


### PR DESCRIPTION
## Description

Ruby doesn't like `break` there (we get an error saying "LocalJumpError: break from proc-closure"); try using `next` instead.

## Test plan

- Deploy SCF as normal
- Kill the `api-group` pod halfway through the migration (after the `users` table is created, but before Sequel records that fact).
