### PR TITLE
v3 - Fixed remaining *.service.cf.internal addresses

### DIFF
--- a/bosh/releases/pre_render_scripts/api/cloud_controller_ng/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/api/cloud_controller_ng/patch_bpm.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/capi/cloud_controller_ng/templates/bpm.yml.erb"
 
 # Patch a few things on the BPM:
 #   - DYNO environment variable is not needed.
 #   - We don't enable New Relic.
 #   - NGINX maintenance shouldn't run.
-patch /var/vcap/all-releases/jobs-src/capi/cloud_controller_ng/templates/bpm.yml.erb <<'EOT'
+patch --verbose "${target}" <<'EOT'
 23d22
 <     "DYNO" => "#{spec.job.name}-#{spec.index}",
 77,78d75

--- a/bosh/releases/pre_render_scripts/api/cloud_controller_ng/remove_tee_output_to_sys_log.sh
+++ b/bosh/releases/pre_render_scripts/api/cloud_controller_ng/remove_tee_output_to_sys_log.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/capi/cloud_controller_ng/templates/pre-start.sh.erb"
 
 # TODO: Figure out why tee_output_to_sys_log fails the pre-start.
-patch /var/vcap/all-releases/jobs-src/capi/cloud_controller_ng/templates/pre-start.sh.erb <<'EOT'
+patch --verbose "${target}" <<'EOT'
 7d6
 < tee_output_to_sys_log "cloud_controller_ng.$(basename "$0")"
 EOT

--- a/bosh/releases/pre_render_scripts/api/routing-api/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/api/routing-api/patch_bpm.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -o errexit -o nounset
 
-patch --binary --unified /var/vcap/all-releases/jobs-src/routing/routing-api/templates/bpm.yml.erb <<'EOT'
+target="/var/vcap/all-releases/jobs-src/routing/routing-api/templates/bpm.yml.erb"
+
+patch --binary --unified --verbose "${target}" <<'EOT'
 @@ -11,7 +11,7 @@
      - -timeFormat
      - rfc3339

--- a/bosh/releases/pre_render_scripts/database/mysql/patch_pre-start-setup.sh
+++ b/bosh/releases/pre_render_scripts/database/mysql/patch_pre-start-setup.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/cf-mysql/mysql/templates/pre-start-setup.erb"
 
 # Patch pre-start-setup.erb to play nice with BPM's persistent disk. Instead of checking for the
 # existence of the directory /var/vcap/store/mysql, it checks for the existence of the file
 # /var/vcap/store/mysql/setup_succeeded, which is also created in a command from this patch.
-patch /var/vcap/all-releases/jobs-src/cf-mysql/mysql/templates/pre-start-setup.erb <<'EOT'
+patch --verbose "${target}" <<'EOT'
 82,84c82,84
 < if ! test -d ${datadir}; then
 <   log "pre-start setup script: making ${datadir} and running /var/vcap/packages/mariadb/scripts/mysql_install_db"

--- a/bosh/releases/pre_render_scripts/log-api/loggregator_trafficcontroller/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/log-api/loggregator_trafficcontroller/patch_bpm.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -o errexit -o nounset
 
-patch --binary --unified /var/vcap/all-releases/jobs-src/loggregator/loggregator_trafficcontroller/templates/bpm.yml.erb <<'EOT'
+target="/var/vcap/all-releases/jobs-src/loggregator/loggregator_trafficcontroller/templates/bpm.yml.erb"
+
+patch --binary --unified --verbose "${target}" <<'EOT'
 @@ -35,7 +35,7 @@
        CC_CA_FILE: "/var/vcap/jobs/loggregator_trafficcontroller/config/certs/mutual_tls_ca.crt"
        CC_SERVER_NAME: "<%= p('cc.internal_service_hostname') %>"

