### PR TITLE
Get rid of cluster-admin role binding for eirini service account

### DIFF
--- a/chart-parts/eirini-daemonset.yaml
+++ b/chart-parts/eirini-daemonset.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.enable.eirini }}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -18,24 +19,28 @@ spec:
       initContainers:
       - name: copy-certs
         env:
-        - name: INTERNAL_CA_CERT
+        - name: "INTERNAL_CA_CERT"
           valueFrom:
             secretKeyRef:
-              key: internal-ca-cert
-              name: "<%= p('scf.secrets_generation_name') %>"
+              key: "internal-ca-cert"
+              {{- if .Values.secrets.INTERNAL_CA_CERT }}
+              name: "secrets"
+              {{- else }}
+              name: "secrets-{{.Chart.Version}}-{{.Values.kube.secrets_generation_counter}}"
+              {{- end }}
         - name: REGISTRY
-          value: "<%= p('scf.eirini.registry.address') %>"
+          value: "registry.{{.Values.env.DOMAIN}}"
         - name: SCF_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "<%= p('scf.eirini.cert_copier_image') %>"
+        image: {{.Values.env.EIRINI_CERT_COPIER_IMAGE | quote}}
         volumeMounts:
         - name: host-docker
           mountPath: /workspace/docker
       containers:
       - name: eirini-loggregator-fluentd
-        image: <%= p('scf.eirini.fluentd_image') %>
+        image: {{.Values.env.EIRINI_FLUENTD_IMAGE | quote}}
         imagePullPolicy: Always
         env:
         - name: FLUENT_UID
@@ -64,15 +69,17 @@ spec:
           mountPath: /fluentd/certs
           readOnly: true
       - name: loggregator-agent
+        # XXX untagged image from dockerhub!
         image: loggregator/agent
         imagePullPolicy: Always
         env:
         - name: AGENT_METRIC_SOURCE_ID
           value: scf/daemonset/loggregator-fluentd
+        # Note: KUBERNETES_CLUSTER_DOMAIN hard-coded to "cluster.local"
         - name: ROUTER_ADDR
-          value: <%= p('scf.eirini.doppler_address') %>
+          value: "doppler-doppler.{{.Release.Namespace}}.svc.cluster.local:8082"
         - name: ROUTER_ADDR_WITH_AZ
-          value: <%= p('scf.eirini.doppler_address_with_az') %>
+          value: "doppler-doppler.{{.Release.Namespace}}.svc.cluster.local:8082"
         - name: AGENT_PPROF_PORT
           value: "6062"
         - name: AGENT_HEALTH_ENDPOINT_PORT
@@ -103,7 +110,7 @@ spec:
           path: /var/vcap/data/
       - name: loggregator-tls-certs
         secret:
-          secretName: <%= p('scf.secrets_generation_name') %>
+          secretName: "secrets-{{.Chart.Version}}-{{.Values.kube.secrets_generation_counter}}"
           items:
             - key: loggregator-agent-cert
               path: agent.crt
@@ -115,3 +122,4 @@ spec:
         hostPath:
           path: /etc/docker
           type: Directory
+{{- end }}

