### PR TITLE
Bump scf helper to version including the SSG modified for parallel cert generation.

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -140,9 +140,9 @@ releases:
   version: "1.0.4"
   sha1: "22381250b0f334d2c5dde04e85a9c1116d8e04fa"
 - name: scf-helper
-  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.2.tgz"
-  version: "1.0.2"
-  sha1: "0f2fb334ad456e35fff7be1fc56edaf2e07e4e26"
+  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.3.tgz"
+  version: "1.0.3"
+  sha1: "c6187d732f0b49f837bdadd0221fe0d91eb55515"
 - name: "bits-service"
   version: "2.26.0"
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=2.26.0"


### PR DESCRIPTION
## Description

Ref: https://jira.suse.com/browse/CAP-385

Subordinate UAA PR: https://github.com/SUSE/uaa-fissile-release/pull/164

## Test plan

  - Build a cluster in vagrant as usual.
  - After and/or during startup inspect the kube logs of the secret generation pods.
    The output from the cert generations should be interleaved instead of serial.
    Note: As UAA has not as many certs to generate than SCF the amount of interleaving is limited, pure randomness can make it look mostly serial.
