### PR TITLE
Make the release URLs customizable

### DIFF
--- a/deploy/helm/scf/assets/operations/set_release_urls.yaml
+++ b/deploy/helm/scf/assets/operations/set_release_urls.yaml
@@ -2,180 +2,180 @@
 
 - type: replace
   path: /releases/name=binary-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=binary-buildpack/sha1
 
 - type: replace
   path: /releases/name=bpm/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=bpm/sha1
 
 - type: replace
   path: /releases/name=capi/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=capi/sha1
 
 - type: replace
   path: /releases/name=cf-networking/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=cf-networking/sha1
 
 - type: replace
   path: /releases/name=cf-smoke-tests/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=cf-smoke-tests/sha1
 
 - type: replace
   path: /releases/name=cf-syslog-drain/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=cf-syslog-drain/sha1
 
 - type: replace
   path: /releases/name=cflinuxfs3/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=cflinuxfs3/sha1
 
 - type: replace
   path: /releases/name=credhub/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=credhub/sha1
 
 - type: replace
   path: /releases/name=diego/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=diego/sha1
 
 - type: replace
   path: /releases/name=dotnet-core-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=dotnet-core-buildpack/sha1
 
 - type: replace
   path: /releases/name=garden-runc/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=garden-runc/sha1
 
 - type: replace
   path: /releases/name=go-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=go-buildpack/sha1
 
 - type: replace
   path: /releases/name=java-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=java-buildpack/sha1
 
 - type: replace
   path: /releases/name=loggregator/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=loggregator/sha1
 
 - type: replace
   path: /releases/name=nats/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=nats/sha1
 
 - type: replace
   path: /releases/name=nginx-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=nginx-buildpack/sha1
 
 - type: replace
   path: /releases/name=r-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=r-buildpack/sha1
 
 - type: replace
   path: /releases/name=nodejs-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=nodejs-buildpack/sha1
 
 - type: replace
   path: /releases/name=php-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=php-buildpack/sha1
 
 - type: replace
   path: /releases/name=python-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=python-buildpack/sha1
 
 - type: replace
   path: /releases/name=routing/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=routing/sha1
 
 - type: replace
   path: /releases/name=ruby-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=ruby-buildpack/sha1
 
 - type: replace
   path: /releases/name=silk/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=silk/sha1
 
 - type: replace
   path: /releases/name=staticfile-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=staticfile-buildpack/sha1
 
 - type: replace
   path: /releases/name=statsd-injector/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=statsd-injector/sha1
 
 - type: replace
   path: /releases/name=uaa/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=uaa/sha1
 
 - type: replace
   path: /releases/name=loggregator-agent/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=loggregator-agent/sha1
 
 - type: replace
   path: /releases/name=log-cache/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=log-cache/sha1
 
 - type: replace
   path: /releases/name=bosh-dns-aliases/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=bosh-dns-aliases/sha1
 
 - type: replace
   path: /releases/name=cf-cli/url
-  value: docker.io/cfcontainerization
+  value: ((container-image-prefix))
 - type: remove
   path: /releases/name=cf-cli/sha1

--- a/deploy/helm/scf/templates/implicit_vars.yaml
+++ b/deploy/helm/scf/templates/implicit_vars.yaml
@@ -1,8 +1,9 @@
+{{- define "scf.implicit-var" }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.deployment_name }}.var-system-domain
+  name: {{ .Values.deployment_name }}.var-{{ index . "variable-name" | replace "_" "-" }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
@@ -11,18 +12,9 @@ metadata:
     helm.sh/chart: {{ include "scf.chart" . }}
 type: Opaque
 stringData:
-  value: {{ .Values.system_domain | quote }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.deployment_name }}.var-deployment-name
-  labels:
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/name: {{ include "scf.fullname" . }}
-    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
-    helm.sh/chart: {{ include "scf.chart" . }}
-type: Opaque
-stringData:
-  value: {{ .Values.deployment_name | quote }}
+  value: {{ index .Values ( index . "variable-name" ) | quote }}
+{{- end }}
+
+{{ include "scf.implicit-var" (merge (dict "variable-name" "system_domain") .) }}
+{{ include "scf.implicit-var" (merge (dict "variable-name" "deployment_name") .) }}
+{{ include "scf.implicit-var" (merge (dict "variable-name" "container_image_prefix") .) }}

--- a/deploy/helm/scf/values.yaml
+++ b/deploy/helm/scf/values.yaml
@@ -1,2 +1,3 @@
 system_domain: ~
 deployment_name: scf
+container_image_prefix: docker.io/cfcontainerization


### PR DESCRIPTION
## Description

This lets us change the release URLs (actually the docker org for the
images to use); also, refactor how we do implicit variables a bit to
reduce duplication.

No change to default behaviour.

Closes jsc#CAP-553.

## Test plan

A normal `bazel run //dev/scf:apply` should have no changes. However, we should now be able to override the prefix to something different (which will not work because we don't have those images).
