### PR TITLE
Add api instance group with cloud_controller_ng

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,4 @@ password
 *.vmdk
 personal-setup
 
-bazel-bin
-bazel-genfiles
-bazel-out
-bazel-scf
-bazel-testlogs
 /bazel-*

--- a/deploy/helm/scf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/api.yaml
@@ -1,0 +1,95 @@
+# Selectively remove jobs temporarily.
+- type: remove
+  path: /instance_groups/name=api/jobs/name=route_registrar
+- type: remove
+  path: /instance_groups/name=api/jobs/name=statsd_injector
+- type: remove
+  path: /instance_groups/name=api/jobs/name=file_server
+- type: remove
+  path: /instance_groups/name=api/jobs/name=routing-api
+- type: remove
+  path: /instance_groups/name=api/jobs/name=policy-server
+- type: remove
+  path: /instance_groups/name=api/jobs/name=policy-server-internal
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cc_uploader
+- type: remove
+  path: /instance_groups/name=api/jobs/name=loggr-udp-forwarder
+
+# TODO: Remove this replace once all buildpacks are included.
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/install_buildpacks
+  value:
+  - name: binary_buildpack
+    package: binary-buildpack-cflinuxfs3
+
+# TODO: Remove these `remove` once all buildpack images are built.
+- type: remove
+  path: /instance_groups/name=api/jobs/name=dotnet-core-buildpack
+- type: remove
+  path: /instance_groups/name=api/jobs/name=go-buildpack
+- type: remove
+  path: /instance_groups/name=api/jobs/name=java-buildpack
+- type: remove
+  path: /instance_groups/name=api/jobs/name=nodejs-buildpack
+- type: remove
+  path: /instance_groups/name=api/jobs/name=nginx-buildpack
+- type: remove
+  path: /instance_groups/name=api/jobs/name=r-buildpack
+- type: remove
+  path: /instance_groups/name=api/jobs/name=php-buildpack
+- type: remove
+  path: /instance_groups/name=api/jobs/name=python-buildpack
+- type: remove
+  path: /instance_groups/name=api/jobs/name=ruby-buildpack
+- type: remove
+  path: /instance_groups/name=api/jobs/name=staticfile-buildpack
+
+# core_file_pattern should be disabled as CC is not running on a VM.
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/core_file_pattern?
+  value: false
+
+# TODO: Figure out the DB encryption validation.
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/database_encryption?/skip_validation?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/bosh_containerization?
+  value:
+    pre_render_scripts:
+    # TODO: Figure out why tee_output_to_sys_log fails the pre-start.
+    - |
+      set -o errexit
+
+      patch /var/vcap/all-releases/jobs-src/capi/cloud_controller_ng/templates/pre-start.sh.erb << EOT
+      7d6
+      < tee_output_to_sys_log "cloud_controller_ng.\$(basename "\$0")"
+      EOT
+    # Patch a few things on the BPM:
+    #   - DYNO environment variable is not needed.
+    #   - We don't enable New Relic.
+    #   - NGINX maintenance shouldn't run.
+    - |
+      set -o errexit
+
+      patch /var/vcap/all-releases/jobs-src/capi/cloud_controller_ng/templates/bpm.yml.erb << EOT
+      23d22
+      <     "DYNO" => "#{spec.job.name}-#{spec.index}",
+      77,78d75
+      <     nginx_newrelic_plugin_config,
+      <     nginx_maintenance_config,
+      EOT
+
+# Set buildpacks stemcells.
+- type: replace
+  path: /releases/name=binary-buildpack/stemcell?
+  value:
+    os: opensuse-42.3
+    version: 36.g03b4653-30.80-7.0.0_340.g2b599a90
+
+# Add empty BPM processes to buildpacks.
+- type: replace
+  path: /instance_groups/name=api/jobs/name=binary-buildpack/properties?/bosh_containerization?/bpm?/processes?
+  value: []

--- a/deploy/helm/scf/assets/operations/set_opensuse_stemcells.yaml
+++ b/deploy/helm/scf/assets/operations/set_opensuse_stemcells.yaml
@@ -6,7 +6,7 @@
 
 - type: replace
   path: /stemcells/alias=default/version
-  value: 30.g9c91e77-30.80-7.0.0_257.gb97ced55
+  value: 32.g37e6301-30.80-7.0.0_297.g2485f273
 
 - type: replace
   path: /addons/name=loggregator_agent/include/stemcell/os=ubuntu-xenial/os

--- a/deploy/helm/scf/assets/operations/temporary/remove_roles.yaml
+++ b/deploy/helm/scf/assets/operations/temporary/remove_roles.yaml
@@ -10,8 +10,6 @@
 - type: remove
   path: /instance_groups/name=singleton-blobstore
 - type: remove
-  path: /instance_groups/name=api
-- type: remove
   path: /instance_groups/name=cc-worker
 - type: remove
   path: /instance_groups/name=scheduler

--- a/deploy/helm/scf/assets/operations/temporary/remove_variables.yaml
+++ b/deploy/helm/scf/assets/operations/temporary/remove_variables.yaml
@@ -2,17 +2,7 @@
 # It should go away once all instance_groups work properly with cf-operator.
 
 - type: remove
-  path: /variables/name=blobstore_admin_users_password
-- type: remove
   path: /variables/name=blobstore_secure_link_secret
-- type: remove
-  path: /variables/name=cc_bulk_api_password
-- type: remove
-  path: /variables/name=cc_db_encryption_key
-- type: remove
-  path: /variables/name=cc_internal_api_password
-- type: remove
-  path: /variables/name=cc_staging_upload_password
 - type: remove
   path: /variables/name=silk_ca
 - type: remove
@@ -30,15 +20,9 @@
 - type: remove
   path: /variables/name=cf_bosh_password
 - type: remove
-  path: /variables/name=router_route_services_secret
-- type: remove
   path: /variables/name=diego_bbs_encryption_keys_passphrase
 - type: remove
   path: /variables/name=credhub_encryption_password
-- type: remove
-  path: /variables/name=diego_ssh_proxy_host_key
-- type: remove
-  path: /variables/name=service_cf_internal_ca
 - type: remove
   path: /variables/name=blobstore_tls
 - type: remove
@@ -78,23 +62,15 @@
 - type: remove
   path: /variables/name=logs_provider
 - type: remove
-  path: /variables/name=log_cache_ca
-- type: remove
   path: /variables/name=log_cache
 - type: remove
   path: /variables/name=log_cache_to_loggregator_agent
-- type: remove
-  path: /variables/name=cc_logcache_tls
 - type: remove
   path: /variables/name=logcache_ssl
 - type: remove
   path: /variables/name=router_ca
 - type: remove
   path: /variables/name=router_ssl
-- type: remove
-  path: /variables/name=cc_tls
-- type: remove
-  path: /variables/name=cc_public_tls
 - type: remove
   path: /variables/name=cc_bridge_tps
 - type: remove
@@ -113,8 +89,6 @@
   path: /variables/name=diego_instance_identity_ca
 - type: remove
   path: /variables/name=gorouter_backend_tls
-- type: remove
-  path: /variables/name=credhub_ca
 - type: remove
   path: /variables/name=credhub_tls
 - type: remove


### PR DESCRIPTION
## Description

Bumped the default stemcell version and added the api instance group with the cloud_controller_ng job and the binary buildpack.

## Test plan

Deploy the cf-operator and on SCF:

```
bazel build //deploy/helm/scf:chart && helm template --name scf bazel-bin/deploy/helm/scf/scf-3.0.0.tgz --namespace scf --set "system_domain=$(minikube ip).xip.io" | kubectl apply -f - --namespace scf
```
