### PR TITLE
v3 - Bumped openSUSE Minikube image to 0.1.3

### DIFF
--- a/dev/minikube/def.bzl
+++ b/dev/minikube/def.bzl
@@ -48,7 +48,7 @@ attrs = {
         default = "120g",
     ),
     "iso_url": attr.string(
-        default = "https://github.com/f0rmiga/opensuse-minikube-image/releases/download/v0.1.0/minikube-openSUSE.x86_64-1.0.0.iso",
+        default = "https://github.com/f0rmiga/opensuse-minikube-image/releases/download/v0.1.3/minikube-openSUSE.x86_64-0.1.3.iso",
     ),
     "_minikube": attr.label(
         allow_single_file = True,


### PR DESCRIPTION
## Description

Bumping the openSUSE Minikube image that fixes the DNS issues we were seeing.

## Test plan

DNS queries should resolve external names.
