### PR TITLE
Fixed database with BPM persistent disk

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/database.yaml
@@ -82,6 +82,25 @@
 - type: replace
   path: /instance_groups/name=database/jobs/name=mysql/properties/bosh_containerization?
   value:
+    pre_render_scripts:
+    # Patch pre-start-setup.erb to play nice with BPM's persistent disk. Instead of checking for the
+    # existence of the directory /var/vcap/store/mysql, it checks for the existence of the file
+    # /var/vcap/store/mysql/setup_succeeded, which is also created in a command from this patch.
+    - |
+      set -o errexit
+
+      patch /var/vcap/all-releases/jobs-src/cf-mysql/mysql/templates/pre-start-setup.erb << EOT
+      82,84c82,84
+      < if ! test -d \${datadir}; then
+      <   log "pre-start setup script: making \${datadir} and running /var/vcap/packages/mariadb/scripts/mysql_install_db"
+      <   mkdir -p \${datadir}
+      ---
+      > setup_control_file="\${datadir}/setup_succeeded"
+      > if ! test -e "\${setup_control_file}"; then
+      >   log "pre-start setup script: running /var/vcap/packages/mariadb/scripts/mysql_install_db"
+      89a90
+      >   touch "\${setup_control_file}"
+      EOT
     ports:
     - name: mysql
       protocol: TCP


### PR DESCRIPTION
## Description

Since the BPM persistent disk is mounted on /var/vcap/store/mysql, the
original script that runs the database setup stopped running, as the
creation of this directory itself was done as part of the pre-start
setup. The patch introduced in this commit fixes that by switching the
logic to a file inside that folder.

## Test plan

The database should work again, and UAA should connect to it successfully.
