### PR TITLE
v3 - Fix breaking changes related to cf-operator

### DIFF
--- a/bosh/releases/generators/pre_render_scripts/generator.sh
+++ b/bosh/releases/generators/pre_render_scripts/generator.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset
 {
 cat <<EOT
 - type: replace
-  path: /instance_groups/name=${INSTANCE_GROUP}/jobs/name=${JOB}/properties/bosh_containerization?/pre_render_scripts/-
+  path: /instance_groups/name=${INSTANCE_GROUP}/jobs/name=${JOB}/properties/quarks?/pre_render_scripts/-
   value: |
 EOT
 sed 's/^/    /' < "${PRE_RENDER_SCRIPT}"

--- a/bosh/releases/pre_render_scripts/README.md
+++ b/bosh/releases/pre_render_scripts/README.md
@@ -1,4 +1,4 @@
 # Pre-render scripts
 
-This directory contains the `pre_render_scripts` added to the `bosh_containerization` property.
+This directory contains the `pre_render_scripts` added to the `quarks` property.
 The structure of this directory should be `<instance_group>/<job>/<script>`.

--- a/deploy/helm/scf/assets/operations/instance_groups/adapter.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/adapter.yaml
@@ -6,9 +6,9 @@
   path: /instance_groups/name=adapter/jobs/name=adapter/properties/scalablesyslog/adapter/logs?/addr
   value: ((deployment-name))-log-api:8082
 
-# Add bosh_containerization properties.
+# Add quarks properties.
 - type: replace
-  path: /instance_groups/name=adapter/jobs/name=adapter/properties/bosh_containerization?
+  path: /instance_groups/name=adapter/jobs/name=adapter/properties/quarks?
   value:
     ports:
     - name: adapter

--- a/deploy/helm/scf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/api.yaml
@@ -142,12 +142,12 @@
 
 # Add empty BPM processes to buildpacks.
 - type: replace
-  path: /instance_groups/name=api/jobs/name=binary-buildpack/properties?/bosh_containerization?/bpm?/processes?
+  path: /instance_groups/name=api/jobs/name=binary-buildpack/properties?/quarks?/bpm?/processes?
   value: []
 
-# Add bosh_containerization properties for cloud_controller_ng.
+# Add quarks properties for cloud_controller_ng.
 - type: replace
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/bosh_containerization?
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/quarks?
   value:
     ports:
     - name: api
@@ -163,9 +163,9 @@
       memory: 4096
       virtual-cpus: 4
 
-# Add bosh_containerization properties for routing-api.
+# Add quarks properties for routing-api.
 - type: replace
-  path: /instance_groups/name=api/jobs/name=routing-api/properties/bosh_containerization?
+  path: /instance_groups/name=api/jobs/name=routing-api/properties/quarks?
   value:
     ports:
     - name: routing-api
@@ -175,9 +175,9 @@
       memory: 128
       virtual-cpus: 4
 
-# Add bosh_containerization properties for cc_uploader.
+# Add quarks properties for cc_uploader.
 - type: replace
-  path: /instance_groups/name=api/jobs/name=cc_uploader/properties/bosh_containerization?
+  path: /instance_groups/name=api/jobs/name=cc_uploader/properties/quarks?
   value:
     ports:
     - name: cc-uploader
@@ -187,9 +187,9 @@
       memory: 256
       virtual-cpus: 4
 
-# Add bosh_containerization properties for file_server.
+# Add quarks properties for file_server.
 - type: replace
-  path: /instance_groups/name=api/jobs/name=file_server/properties/bosh_containerization?
+  path: /instance_groups/name=api/jobs/name=file_server/properties/quarks?
   value:
     ports:
     - name: file-server
@@ -204,9 +204,9 @@
             tcpSocket:
               port: *file-server-port
 
-# Add bosh_containerization properties for statsd_injector.
+# Add quarks properties for statsd_injector.
 - type: replace
-  path: /instance_groups/name=api/jobs/name=statsd_injector/properties/bosh_containerization?
+  path: /instance_groups/name=api/jobs/name=statsd_injector/properties/quarks?
   value:
     ports:
     # TODO: Can we remove this port?
@@ -217,9 +217,9 @@
       memory: 256
       virtual-cpus: 2
 
-# Add bosh_containerization properties for policy-server.
+# Add quarks properties for policy-server.
 - type: replace
-  path: /instance_groups/name=api/jobs/name=policy-server/properties/bosh_containerization?
+  path: /instance_groups/name=api/jobs/name=policy-server/properties/quarks?
   value:
     ports:
     - name: policy-server
@@ -229,9 +229,9 @@
       memory: 256
       virtual-cpus: 2
 
-# Add bosh_containerization properties for policy-server-internal.
+# Add quarks properties for policy-server-internal.
 - type: replace
-  path: /instance_groups/name=api/jobs/name=policy-server-internal/properties/bosh_containerization?
+  path: /instance_groups/name=api/jobs/name=policy-server-internal/properties/quarks?
   value:
     run:
       memory: 256

--- a/deploy/helm/scf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/database.yaml
@@ -76,10 +76,10 @@
               server_certificate: "((mysql_server_certificate.certificate))"
               server_key: "((mysql_server_certificate.private_key))"
 
-# Add bosh_containerization properties. It adds the BPM configuration as cf-mysql-release lacks
+# Add quarks properties. It adds the BPM configuration as cf-mysql-release lacks
 # support for it upstream.
 - type: replace
-  path: /instance_groups/name=database/jobs/name=mysql/properties/bosh_containerization?
+  path: /instance_groups/name=database/jobs/name=mysql/properties/quarks?
   value:
     ports:
     - name: mysql

--- a/deploy/helm/scf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/diego-api.yaml
@@ -61,9 +61,9 @@
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/set_kernel_parameters?
   value: false
 
-# Add bosh_containerization properties for locket.
+# Add quarks properties for locket.
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/bosh_containerization?
+  path: /instance_groups/name=diego-api/jobs/name=locket/properties/quarks?
   value:
     ports:
     - name: locket
@@ -73,9 +73,9 @@
       memory: 128
       virtual-cpus: 2
 
-# Add bosh_containerization properties for bbs.
+# Add quarks properties for bbs.
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/bosh_containerization?
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/quarks?
   value:
     ports:
     - name: cell-bbs-api
@@ -86,5 +86,5 @@
       virtual-cpus: 2
 
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=cfdot/properties?/bosh_containerization?/bpm?/processes?
+  path: /instance_groups/name=diego-api/jobs/name=cfdot/properties/quarks?/bpm/processes
   value: []

--- a/deploy/helm/scf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/diego-cell.yaml
@@ -43,9 +43,9 @@
   path: /instance_groups/name=diego-cell/jobs/name=cfdot/properties/locket?/hostname
   value: ((deployment-name))-diego-api
 
-# Add bosh_containerization properties.
+# Add quarks properties.
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/bosh_containerization?
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/quarks?
   value:
     run:
       memory: 4096
@@ -64,8 +64,8 @@
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/network_plugin_extra_args
 
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties?/bosh_containerization?/bpm?/processes?
+  path: /instance_groups/name=diego-cell/jobs/name=cflinuxfs3-rootfs-setup/properties/quarks?/bpm/processes
   value: []
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=cfdot/properties?/bosh_containerization?/bpm?/processes?
+  path: /instance_groups/name=diego-cell/jobs/name=cfdot/properties/quarks?/bpm/processes
   value: []

--- a/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
@@ -16,9 +16,9 @@
   path: /instance_groups/name=doppler/jobs/name=route_registrar/properties/route_registrar?/routing_api/oauth_url
   value: https://((deployment-name))-uaa:8443
 
-# Add bosh_containerization properties for doppler.
+# Add quarks properties for doppler.
 - type: replace
-  path: /instance_groups/name=doppler/jobs/name=doppler/properties/bosh_containerization?
+  path: /instance_groups/name=doppler/jobs/name=doppler/properties/quarks?
   value:
     ports:
     - name: dropsonde-tcp
@@ -40,9 +40,9 @@
       memory: 512
       virtual-cpus: 2
 
-# Add bosh_containerization properties for log-cache.
+# Add quarks properties for log-cache.
 - type: replace
-  path: /instance_groups/name=doppler/jobs/name=log-cache/properties/bosh_containerization?
+  path: /instance_groups/name=doppler/jobs/name=log-cache/properties/quarks?
   value:
     ports:
     - name: log-cache

--- a/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
@@ -25,9 +25,9 @@
   path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/route_registrar?/routing_api/oauth_url
   value: https://((deployment-name))-uaa:8443
 
-# Add bosh_containerization properties for loggregator_trafficcontroller.
+# Add quarks properties for loggregator_trafficcontroller.
 - type: replace
-  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/properties/bosh_containerization?
+  path: /instance_groups/name=log-api/jobs/name=loggregator_trafficcontroller/properties/quarks?
   value:
     ports:
     - name: dropsonde
@@ -37,9 +37,9 @@
       memory: 128
       virtual-cpus: 2
 
-# Add bosh_containerization properties for reverse_log_proxy.
+# Add quarks properties for reverse_log_proxy.
 - type: replace
-  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy/properties/bosh_containerization?
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy/properties/quarks?
   value:
     ports:
     - name: grpc-egress

--- a/deploy/helm/scf/assets/operations/instance_groups/nats.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/nats.yaml
@@ -1,6 +1,6 @@
-# Add bosh_containerization properties.
+# Add quarks properties.
 - type: replace
-  path: /instance_groups/name=nats/jobs/name=nats/properties/bosh_containerization?
+  path: /instance_groups/name=nats/jobs/name=nats/properties/quarks?
   value:
     ports:
     - name: nats

--- a/deploy/helm/scf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/router.yaml
@@ -13,9 +13,9 @@
   value:
   - ((deployment-name))-nats
 
-# Add bosh_containerization properties for the gorouter job.
+# Add quarks properties for the gorouter job.
 - type: replace
-  path: /instance_groups/name=router/jobs/name=gorouter/properties/bosh_containerization?
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/quarks?
   value:
     ports:
     - name: router

--- a/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
@@ -85,9 +85,9 @@
   path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/diego/ssh_proxy/uaa?/url
   value: https://((deployment-name))-uaa
 
-# Add bosh_containerization properties for the scheduler job.
+# Add quarks properties for the scheduler job.
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/bosh_containerization?
+  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/quarks?
   value:
     run:
       memory: 256
@@ -98,9 +98,9 @@
             exec:
               command: ['curl', '--fail', '--head', 'http://127.0.0.1:8080/health']
 
-# Add bosh_containerization properties for the auctioneer job.
+# Add quarks properties for the auctioneer job.
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=auctioneer/properties/bosh_containerization?
+  path: /instance_groups/name=scheduler/jobs/name=auctioneer/properties/quarks?
   value:
     ports:
     - name: auctioneer
@@ -115,9 +115,9 @@
             exec:
               command: ['curl', '--fail', '--head', 'http://127.0.0.1:8080/health']
 
-# Add bosh_containerization properties for the ssh_proxy job.
+# Add quarks properties for the ssh_proxy job.
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/bosh_containerization?
+  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/quarks?
   value:
     ports:
     - name: ssh-proxy
@@ -128,5 +128,5 @@
       virtual-cpus: 2
 
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=cfdot/properties/bosh_containerization?/bpm/processes
+  path: /instance_groups/name=scheduler/jobs/name=cfdot/properties/quarks?/bpm/processes
   value: []

--- a/deploy/helm/scf/assets/operations/instance_groups/singleton-blobstore.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/singleton-blobstore.yaml
@@ -26,7 +26,7 @@
   value: https://((deployment-name))-uaa:8443
 
 - type: replace
-  path: /instance_groups/name=singleton-blobstore/jobs/name=blobstore/properties/bosh_containerization?
+  path: /instance_groups/name=singleton-blobstore/jobs/name=blobstore/properties/quarks?
   value:
     ports:
     - name: http

--- a/deploy/helm/scf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/uaa.yaml
@@ -24,9 +24,9 @@
   path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/route_registrar?/routing_api/oauth_url
   value: https://((deployment-name))-uaa:8443
 
-# Add bosh_containerization properties.
+# Add quarks properties.
 - type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/bosh_containerization?
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/quarks?
   value:
     ports:
     - name: http

--- a/deploy/helm/scf/templates/bosh_deployment.yaml
+++ b/deploy/helm/scf/templates/bosh_deployment.yaml
@@ -12,27 +12,27 @@ metadata:
     helm.sh/chart: {{ include "scf.chart" . }}
 spec:
   manifest:
-    ref: cf-deployment
+    name: cf-deployment
     type: configmap
   ops:
 # Reference all the ConfigMaps created for each ops file under assets/operations.
 {{- range $path, $bytes := .Files.Glob "assets/operations/temporary/*" }}
-  - ref: {{ include "scf.ops-name" $path }}
+  - name: {{ include "scf.ops-name" $path }}
     type: configmap
 {{- end }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/instance_groups/*" }}
-  - ref: {{ include "scf.ops-name" $path }}
+  - name: {{ include "scf.ops-name" $path }}
     type: configmap
 {{- end }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/*" }}
-  - ref: {{ include "scf.ops-name" $path }}
+  - name: {{ include "scf.ops-name" $path }}
     type: configmap
 {{- end }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/*" }}
-  - ref: {{ include "scf.ops-name" $path }}
+  - name: {{ include "scf.ops-name" $path }}
     type: configmap
 {{- end }}
 {{- if not .Values.sizing.HA }}
-  - ref: ops-single-availability
+  - name: ops-single-availability
     type: configmap
 {{- end }}

--- a/dev/scf/.gitignore
+++ b/dev/scf/.gitignore
@@ -1,1 +1,2 @@
 *values.yaml
+!values.yaml

--- a/dev/scf/BUILD.bazel
+++ b/dev/scf/BUILD.bazel
@@ -7,9 +7,6 @@ NAMESPACE = "scf"
 
 helm_template(
     name = "rendered_template",
-    set_values = {
-        "deployment_name": "scf-dev",
-    },
     values = glob(["**/*values.yaml"]),
     install_name = "scf",
     namespace = NAMESPACE,

--- a/dev/scf/values.yaml
+++ b/dev/scf/values.yaml
@@ -1,1 +1,2 @@
 system_domain: scf.suse.dev
+deployment_name: scf


### PR DESCRIPTION
## Description

`cf-operator` has 2 breaking changes on the current master that we should update here:
1. `bosh_containerization` was renamed to `quarks`.
2. `spec.ops.ref` was renamed to `spec.ops.name`, and `spec.manifest.ref` was renamed to `spec.manifest.name`.

## Test plan

This branch should work with `cf-operator` master.
