### PR TITLE
SCF v2 - Enable log-api instance group and jobs

### DIFF
--- a/bosh/releases/pre_render_scripts/log-api/loggregator_trafficcontroller/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/log-api/loggregator_trafficcontroller/patch_bpm.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+patch --binary --unified /var/vcap/all-releases/jobs-src/loggregator/loggregator_trafficcontroller/templates/bpm.yml.erb <<'EOT'
+@@ -35,7 +35,7 @@
+       CC_CA_FILE: "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/mutual_tls_ca.crt"
+       CC_SERVER_NAME: "<%= p('cc.internal_service_hostname') %>"
+
+-      TRAFFIC_CONTROLLER_IP: "<%= spec.ip %>"
++      TRAFFIC_CONTROLLER_IP: "scf-log-api"
+       TRAFFIC_CONTROLLER_API_HOST: "<%= "https://#{p('cc.internal_service_hostname')}:#{p('cc.tls_port')}" %>"
+       TRAFFIC_CONTROLLER_OUTGOING_DROPSONDE_PORT: "<%= p("loggregator.outgoing_dropsonde_port") %>"
+       TRAFFIC_CONTROLLER_OUTGOING_CERT_FILE: "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/trafficcontroller_outgoing.crt"
+
+EOT

--- a/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
@@ -19,3 +19,14 @@
   value:
     os: opensuse-42.3
     version: 36.g03b4653-30.80-7.0.0_340.g2b599a90
+
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/properties/bosh_containerization?
+  value:
+    run:
+      memory: 128
+      virtual-cpus: 2
+    ports:
+    - name: dropsonde
+      protocol: TCP
+      internal: 8081

--- a/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
@@ -1,0 +1,14 @@
+# ops for the log-api instance group
+# Initial: remove all the jobs
+
+- type: remove
+  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller
+- type: remove
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy
+- type: remove
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway
+- type: remove
+  path: /instance_groups/name=log-api/jobs/name=route_registrar
+
+# Attention: scf/fissile does not use the reverse_log_proxy_gateway
+# We may be able to go without this job

--- a/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
@@ -2,8 +2,6 @@
 # Initial: remove all the jobs
 
 - type: remove
-  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller
-- type: remove
   path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy
 - type: remove
   path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway
@@ -12,3 +10,12 @@
 
 # Attention: scf/fissile does not use the reverse_log_proxy_gateway
 # We may be able to go without this job
+
+# Set loggegrator stemcell to get around issues with the CI not building the general one.
+# See buildpacks in api.yaml as well.
+# (ak) TODO: Remove when we have a proper CI pipeline for stemcells and images.
+- type: replace
+  path: /releases/name=loggregator/stemcell?
+  value:
+    os: opensuse-42.3
+    version: 36.g03b4653-30.80-7.0.0_340.g2b599a90

--- a/deploy/helm/scf/assets/operations/temporary/remove_roles.yaml
+++ b/deploy/helm/scf/assets/operations/temporary/remove_roles.yaml
@@ -18,8 +18,6 @@
 - type: remove
   path: /instance_groups/name=doppler
 - type: remove
-  path: /instance_groups/name=log-api
-- type: remove
   path: /instance_groups/name=credhub
 - type: remove
   path: /instance_groups/name=rotate-cc-database-key

--- a/deploy/helm/scf/assets/operations/temporary/remove_variables.yaml
+++ b/deploy/helm/scf/assets/operations/temporary/remove_variables.yaml
@@ -38,16 +38,6 @@
 - type: remove
   path: /variables/name=loggregator_tls_doppler
 - type: remove
-  path: /variables/name=loggregator_tls_tc
-- type: remove
-  path: /variables/name=loggregator_tls_cc_tc
-- type: remove
-  path: /variables/name=loggregator_rlp_gateway_tls_cc
-- type: remove
-  path: /variables/name=loggregator_tls_rlp
-- type: remove
-  path: /variables/name=loggregator_rlp_gateway
-- type: remove
   path: /variables/name=adapter_rlp_tls
 - type: remove
   path: /variables/name=scheduler_api_tls
@@ -89,7 +79,3 @@
   path: /variables/name=credhub_tls
 - type: remove
   path: /variables/name=ssh_proxy_backends_tls
-- type: remove
-  path: /variables/name=loggregator_rlp_gateway_tls
-- type: remove
-  path: /variables/name=loggregator_trafficcontroller_tls


### PR DESCRIPTION
## Description 

See https://jira.suse.com/browse/CAP-515

Note: Only the `trafficcontroller` job is activated here.
The other jobs
  - reverse-log-proxy
  - reverse-log-proxy-gateway
  - route-registrar

are still disabled, and will be activated in future PRs, as needed.

## Test plan

- Start a local kube cluster (minikube, or kind).
- Start modified scf, see log-api role being green.