--- a/chart-parts/eirini-namespace.yaml
+++ b/chart-parts/eirini-namespace.yaml
@@ -4,4 +4,30 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{.Values.env.EIRINI_KUBE_NAMESPACE | quote}}
+{{- if and (eq (printf "%s" .Values.kube.auth) "rbac") (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eirini
+  namespace: {{.Values.env.EIRINI_KUBE_NAMESPACE | quote}}
+rules:
+- apiGroups: ['*']
+  resources: ['*']
+  verbs:     ['*']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eirini
+  namespace: {{.Values.env.EIRINI_KUBE_NAMESPACE | quote}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eirini
+subjects:
+- kind: ServiceAccount
+  name: eirini
+  namespace: {{.Release.Namespace}}
+{{- end }}
 {{- end }}

--- a/chart-parts/eirini-namespace.yaml
+++ b/chart-parts/eirini-namespace.yaml
@@ -1,0 +1,7 @@
+---
+{{- if .Values.enable.eirini }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{.Values.env.EIRINI_KUBE_NAMESPACE | quote}}
+{{- end }}

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2429,10 +2429,6 @@ configuration:
       - apiGroups: [""]
         resources: [nodes]
         verbs: [get, list, watch]
-      eirini-role:
-      - apiGroups: ["*"]
-        resources: ["*"]
-        verbs: ["*"]
       test-cluster-role:
       - apiGroups: [""]
         resources: [namespaces]
@@ -2485,8 +2481,7 @@ configuration:
         roles: [configgin-role, psp-role]
         cluster-roles: [node-reader-role]
       eirini:
-        roles: [configgin-role]
-        cluster-roles: [eirini-role]
+        roles: [configgin-role, psp-role]
   templates:
     az: '"((KUBE_AZ))"'
     id: ((HOSTNAME))

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2467,6 +2467,8 @@ configuration:
         - projected
         - persistentVolumeClaim
         - nfs
+        # hostPath is only used by the Eirini DaemonSet
+        - hostPath
     accounts:
       default:
         roles: [configgin-role, psp-role]
@@ -2481,7 +2483,7 @@ configuration:
         roles: [configgin-role, psp-role]
         cluster-roles: [node-reader-role]
       eirini:
-        roles: [configgin-role, psp-role]
+        roles: [configgin-role, secrets-role, psp-role]
   templates:
     az: '"((KUBE_AZ))"'
     id: ((HOSTNAME))

--- a/src/scf-release/jobs/configure-scf/spec
+++ b/src/scf-release/jobs/configure-scf/spec
@@ -11,7 +11,6 @@ packages:
 
 templates:
   run.erb: bin/run
-  eirini-daemonset.yaml.erb: config/eirini-daemonset.yaml
 
 properties:
   cf.insecure_api_url:

--- a/src/scf-release/jobs/configure-scf/templates/run.erb
+++ b/src/scf-release/jobs/configure-scf/templates/run.erb
@@ -146,14 +146,6 @@ ${scf_secrets}
 EOT
 /var/vcap/packages/kubectl/bin/kubectl apply -f secret.yml --namespace "<%= p("scf.eirini.namespace") %>"
 
-status "Setting up Eirini daemonsets"
-
-/var/vcap/packages/kubectl/bin/kubectl apply -f /var/vcap/jobs/configure-scf/config/eirini-daemonset.yaml
-
-<% else %>
-
-/var/vcap/packages/kubectl/bin/kubectl delete -f /var/vcap/jobs/configure-scf/config/eirini-daemonset.yaml || true
-
 <% end %>
 
 status "SCF configuration complete."


### PR DESCRIPTION
Running pods with `cluster-admin` privileges seems like a very bad idea. Even having service accounts with `cluster-admin` access is dangerous when you have pods that have the right to create or modify pods, deployments, stateful sets etc. because they can then make use of the service account to escalate privileges.

`cluster-admin` was needed for 2 purposes:

* granting access to the eirini namespace to schedule applications there
* allowing the post-deployment setup to create daemonsets for fluentd, and running the cert-copier

Access to the eirini namespace can be provided by a role inside the eirini namespace that is then bound to the service account in the scf namespace.

The daemonset shouldn't be created inside the post-deployment job in the first place; it should be part of the helm chart.

One remaining problem with this PR is that the daemonset uses the `loggregator/agent:latest` image, which doesn't use the Configgin mechanism to configure bosh jobs. Therefore we don't have access to `KUBERNETES_CLUSTER_DOMAIN` and have to hard-code it to the `cluster.local` default value.

Another reason for moving the daemonset to the helm chart was to make it easier to modify it at deployment time to debug problems on different kube installations.

Finally, creating the eirini namespace also makes sure it is being cleaned up when the release is deleted from the cluster.