### PR TITLE
Make the release URLs customizable

### DIFF
--- a/deploy/helm/scf/assets/operations/set_release_urls.yaml
+++ b/deploy/helm/scf/assets/operations/set_release_urls.yaml
@@ -2,180 +2,180 @@
 
 - type: replace
   path: /releases/name=binary-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=binary-buildpack/sha1
 
 - type: replace
   path: /releases/name=bpm/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=bpm/sha1
 
 - type: replace
   path: /releases/name=capi/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=capi/sha1
 
 - type: replace
   path: /releases/name=cf-networking/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=cf-networking/sha1
 
 - type: replace
   path: /releases/name=cf-smoke-tests/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=cf-smoke-tests/sha1
 
 - type: replace
   path: /releases/name=cf-syslog-drain/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=cf-syslog-drain/sha1
 
 - type: replace
   path: /releases/name=cflinuxfs3/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=cflinuxfs3/sha1
 
 - type: replace
   path: /releases/name=credhub/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=credhub/sha1
 
 - type: replace
   path: /releases/name=diego/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=diego/sha1
 
 - type: replace
   path: /releases/name=dotnet-core-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=dotnet-core-buildpack/sha1
 
 - type: replace
   path: /releases/name=garden-runc/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=garden-runc/sha1
 
 - type: replace
   path: /releases/name=go-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=go-buildpack/sha1
 
 - type: replace
   path: /releases/name=java-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=java-buildpack/sha1
 
 - type: replace
   path: /releases/name=loggregator/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=loggregator/sha1
 
 - type: replace
   path: /releases/name=nats/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=nats/sha1
 
 - type: replace
   path: /releases/name=nginx-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=nginx-buildpack/sha1
 
 - type: replace
   path: /releases/name=r-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=r-buildpack/sha1
 
 - type: replace
   path: /releases/name=nodejs-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=nodejs-buildpack/sha1
 
 - type: replace
   path: /releases/name=php-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=php-buildpack/sha1
 
 - type: replace
   path: /releases/name=python-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=python-buildpack/sha1
 
 - type: replace
   path: /releases/name=routing/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=routing/sha1
 
 - type: replace
   path: /releases/name=ruby-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=ruby-buildpack/sha1
 
 - type: replace
   path: /releases/name=silk/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=silk/sha1
 
 - type: replace
   path: /releases/name=staticfile-buildpack/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=staticfile-buildpack/sha1
 
 - type: replace
   path: /releases/name=statsd-injector/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=statsd-injector/sha1
 
 - type: replace
   path: /releases/name=uaa/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=uaa/sha1
 
 - type: replace
   path: /releases/name=loggregator-agent/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=loggregator-agent/sha1
 
 - type: replace
   path: /releases/name=log-cache/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=log-cache/sha1
 
 - type: replace
   path: /releases/name=bosh-dns-aliases/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=bosh-dns-aliases/sha1
 
 - type: replace
   path: /releases/name=cf-cli/url
-  value: docker.io/cfcontainerization
+  value: ((releases-defaults-url))
 - type: remove
   path: /releases/name=cf-cli/sha1

--- a/deploy/helm/scf/templates/_helpers.tpl
+++ b/deploy/helm/scf/templates/_helpers.tpl
@@ -37,3 +37,21 @@ Get the metadata name for an ops file.
 {{- define "scf.ops-name" -}}
 {{- printf "ops-%s" (base . | trimSuffix (ext .) | lower | replace "_" "-") -}}
 {{- end -}}
+
+{{- /*
+  Template "scf.dig" takes a dict and a list; it indexes the dict with each
+  successive element of the list.
+
+  For example, given (using JSON prepresentations)
+    $a = { foo: { bar: { baz: 1 } } }
+    $b = [ foo bar baz ]
+  Then `template "scf.dig" $a $b` will return "1".
+
+  Note that if the key is missing there will be a rendering error.
+*/ -}}
+{{- define "scf.dig" }}
+{{- $obj := first . }}
+{{- $keys := last . }}
+{{- range $key := $keys }}{{ $obj = index $obj $key }}{{ end }}
+{{- $obj | quote }}
+{{- end }}

--- a/deploy/helm/scf/templates/implicit_vars.yaml
+++ b/deploy/helm/scf/templates/implicit_vars.yaml
@@ -1,8 +1,16 @@
+{{- /*
+  Template "scf.implicit-var" generates the kube secret declaration for a
+  variable.  It takes a list of two arguments: the context, and the variable
+  name.
+*/ -}}
+{{- define "scf.implicit-var" }}
+{{- $variable_name := (last .) }}
+{{- with (first .) }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.deployment_name }}.var-system-domain
+  name: {{ .Values.deployment_name }}.var-{{ $variable_name | replace "_" "-" | replace "." "-" }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
@@ -11,18 +19,10 @@ metadata:
     helm.sh/chart: {{ include "scf.chart" . }}
 type: Opaque
 stringData:
-  value: {{ .Values.system_domain | quote }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.deployment_name }}.var-deployment-name
-  labels:
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/name: {{ include "scf.fullname" . }}
-    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
-    helm.sh/chart: {{ include "scf.chart" . }}
-type: Opaque
-stringData:
-  value: {{ .Values.deployment_name | quote }}
+  value: {{ template "scf.dig" (list .Values ( splitList "." $variable_name )) }}
+{{- end }}
+{{- end }}
+
+{{ include "scf.implicit-var" (list . "system_domain") }}
+{{ include "scf.implicit-var" (list . "deployment_name") }}
+{{ include "scf.implicit-var" (list . "releases.defaults.url") }}

--- a/deploy/helm/scf/values.yaml
+++ b/deploy/helm/scf/values.yaml
@@ -1,2 +1,6 @@
 system_domain: ~
 deployment_name: scf
+releases:
+  # The defaults for all releases, where we do not otherwise override them.
+  defaults:
+    url: docker.io/cfcontainerization


### PR DESCRIPTION
## Description

This lets us change the release URLs (actually the docker org for the images to use); also, refactor how we do implicit variables a bit to reduce duplication.

No change to default behaviour.

Closes jsc#CAP-553.  Supercedes #2601 (due to the change in the base branch).

## Test plan

A normal `bazel run //dev/scf:apply` should have no changes. However, we should now be able to override the prefix to something different (which will not work because we don't have those images)