### PR TITLE
Moved packaging logic to a standalone script

### DIFF
--- a/rules/helm/BUILD.bazel
+++ b/rules/helm/BUILD.bazel
@@ -1,1 +1,3 @@
 package(default_visibility = ["//visibility:public"])
+
+exports_files(["package.sh"])

--- a/rules/helm/def.bzl
+++ b/rules/helm/def.bzl
@@ -10,6 +10,7 @@ def _package_impl(ctx):
         executable = ctx.executable._script,
         env = {
             "PACKAGE_DIR": ctx.attr.package_dir,
+            # TODO(f0rmiga): Figure out a way of working with paths that contain spaces.
             "TARS": " ".join([f.path for f in ctx.files.tars]),
             "HELM": ctx.executable._helm.path,
             "CHART_VERSION": ctx.attr.chart_version,

--- a/rules/helm/package.sh
+++ b/rules/helm/package.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+build_dir="tmp/build/${PACKAGE_DIR}"
+mkdir -p "${build_dir}"
+cp --dereference --recursive "${PACKAGE_DIR}"/* "${build_dir}"
+
+for t in ${TARS}; do
+  tar xf "${t}" -C "${build_dir}"
+done
+
+"${HELM}" init --client-only > /dev/null
+"${HELM}" package "${build_dir}" \
+  --version="${CHART_VERSION}" \
+  --app-version="${APP_VERSION}" > /dev/null
+
+mv "${OUTPUT_FILENAME}" "${OUTPUT_TGZ}"


### PR DESCRIPTION
## Description

Moved packaging logic to a standalone script to make it "lintable" and easier to maintain.

## Test plan

`bazel build //deploy/helm/scf:chart` should produce the chart package under `bazel-bin/deploy/helm/scf/scf-3.0.0.tgz`.
