### PR TITLE
v3 - Specify pod values

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
@@ -48,3 +48,12 @@
     run:
       memory: 128
       virtual-cpus: 2
+
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/properties/bosh_containerization/envs?/-
+  value:
+    name: TRAFFIC_CONTROLLER_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP


### PR DESCRIPTION
## Description

- Supported `TRAFFIC_CONTROLLER_IP ` env value 


** Maybe it's **working in the process** that we should replace other values by pod fields.

## Test plan
After deployment, 
IBMMasterMBP:~ bjxzi$ k exec -it -n scf scf-dev-log-api-v1-0 -c loggregator-trafficcontroller-loggregator-trafficcontroller -- bash
/:/# env | grep TRAFFIC_CONTROLLER_IP
TRAFFIC_CONTROLLER_IP=172.30.23.17