### PR TITLE
Copy folder on darwin OS

### DIFF
--- a/rules/helm/package.sh
+++ b/rules/helm/package.sh
@@ -4,7 +4,7 @@ set -o errexit -o nounset
 
 build_dir="tmp/build/${PACKAGE_DIR}"
 mkdir -p "${build_dir}"
-cp -L --recursive "${PACKAGE_DIR}"/* "${build_dir}"
+cp -L -R "${PACKAGE_DIR}"/* "${build_dir}"
 
 for t in ${TARS}; do
   tar xf "${t}" -C "${build_dir}"


### PR DESCRIPTION
## Description

Running on mac, where the `cp -L --recursive` in rules/helm/package.sh fails. This PR worked on replacing `cp` command with `rsync`. Most machines will have rsync available.

## Test plan

Run `bazel run //dev/scf:apply --verbose_failures --sandbox_debug` on different OS.