--- a/bosh/releases/pre_render_scripts/singleton-blobstore/blobstore/patch_blobstore_conf.sh
+++ b/bosh/releases/pre_render_scripts/singleton-blobstore/blobstore/patch_blobstore_conf.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+# Fix the hardcoded server_name.
+
+target="/var/vcap/all-releases/jobs-src/capi/blobstore/templates/blobstore.conf.erb"
+
+patch --binary --unified --verbose "${target}" <<'EOT'
+@@ -13,7 +13,7 @@
+ # Internal server
+ server {
+   listen      <%= p('blobstore.tls.port') %> ssl;
+-  server_name blobstore.service.cf.internal;
++  server_name <%= p("internal_server_name") %>;
+   ssl_certificate     /var/vcap/jobs/blobstore/ssl/blobstore.crt;
+   ssl_certificate_key /var/vcap/jobs/blobstore/ssl/blobstore.key;
+EOT

--- a/bosh/releases/pre_render_scripts/singleton-blobstore/blobstore/patch_blobstore_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/singleton-blobstore/blobstore/patch_blobstore_pre-start.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -o errexit -o nounset
 
 # Perform a faster chown when the blobstore starts.
-patch --binary --unified /var/vcap/all-releases/jobs-src/capi/blobstore/templates/pre-start.sh.erb <<'EOT'
+
+target="/var/vcap/all-releases/jobs-src/capi/blobstore/templates/pre-start.sh.erb"
+
+patch --binary --unified --verbose "${target}" <<'EOT'
 @@ -20,14 +20,10 @@
 
    chown vcap:vcap $store_dir

--- a/bosh/releases/pre_render_scripts/singleton-blobstore/blobstore/patch_job_mf.sh
+++ b/bosh/releases/pre_render_scripts/singleton-blobstore/blobstore/patch_job_mf.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+# Add internal_server_name property so it can be injected.
+
+target="/var/vcap/all-releases/jobs-src/capi/blobstore/job.MF"
+
+patch --binary --unified --verbose "${target}" <<'EOT'
+@@ -95,2 +95,5 @@
+   domain:
+     description: "DEPRECATED: The system domain.  The public server will listen on host 'blobstore.system-domain.tld'"
++
++  internal_server_name:
++    description: "The internal server_name"
+EOT

--- a/bosh/releases/pre_render_scripts/uaa/uaa/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/uaa/uaa/patch_pre-start.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/uaa/uaa/templates/bin/pre-start.erb"
 
 # Patch bin/pre-start.erb for the certificates to work with SUSE.
-patch /var/vcap/all-releases/jobs-src/uaa/uaa/templates/bin/pre-start.erb <<'EOT'
+patch --verbose "${target}" <<'EOT'
 24c24
 < rm -f /usr/local/share/ca-certificates/uaa_*
 ---
@@ -14,12 +16,4 @@ patch /var/vcap/all-releases/jobs-src/uaa/uaa/templates/bin/pre-start.erb <<'EOT
 ---
 >     echo "Adding certificate from manifest to OS certs /etc/pki/trust/anchors/uaa_<%= i %>.crt"
 >     echo -n '<%= cert %>' >> "/etc/pki/trust/anchors/uaa_<%= i %>.crt"
-EOT
-
-# Patch bin/uaa.erb for the certificates to work with SUSE.
-patch /var/vcap/all-releases/jobs-src/uaa/uaa/templates/bin/uaa.erb <<'EOT'
-49c49
-< cp /etc/ssl/certs/ca-certificates.crt "$CERT_FILE"
----
-> cp /var/lib/ca-certificates/ca-bundle.pem "$CERT_FILE"
 EOT

--- a/bosh/releases/pre_render_scripts/uaa/uaa/patch_uaa.sh
+++ b/bosh/releases/pre_render_scripts/uaa/uaa/patch_uaa.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/uaa/uaa/templates/bin/uaa.erb"
+
+# Patch bin/uaa.erb for the certificates to work with SUSE.
+patch --verbose "${target}" <<'EOT'
+49c49
+< cp /etc/ssl/certs/ca-certificates.crt "$CERT_FILE"
+---
+> cp /var/lib/ca-certificates/ca-bundle.pem "$CERT_FILE"
+EOT

--- a/deploy/helm/scf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/api.yaml
@@ -61,6 +61,17 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/database_encryption?/skip_validation?
   value: true
 
+# Set the common name for the cc_bridge_cc_uploader_server certificate.
+- type: replace
+  path: /variables/name=cc_bridge_cc_uploader_server/options/common_name
+  value: ((deployment-name))-api
+- type: replace
+  path: /variables/name=cc_bridge_cc_uploader_server/options/alternative_names
+  value:
+  - ((deployment-name))-api
+  # 127.0.0.1 is needed by cloud_controller_ng to talk to cc_uploader without having to hairpin.
+  - 127.0.0.1
+
 # Override the addresses for the jobs under the api instance group.
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/address
@@ -82,12 +93,15 @@
   value: https://((deployment-name))-diego-api:8889
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego?/file_server_url
-  value: http://localhost.:8080
+  value: http://127.0.0.1:8080
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego?/cc_uploader_https_url
+  value: https://127.0.0.1:9091
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/internal_service_hostname?
-  value: localhost.
+  value: 127.0.0.1
 - type: replace
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/logcache?
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/logcache?/host
   value: ((deployment-name))-doppler
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/loggregator?/internal_url
@@ -114,6 +128,12 @@
   path: /instance_groups/name=api/jobs/name=route_registrar/properties/nats?/machines
   value:
   - ((deployment-name))-nats
+- type: replace
+  path: /instance_groups/name=api/jobs/name=route_registrar/properties/route_registrar?/routing_api/api_url
+  value: http://127.0.0.1:3000
+- type: replace
+  path: /instance_groups/name=api/jobs/name=route_registrar/properties/route_registrar?/routing_api/oauth_url
+  value: https://((deployment-name))-uaa:8443
 
 # Add empty BPM processes to buildpacks.
 - type: replace
@@ -165,17 +185,6 @@
 #       memory: 128
 #       virtual-cpus: 4
 
-# # Add bosh_containerization properties for file_server.
-# - type: replace
-#   path: /instance_groups/name=api/jobs/name=file_server/properties/bosh_containerization?
-#   value:
-#     ports:
-#     - name: file-server
-#       protocol: TCP
-#       internal: 8080
-#     run:
-#       memory: 512
-#       virtual-cpus: 4
 # Add bosh_containerization properties for file_server.
 - type: replace
   path: /instance_groups/name=api/jobs/name=file_server/properties/bosh_containerization?

--- a/deploy/helm/scf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/diego-api.yaml
@@ -13,7 +13,7 @@
   # included "*.locket.service.cf.internal".
   # - "*.((deployment-name))-diego-api"
   - ((deployment-name))-diego-api
-  # localhost is needed by bbs to talk to locket without having to hairpin.
+  # 127.0.0.1 is needed by bbs to talk to locket without having to hairpin.
   - 127.0.0.1
 
 # Set the common name for the diego_bbs_server certificate.
@@ -27,6 +27,8 @@
   # included "*.bbs.service.cf.internal".
   # - "*.((deployment-name))-diego-api"
   - ((deployment-name))-diego-api
+  # 127.0.0.1 is needed by cfdot to talk to bbs without having to hairpin.
+  - 127.0.0.1
 
 # Override the addresses for the jobs under the diego-api instance group.
 - type: replace
@@ -38,6 +40,18 @@
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/locket?/api_location
   value: 127.0.0.1:8891
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/auctioneer?/api_location
+  value: ((deployment-name))-scheduler:9016
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/advertisement_base_hostname?
+  value: ((deployment-name))-diego-api
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=cfdot/properties/bbs?/hostname
+  value: 127.0.0.1
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=cfdot/properties/locket?/hostname
+  value: 127.0.0.1
 
 # Disable tuning /proc/sys kernel parameters as locket and bbs are running on containers.
 - type: replace

--- a/deploy/helm/scf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/diego-cell.yaml
@@ -30,6 +30,18 @@
   path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/diego/route_emitter/bbs/api_location?
   value:
   - ((deployment-name))-diego-api:8889
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/locks?/locket/hostname
+  value: ((deployment-name))-diego-api
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/routing_api?/url
+  value: http://((deployment-name))-api
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=cfdot/properties/bbs?/hostname
+  value: ((deployment-name))-diego-api
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=cfdot/properties/locket?/hostname
+  value: ((deployment-name))-diego-api
 
 # Add bosh_containerization properties.
 - type: replace

--- a/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
@@ -4,11 +4,17 @@
 - type: remove
   path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy
 
-# Fix the nats address for the route_registrar.
+# Override the addresses for the jobs under the doppler instance group.
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=route_registrar/properties/nats?/machines
   value:
   - ((deployment-name))-nats
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=route_registrar/properties/route_registrar?/routing_api/api_url
+  value: http://((deployment-name))-api:3000
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=route_registrar/properties/route_registrar?/routing_api/oauth_url
+  value: https://((deployment-name))-uaa:8443
 
 # Add bosh_containerization properties for doppler.
 - type: replace

--- a/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
@@ -20,8 +20,24 @@
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=doppler/properties/bosh_containerization?
   value:
+    ports:
+    - name: dropsonde-tcp
+      protocol: TCP
+      internal: 3458
+    - name: doppler-tls
+      protocol: TCP
+      internal: 3459
+    - name: doppler-ws
+      protocol: TCP
+      internal: 8081
+    - name: doppler-grpc
+      protocol: TCP
+      internal: 8082
+    - name: log-cache-proxy # log-cache-cf-auth-proxy
+      protocol: TCP
+      internal: 8083
     run:
-      memory: 410
+      memory: 512
       virtual-cpus: 2
 
 # Add bosh_containerization properties for log-cache.

--- a/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
@@ -1,11 +1,29 @@
-# Attention: scf/fissile does not use the reverse_log_proxy_gateway
-# We may be able to go without this job
-
-# Fix the nats address for the route_registrar.
+# Override the addresses for the jobs under the log-api instance group.
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/properties/cc/internal_service_hostname
+  value: ((deployment-name))-api
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/properties/uaa/internal_url
+  value: https://((deployment-name))-uaa:8443
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway/properties/cc/capi_internal_addr
+  value: https://((deployment-name))-api:9023
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway/properties/cc/common_name
+  value: ((deployment-name))-api
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway/properties/uaa/internal_addr
+  value: https://((deployment-name))-uaa:8443
 - type: replace
   path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/nats?/machines
   value:
   - ((deployment-name))-nats
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/route_registrar?/routing_api/api_url
+  value: http://((deployment-name))-api:3000
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/route_registrar?/routing_api/oauth_url
+  value: https://((deployment-name))-uaa:8443
 
 - type: replace
   path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/properties/bosh_containerization?

--- a/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
@@ -25,6 +25,7 @@
   path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/route_registrar?/routing_api/oauth_url
   value: https://((deployment-name))-uaa:8443
 
+# Add bosh_containerization properties for loggregator_trafficcontroller.
 - type: replace
   path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/properties/bosh_containerization?
   value:
@@ -32,6 +33,15 @@
     - name: dropsonde
       protocol: TCP
       internal: 8081
+    run:
+      memory: 128
+      virtual-cpus: 2
+
+# Add bosh_containerization properties for reverse_log_proxy.
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy/properties/bosh_containerization?
+  value:
+    ports:
     - name: grpc-egress
       protocol: TCP
       internal: 8082

--- a/deploy/helm/scf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/router.yaml
@@ -12,3 +12,24 @@
   path: /instance_groups/name=router/jobs/name=gorouter/properties/nats?/machines
   value:
   - ((deployment-name))-nats
+
+# Add bosh_containerization properties for the gorouter job.
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/bosh_containerization?
+  value:
+    ports:
+    - name: router
+      protocol: TCP
+      internal: 8000
+      public: true
+    - name: router-ssl
+      protocol: TCP
+      internal: 443
+    run:
+      memory: 256
+      virtual-cpus: 2
+      healthcheck:
+        gorouter:
+          readiness:
+            exec:
+              command: ['curl', '--fail', '--head', 'http://127.0.0.1:8080/health']

--- a/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
@@ -66,6 +66,24 @@
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/credhub_api?/hostname
   value: ((deployment-name))-credhub
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cfdot/properties/bbs?/hostname
+  value: ((deployment-name))-diego-api
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cfdot/properties/locket?/hostname
+  value: ((deployment-name))-diego-api
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/scalablesyslog/scheduler/api/url
+  value: https://((deployment-name))-api:9023
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/scalablesyslog/scheduler/tls/api/cn
+  value: ((deployment-name))-api
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/diego/ssh_proxy/bbs?/api_location
+  value: ((deployment-name))-diego-api:8889
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/diego/ssh_proxy/uaa?/url
+  value: https://((deployment-name))-uaa
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cfdot/properties?/bosh_containerization?/bpm?/processes?

--- a/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
@@ -85,6 +85,48 @@
   path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/diego/ssh_proxy/uaa?/url
   value: https://((deployment-name))-uaa
 
+# Add bosh_containerization properties for the scheduler job.
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=cfdot/properties?/bosh_containerization?/bpm?/processes?
+  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/bosh_containerization?
+  value:
+    run:
+      memory: 256
+      virtual-cpus: 2
+      healthcheck:
+        scheduler:
+          readiness:
+            exec:
+              command: ['curl', '--fail', '--head', 'http://127.0.0.1:8080/health']
+
+# Add bosh_containerization properties for the auctioneer job.
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=auctioneer/properties/bosh_containerization?
+  value:
+    ports:
+    - name: auctioneer
+      protocol: TCP
+      internal: 9016
+    run:
+      memory: 256
+      virtual-cpus: 2
+      healthcheck:
+        auctioneer:
+          readiness:
+            exec:
+              command: ['curl', '--fail', '--head', 'http://127.0.0.1:8080/health']
+
+# Add bosh_containerization properties for the ssh_proxy job.
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/bosh_containerization?
+  value:
+    ports:
+    - name: ssh-proxy
+      protocol: TCP
+      internal: 2222
+    run:
+      memory: 256
+      virtual-cpus: 2
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cfdot/properties/bosh_containerization?/bpm/processes
   value: []

--- a/deploy/helm/scf/assets/operations/instance_groups/singleton-blobstore.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/singleton-blobstore.yaml
@@ -10,11 +10,20 @@
   path: /instance_groups/name=singleton-blobstore/persistent_disk?
   value: 102400 # 100GB
 
-# Fix the nats address for the route_registrar.
+# Override the addresses for the jobs under the singleton-blobstore instance group.
+- type: replace
+  path: /instance_groups/name=singleton-blobstore/jobs/name=blobstore/properties/internal_server_name?
+  value: ((deployment-name))-singleton-blobstore
 - type: replace
   path: /instance_groups/name=singleton-blobstore/jobs/name=route_registrar/properties/nats?/machines
   value:
   - ((deployment-name))-nats
+- type: replace
+  path: /instance_groups/name=singleton-blobstore/jobs/name=route_registrar/properties/route_registrar?/routing_api/api_url
+  value: http://((deployment-name))-api:3000
+- type: replace
+  path: /instance_groups/name=singleton-blobstore/jobs/name=route_registrar/properties/route_registrar?/routing_api/oauth_url
+  value: https://((deployment-name))-uaa:8443
 
 - type: replace
   path: /instance_groups/name=singleton-blobstore/jobs/name=blobstore/properties/bosh_containerization?

--- a/deploy/helm/scf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/uaa.yaml
@@ -42,9 +42,8 @@
     run:
       memory: 1532
       virtual-cpus: 2
-      # healthcheck:
-      #   uaa:
-      #     readiness: &probe
-      #       exec:
-      #         command: ['sh', '-c', '/var/vcap/jobs/uaa/bin/health_check']
-      #     liveness: *probe
+      healthcheck:
+        uaa:
+          readiness:
+            exec:
+              command: ['sh', '-c', '/var/vcap/jobs/uaa/bin/health_check']

--- a/deploy/helm/scf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/uaa.yaml
@@ -12,17 +12,21 @@
   path: /variables/name=uaa_ssl/options/alternative_names/-
   value: ((deployment-name))-uaa
 
-# Fix uaa.zones.internal.hostnames to point to the correct service DNS.
+# Override the addresses for the jobs under the uaa instance group.
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/zones/internal/hostnames
   value:
   - ((deployment-name))-uaa
-
-# Fix the nats address for the route_registrar.
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/nats?/machines
   value:
   - ((deployment-name))-nats
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar?/routing_api/api_url
+  value: http://((deployment-name))-api:3000
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar?/routing_api/oauth_url
+  value: https://((deployment-name))-uaa:8443
 
 # Add bosh_containerization properties.
 - type: replace


### PR DESCRIPTION
## Description

After doing a `grep -r -B 10 "service.cf.internal" /var/vcap/jobs/` on each statefulset, it revealed that many `*.service.cf.internal` addresses were still there.

## Test plan

```
for pod in $(kgpon scf -o name); do
  kexn scf "${pod#"pod/"}" -- bash -c 'grep -r -B 10 "service.cf.internal" /var/vcap/jobs/'
done
```
should return no `service.cf.internal` addresses.