### PR TITLE
Make `bazel run` targets use rules ending in `_binary`

### DIFF
--- a/dev/kind/BUILD.bazel
+++ b/dev/kind/BUILD.bazel
@@ -1,15 +1,15 @@
 package(default_visibility = ["//visibility:public"])
 
-load(":def.bzl", "kind_start", "kind_delete")
+load(":def.bzl", "kind_start_binary", "kind_delete_binary")
 
 CLUSTER_NAME = "scf"
 
-kind_start(
+kind_start_binary(
     name = "start",
     cluster_name = CLUSTER_NAME,
 )
 
-kind_delete(
+kind_delete_binary(
     name = "delete",
     cluster_name = CLUSTER_NAME,
 )

--- a/dev/kind/def.bzl
+++ b/dev/kind/def.bzl
@@ -51,7 +51,7 @@ attrs = {
     ),
 }
 
-kind_start = rule(
+kind_start_binary = rule(
     implementation = _kind_impl,
     attrs = dict({
         "_script": attr.label(
@@ -64,7 +64,7 @@ kind_start = rule(
     executable = True,
 )
 
-kind_delete = rule(
+kind_delete_binary = rule(
     implementation = _kind_impl,
     attrs = dict({
         "_script": attr.label(

--- a/dev/minikube/BUILD.bazel
+++ b/dev/minikube/BUILD.bazel
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load(":def.bzl", "minikube_start", "minikube_delete")
+load(":def.bzl", "minikube_start_binary", "minikube_delete_binary")
 
-minikube_start(
+minikube_start_binary(
     name = "start",
 )
 
-minikube_delete(
+minikube_delete_binary(
     name = "delete",
 )

--- a/dev/minikube/def.bzl
+++ b/dev/minikube/def.bzl
@@ -64,7 +64,7 @@ attrs = {
     ),
 }
 
-minikube_start = rule(
+minikube_start_binary = rule(
     implementation = _minikube_start_impl,
     attrs = dict({
         "_script": attr.label(
@@ -77,7 +77,7 @@ minikube_start = rule(
     executable = True,
 )
 
-minikube_delete = rule(
+minikube_delete_binary = rule(
     implementation = _minikube_start_impl,
     attrs = dict({
         "_script": attr.label(

--- a/dev/scf/BUILD.bazel
+++ b/dev/scf/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//rules/helm:def.bzl", helm_template = "template")
-load("//rules/kubectl:def.bzl", kubectl_apply = "apply", kubectl_delete = "delete")
+load("//rules/kubectl:def.bzl", kubectl_apply_binary = "apply", kubectl_delete_binary = "delete")
 
 NAMESPACE = "scf"
 
@@ -16,13 +16,13 @@ helm_template(
     chart_package = "//deploy/helm/scf:chart",
 )
 
-kubectl_apply(
+kubectl_apply_binary(
     name = "apply",
     resource = ":rendered_template",
     namespace = NAMESPACE,
 )
 
-kubectl_delete(
+kubectl_delete_binary(
     name = "delete",
     resource = ":rendered_template",
     namespace = NAMESPACE,


### PR DESCRIPTION
## Description

The bash completion included in bazel seems to want the convention where
things we `bazel run` are written with rules ending in `_binary`; also,
`bazel test` targets should be written with rules ending in `_test` or
be named `test_suite`.

This fixes auto-completion for me.

## Test plan

Make sure `bazel run //dev/kind:start`, etc. still work.
If you have bash completion, check that `bazel run //dev/kind:` completes `start`, `delete`.