### PR TITLE
Bumped openSUSE Minikube image to 0.1.4

### DIFF
--- a/dev/minikube/def.bzl
+++ b/dev/minikube/def.bzl
@@ -44,7 +44,7 @@ attrs = {
         default = "120g",
     ),
     "iso_url": attr.string(
-        default = "https://github.com/f0rmiga/opensuse-minikube-image/releases/download/v0.1.3/minikube-openSUSE.x86_64-0.1.3.iso",
+        default = "https://github.com/f0rmiga/opensuse-minikube-image/releases/download/v0.1.4/minikube-openSUSE.x86_64-0.1.4.iso",
     ),
     "_minikube": attr.label(
         allow_single_file = True,


### PR DESCRIPTION
## Description

This fixes the Docker daemon not being reachable from the host on Virtualbox.

## Test plan

Should work on both KVM and Virtualbox.
