### PR TITLE
v3 - Remove `azs` for single zone

### DIFF
--- a/deploy/helm/scf/templates/single_availability.yaml
+++ b/deploy/helm/scf/templates/single_availability.yaml
@@ -52,4 +52,30 @@ data:
     - type: replace
       path: /instance_groups/name=log-api/instances
       value: 1
+    - type: remove
+      path: /instance_groups/name=nats/azs?
+    - type: remove
+      path: /instance_groups/name=adapter/azs?
+    - type: remove
+      path: /instance_groups/name=database/azs?
+    - type: remove
+      path: /instance_groups/name=diego-api/azs?
+    - type: remove
+      path: /instance_groups/name=uaa/azs?
+    - type: remove
+      path: /instance_groups/name=singleton-blobstore/azs?
+    - type: remove
+      path: /instance_groups/name=api/azs?
+    - type: remove
+      path: /instance_groups/name=cc-worker/azs?
+    - type: remove
+      path: /instance_groups/name=scheduler/azs?
+    - type: remove
+      path: /instance_groups/name=router/azs?
+    - type: remove
+      path: /instance_groups/name=doppler/azs?
+    - type: remove
+      path: /instance_groups/name=diego-cell/azs?
+    - type: remove
+      path: /instance_groups/name=log-api/azs?
 {{- end }}


### PR DESCRIPTION
derived from https://www.pivotaltracker.com/story/show/167851849, this PR will fix this one. And I opened a story to track Bosh AZs support if anything lost.

## More details

cf-operator will define required node affinities when setting `ExtendedStatefulSetSpec.Zones` which come from `instance_groups.azs`. After cf-operator applies node affinities, scf will be blocked if kube nodes have not required labels such as (`failure-domain.beta.kubernetes.io/zone: z1`).

For single availability, it **should not** set any AZs for ExtendedStatefulSets. Because it doesn't need any node affinity and we don't need more node labeling operations.

For high availability, the statefulsets count of instance group = AZs * instances. That's what we designed: https://github.com/cloudfoundry-incubator/cf-operator/blob/master/docs/rendering_templates.md#services-and-dns-addresses

cf-operator should support rules from: https://bosh.io/docs/azs/#assigning-azs
- new instances will be spread as evenly as possible over specified AZs
- existing instances will be preserved
- existing instances with persistent disks will not be rebalanced to avoid losing persistent data

