### PR TITLE
make/kube: update CLUSTER_BUILD from git tag

### DIFF
--- a/make/kube
+++ b/make/kube
@@ -32,6 +32,8 @@ version: ${GIT_TAG}
 EOF
     cp chart-parts/* "${FISSILE_OUTPUT_DIR}/templates/"
     ruby bin/image-list.rb "${FISSILE_OUTPUT_DIR}"
+    # Update the cluster version string
+    perl -p -i -e "s@(CLUSTER_BUILD:).*@\\1 \"${GIT_TAG}\"@" "${FISSILE_OUTPUT_DIR}/values.yaml"
 elif [ "${BUILD_TARGET}" = "kube" ]; then
     # This is a small hack to make the output of make kube be compatible with K8s 1.6
     perl -p -i -e 's@extensions/v1beta1@batch/v1@' $(grep -rl 'kind: "Job"' "${FISSILE_OUTPUT_DIR}")


### PR DESCRIPTION
## Description

This ensures that the /v2/info endpoint will have the correct values automatically.  Should help us avoid shipping with the wrong version in the future.

## Test plan

Run `make helm` (or do it via Jenkins), and check that `CLUSTER_BUILD` is 2.17.1 (from the git tag); alternatively, check that the `/v2/info` endpoint responds with a build of 2.17.1.
