### PR TITLE
Jenkinsfile: add logs of UAA on failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -982,6 +982,7 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
                 if (getBuildType() in [BuildType.Master, BuildType.Develop]) {
                     writeFile(file: 'build.log', text: getBuildLog())
                     sh "bin/clean-jenkins-log"
+                    sh "container-host-files/opt/scf/bin/klog.sh -f ${uaaNamespace}"
                     sh "container-host-files/opt/scf/bin/klog.sh -f ${cfNamespace}"
                     withAWS(region: params.S3_REGION) {
                         withCredentials([usernamePassword(


### PR DESCRIPTION
## Description

It's kind of annoying to have klogs for SCF, but not UAA, when a lot of the time we're failing tests because (we suspect) UAA fell over.  So this pulls the UAA logs first, so they'll show up when we bundle the SCF logs.

## Test plan

1. Get a Jenkins build that fails
2. Check that the uploaded logs contains UAA bits.
