### PR TITLE
Updated Minikube image and added VM_DRIVER option

### DIFF
--- a/dev/minikube/README.md
+++ b/dev/minikube/README.md
@@ -11,6 +11,9 @@ bazel run //dev/minikube:start
 The following environment variables are used by the `start` target to allocate the resources used by
 Minikube:
 
+  - VM_DRIVER - the driver to be used by Minikube for the virtualization. Available options:
+      - virtualbox
+      - kvm2
   - VM_CPUS - the number of CPUs Minikube will use.
   - VM_MEMORY - the amount of RAM Minikube will be allowed to use.
   - VM_DISK_SIZE - the disk size Minikube will be allowed to use.

--- a/dev/minikube/def.bzl
+++ b/dev/minikube/def.bzl
@@ -6,6 +6,7 @@ def _minikube_start_impl(ctx):
         set -o errexit
         export MINIKUBE="{minikube}"
         export K8S_VERSION="${{K8S_VERSION:-{k8s_version}}}"
+        export VM_DRIVER="${{VM_DRIVER:-{vm_driver}}}"
         export VM_CPUS="${{VM_CPUS:-{vm_cpus}}}"
         export VM_MEMORY="${{VM_MEMORY:-{vm_memory}}}"
         export VM_DISK_SIZE="${{VM_DISK_SIZE:-{vm_disk_size}}}"
@@ -15,6 +16,7 @@ def _minikube_start_impl(ctx):
     """.format(
         minikube = ctx.executable._minikube.path,
         k8s_version = ctx.attr.k8s_version,
+        vm_driver = ctx.attr.vm_driver,
         vm_cpus = ctx.attr.vm_cpus,
         vm_memory = ctx.attr.vm_memory,
         vm_disk_size = ctx.attr.vm_disk_size,
@@ -38,6 +40,9 @@ attrs = {
     "k8s_version": attr.string(
         default = "v{}".format(project.kubernetes.version),
     ),
+    "vm_driver": attr.string(
+        default = "virtualbox",
+    ),
     "vm_cpus": attr.string(
         default = "4",
     ),
@@ -48,7 +53,7 @@ attrs = {
         default = "120g",
     ),
     "iso_url": attr.string(
-        default = "https://github.com/f0rmiga/opensuse-minikube-image/releases/download/v0.1.0/minikube-openSUSE.x86_64-1.0.0.iso",
+        default = "https://github.com/f0rmiga/opensuse-minikube-image/releases/download/v0.1.2/minikube-openSUSE.x86_64-0.1.2.iso",
     ),
     "_minikube": attr.label(
         allow_single_file = True,

--- a/dev/minikube/start.sh
+++ b/dev/minikube/start.sh
@@ -4,6 +4,7 @@ set -o errexit -o nounset
 
 if ! "${MINIKUBE}" status > /dev/null; then
   "${MINIKUBE}" start \
+    --vm-driver "${VM_DRIVER}" \
     --kubernetes-version "${K8S_VERSION}" \
     --cpus "${VM_CPUS}" \
     --memory "${VM_MEMORY}" \


### PR DESCRIPTION
## Description

It now supports `VM_DRIVER=kvm2`.

## Test plan

Check that `bazel run //dev/minikube:start` works with `virtualbox` and `kvm2`.
