### PR TITLE
Add min kernel check version to bin/dev/kube-ready-state-check.sh

### DIFF
--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -92,6 +92,22 @@ if having_category node ; then
     status "docker info should not show aufs"
 fi
 
+# kernel must be >= 3.19
+if having_category kube ; then
+    min_ver="3.19"
+    ver_check_rc=0
+    for i in $(kubectl get nodes --no-headers -o=custom-columns=NODES:.status.nodeInfo.kernelVersion); do
+        if test "$(printf '%s\n%s\n' "$i" "$min_ver" | sort -V | head -n 1)" != "$min_ver" ; then
+            ver_check_rc=1
+            break
+        fi
+    done
+    if [[ $ver_check_rc -ne 0 ]]; then
+        false
+    fi
+    status "nodes should have kernel version $min_ver or higher"
+fi
+
 # kube auth
 if having_category kube ; then
     kubectl auth can-i get pods --namespace=kube-system &> /dev/null


### PR DESCRIPTION
## Description

Adds a minimal kernel check version to bin/dev/kube-ready-state-check.sh.

## Test plan

Run `bin/dev/kube-ready-state-check.sh`, see that it shows:
```
Verified: nodes should have kernel version 3.19 or higher
```
or
```
Configuration problem detected: nodes should have kernel version 3.19 or higher
```

Already tested and working on all cases:
```
 bash ~/code/cap/scf/bin/dev/kube-ready-state-check.sh
Testing all
...
Verified: nodes should have kernel version 3.19 or higher
...
```

Changed min_ver to `4.19`, where the installed kernels are `4.12`, to make it fail:
```
$ bash ~/code/cap/scf/bin/dev/kube-ready-state-check.sh
Testing all
...
Configuration problem detected: nodes should have kernel version 4.19 or higher
...
```
Changed the min_ver to `4.12.14-197.15-default`, same as installed, to make it pass:
```
Verified: nodes should have kernel version 4.12.14-197.15-default or higher
```