### PR TITLE
Get rid of cluster-admin binding for the eirini service account

### DIFF
--- a/chart-parts/eirini-namespace.yaml
+++ b/chart-parts/eirini-namespace.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.enable.eirini }}
+
+{{- if ne .Values.env.EIRINI_KUBE_NAMESPACE .Release.Namespace }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{.Values.env.EIRINI_KUBE_NAMESPACE | quote}}
+{{- end }}
+
+{{- if and (eq (printf "%s" .Values.kube.auth) "rbac") (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eirini
+  namespace: {{.Values.env.EIRINI_KUBE_NAMESPACE | quote}}
+rules:
+- apiGroups: ['*']
+  resources: ['*']
+  verbs:     ['*']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eirini
+  namespace: {{.Values.env.EIRINI_KUBE_NAMESPACE | quote}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eirini
+subjects:
+- kind: ServiceAccount
+  name: eirini
+  namespace: {{.Release.Namespace}}
+{{- end }}
+
+{{- end }}

--- a/chart-parts/eirini-namespace.yaml
+++ b/chart-parts/eirini-namespace.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.enable.eirini }}
+{{- if .Values.enable.eirini }}
 
 {{- if ne .Values.env.EIRINI_KUBE_NAMESPACE .Release.Namespace }}
 ---

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2514,6 +2514,10 @@ configuration:
       - apiGroups: [""]
         resources: [nodes]
         verbs: [get, list, watch]
+      mutating-webhook-role:
+      - apiGroups: ["admissionregistration.k8s.io"]
+        resources: [mutatingwebhookconfigurations]
+        verbs: ['*']
       test-cluster-role:
       - apiGroups: [""]
         resources: [namespaces]
@@ -2568,6 +2572,7 @@ configuration:
         cluster-roles: [node-reader-role]
       eirini:
         roles: [configgin-role, secrets-role, psp-role]
+        cluster-roles: [mutating-webhook-role]
   templates:
     az: '"((KUBE_AZ))"'
     id: ((HOSTNAME))

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2514,10 +2514,6 @@ configuration:
       - apiGroups: [""]
         resources: [nodes]
         verbs: [get, list, watch]
-      eirini-role:
-      - apiGroups: ["*"]
-        resources: ["*"]
-        verbs: ["*"]
       test-cluster-role:
       - apiGroups: [""]
         resources: [namespaces]
@@ -2571,8 +2567,7 @@ configuration:
         roles: [configgin-role, psp-role]
         cluster-roles: [node-reader-role]
       eirini:
-        roles: [configgin-role]
-        cluster-roles: [eirini-role]
+        roles: [configgin-role, secrets-role, psp-role]
   templates:
     az: '"((KUBE_AZ))"'
     id: ((HOSTNAME))


### PR DESCRIPTION
### Description

Instead we create an eirini role with full access inside the eirini namespace and bind it to the eirini service account in the release namespace.

Replaces #2520.
[jsc#CAP-485]

### Test plan

Deploy SCF with `--set enable.eirini=true` and verify that you can push an app.