### PR TITLE
Jenkinsfile, version.sh: Bump fissile stemcell version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -288,7 +288,7 @@ pipeline {
         )
         string(
             name: 'FISSILE_STEMCELL_VERSION',
-            defaultValue: '12SP4-0.gcdd8986-0.225',
+            defaultValue: '12SP4-2.gfc2305c-0.228',
             description: 'Fissile stemcell version used as docker image tag',
         )
         booleanParam(

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -27,7 +27,7 @@ export ISTIO_VERSION="1.1.5"
 export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$//')
 
 # Used in: .envrc
-export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-36.g03b4653-30.93}
+export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-38.g82067a9-30.95}
 
 # Used in: bin/generate-dev-certs.sh
 


### PR DESCRIPTION
## Description

This pulls in the new configgin 0.18.8, which has a fix for restarting pods when the BOSH links they import changes.

See also: https://github.com/cloudfoundry-incubator/configgin/pull/104

## Test plan

- Run SCF
- Check that the diego-ssh StatefulSet has the annotation on importing properties from cloud_controller_ng