### PR TITLE
Release candidate support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -408,6 +408,7 @@ pipeline {
                 '''
             }
         }
+
         stage('Checkout') {
             when {
                 expression { return (!params.SKIP_CHECKOUT) || params.WIPE }
@@ -415,10 +416,14 @@ pipeline {
             steps {
                 sh '''
                     git config --global --replace-all submodule.fetchJobs 0
+                    # Remove all RC tags in case we had any un-pushed RCs left
+                    # over on the build slave.
+                    git tag --list '*-rc*' | xargs git tag -d
                 '''
                 checkout scm
             }
         }
+
         stage('Check for Changed Files') {
             when {
                 expression { return getBuildType() != BuildType.Master }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,7 +296,9 @@ pipeline {
     }
 
     stages {
-        stage('ensure_triggered_master') {
+        // Builds off the master branch must be triggered to ensure we have the
+        // correct paremeters set
+        stage('Ensure master Build Triggered Correctly') {
             when {
                 expression { return env.BRANCH_NAME == 'master' }
             }
@@ -309,7 +311,7 @@ pipeline {
             }
         }
 
-        stage('wipe') {
+        stage('Wipe') {
             when {
                 expression { return params.WIPE }
             }
@@ -318,7 +320,7 @@ pipeline {
             }
         }
 
-        stage('clean') {
+        stage('Clean') {
             when {
                 expression { return params.CLEAN }
             }
@@ -385,7 +387,7 @@ pipeline {
                 '''
             }
         }
