### PR TITLE
Remove addons

### DIFF
--- a/deploy/helm/scf/assets/operations/set_opensuse_stemcells.yaml
+++ b/deploy/helm/scf/assets/operations/set_opensuse_stemcells.yaml
@@ -7,15 +7,3 @@
 - type: replace
   path: /stemcells/alias=default/version
   value: 36.g03b4653-30.80-7.0.0_340.g2b599a90
-
-- type: replace
-  path: /addons/name=loggregator_agent/include/stemcell/os=ubuntu-xenial/os
-  value: opensuse-42.3
-
-- type: replace
-  path: /addons/name=forwarder_agent/include/stemcell/os=ubuntu-xenial/os
-  value: opensuse-42.3
-
-- type: replace
-  path: /addons/name=bpm/include/stemcell/os=ubuntu-xenial/os
-  value: opensuse-42.3

--- a/deploy/helm/scf/assets/operations/temporary/remove_addons.yaml
+++ b/deploy/helm/scf/assets/operations/temporary/remove_addons.yaml
@@ -1,0 +1,8 @@
+- type: remove
+  path: /addons/name=loggregator_agent
+- type: remove
+  path: /addons/name=forwarder_agent
+- type: remove
+  path: /addons/name=bpm
+- type: remove
+  path: /addons/name=bosh-dns-aliases


### PR DESCRIPTION
## Description

The current state of cf-operator doesn't allow addons to work as it is currently setup on v2-develop. This PR removed them so we can add them accordingly on a separate branch.

## Test plan

SCF should come up with the latest cf-operator.