-        stage('checkout') {
+        stage('Checkout') {
             when {
                 expression { return (!params.SKIP_CHECKOUT) || params.WIPE }
             }
@@ -396,7 +398,7 @@ pipeline {
                 checkout scm
             }
         }
-        stage('check_for_changed_files') {
+        stage('Check for Changed Files') {
             when {
                 expression { return (env.BRANCH_NAME != 'master') }
             }
@@ -434,7 +436,7 @@ pipeline {
             }
         }
 
-        stage('tag-release-candidate') {
+        stage('Tag Release Candidate') {
             when {
                 expression { return isReleaseCandidateBuild() }
             }
@@ -463,7 +465,7 @@ pipeline {
             }
         }
 
-        stage('tools') {
+        stage('Tools') {
             steps {
                 sh '''
                     set -e +x
@@ -475,7 +477,7 @@ pipeline {
             }
         }
 
-        stage('verify_no_overwrite') {
+        stage('Verify Not Overwriting S3 Artifacts') {
             when {
                 expression { return params.PUBLISH_S3 && noOverwrites() }
             }
@@ -504,7 +506,7 @@ pipeline {
             }
         }
 
-        stage('build') {
+        stage('Build') {
             steps {
                 withCredentials([usernamePassword(
                     credentialsId: params.DOCKER_CREDENTIALS,
@@ -528,7 +530,7 @@ pipeline {
             }
         }
 
-        stage('dist') {
+        stage('Dist') {
             steps {
                 sh '''
                     set -e +x
@@ -541,7 +543,7 @@ pipeline {
             }
         }
 
-        stage('publish_docker') {
+        stage('Publish Docker Images') {
             when {
                 expression { return params.PUBLISH_DOCKER }
             }
@@ -563,7 +565,7 @@ pipeline {
             }
         }
 
-        stage('publish_s3') {
+        stage('Publish Archives to S3') {
             when {
                 expression { return params.PUBLISH_S3 }
             }
@@ -611,7 +613,7 @@ pipeline {
             }
         }
 
-        stage('deploy') {
+        stage('Deploy to Kubernetes') {
             when {
                 expression { return params.TEST_SMOKE || params.TEST_BRAIN || params.TEST_SITS || params.TEST_CATS }
             }
@@ -678,7 +680,7 @@ pipeline {
             }
         }
 
-        stage('rotate') {
+        stage('Test Secret Rotation') {
             when {
                 expression { return params.TEST_ROTATE }
             }
@@ -771,7 +773,7 @@ pipeline {
             }
         }
 
-        stage('smoke') {
+        stage('Smoke Tests') {
             when {
                 expression { return params.TEST_SMOKE }
             }
@@ -791,7 +793,7 @@ pipeline {
             }
         }
 
-        stage('brain') {
+        stage('Brains Tests') {
             when {
                 expression { return params.TEST_BRAIN }
             }
@@ -811,7 +813,7 @@ pipeline {
             }
         }
 
-        stage('sits') {
+        stage('Sync Integration Tests') {
             when {
                 expression { return params.TEST_SITS }
             }
@@ -831,7 +833,7 @@ pipeline {
             }
         }
 
-        stage('cats') {
+        stage('Cloud Foundry Acceptance Tests') {
             when {
                 expression { return params.TEST_CATS }
             }
@@ -851,7 +853,7 @@ pipeline {
             }
         }
 
-        stage('tar_sources') {
+        stage('Tar Sources') {
           when {
                 expression { return params.TAR_SOURCES }
           }
@@ -864,7 +866,7 @@ pipeline {
           }
         }
 
-        stage('commit_sources') {
+        stage('Commit Sources to OBS') {
           when {
                 expression { return params.COMMIT_SOURCES }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ BuildType getBuildType() {
                     return BuildType.Nightly
                 }
                 return BuildType.Develop
-            case 'release-candidate':
+            case 'rc':
                 return BuildType.ReleaseCandidate
         }
         "${CHANGE_ID}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -418,7 +418,7 @@ pipeline {
                     git config --global --replace-all submodule.fetchJobs 0
                     # Remove all RC tags in case we had any un-pushed RCs left
                     # over on the build slave.
-                    git tag --list '*-rc*' | xargs git tag -d
+                    git tag --list '*-rc*' | xargs --no-run-if-empty git tag -d
                 '''
                 checkout scm
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -639,7 +639,7 @@ pipeline {
             }
         }
 
-        stage('Push Release Canididate Tag') {
+        stage('Push Release Candidate Tag') {
             when {
                 expression { return getBuildType() == BuildType.ReleaseCandidate }
             }

--- a/make/include/versioning
+++ b/make/include/versioning
@@ -11,6 +11,8 @@ GIT_DESCRIBE=${GIT_DESCRIBE:-$(git describe --tags --long)}
 GIT_BRANCH=${GIT_BRANCH:-$(git name-rev --name-only HEAD | sed -e 's/[^-a-zA-Z0-9_.]/_/g')}
 
 GIT_TAG=${GIT_TAG:-${GIT_DESCRIBE%-*-*}} # Remove the last two hyphen-separated sections
+# shellcheck disable=2001 # can't use ${x//y} or ${x%y} here
+GIT_TAG="$(echo "${GIT_TAG}" | sed 's@-rc[0-9]\+$@@')" # Remove trailing "-rc1" marker
 GIT_COMMITS=${GIT_COMMITS:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $(NF - 1) }' )}
 GIT_SHA=${GIT_SHA:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $NF }' )}
 


### PR DESCRIPTION
## Description

This branch modifies the Jenkins build process such that when it is built from the `release-candidate` branch, it does some extra things:
- Drops the `-rc?` suffix on the artifacts (so it looks like a release build).
- Tags the repo with the RC release number (so we can go back and look at it).
- Jenkins will only build this on a manual trigger, or updating the [change log](https://github.com/SUSE/scf/blob/develop/CHANGELOG.md).

## Test plan

Please check the new `scf-release-candidate` Jenkins pipeline (not linking because this is a public PR). It's currently set up to build from the PR branch instead of the final RC branch, but otherwise it should be the same.  I manually deleted the extra `0.0.0-rc1` tag it created (I modified the changelog so the top entry was version `0.0.0`).
