### PR TITLE
New script to attempt to recover stuck lock

### DIFF
--- a/container-host-files/opt/scf/bin/recovery-autoscaler-metrics-liquidbase-stale-lock
+++ b/container-host-files/opt/scf/bin/recovery-autoscaler-metrics-liquidbase-stale-lock
@@ -66,7 +66,7 @@ run 'kubectl', 'exec', postgres_pod,
 
 locked_bys = (1..Float::INFINITY).each do |count|
     STDOUT.printf "\rWaiting for pod to get stuck (try %s)...", count
-    locked_bys = capture('kubectl', 'get', 'pods',
+    candidate_locked_bys = capture('kubectl', 'get', 'pods',
                         '--namespace', namespace,
                         '--selector', 'skiff-role-name==autoscaler-metrics',
                         '--output', 'jsonpath={.items[*].metadata.name}')
@@ -79,7 +79,7 @@ locked_bys = (1..Float::INFINITY).each do |count|
         .select { |message| message.include? EXPECTED_ERROR }
         .map { |message| /Currently locked by (.*?) since /.match(message)[1]}
 
-    break locked_bys unless locked_bys.empty?
+    break candidate_locked_bys unless candidate_locked_bys.empty?
     sleep 1
 end
 puts '' # new line after the wait

--- a/container-host-files/opt/scf/bin/recovery-autoscaler-metrics-liquidbase-stale-lock
+++ b/container-host-files/opt/scf/bin/recovery-autoscaler-metrics-liquidbase-stale-lock
@@ -43,19 +43,6 @@ def run(*args)
     fail %Q<"#{cmd.join(' ')}" failed with exit status #{$?.exitstatus}>
 end
 
-locked_bys = capture('kubectl', 'get', 'pods',
-    '--namespace', namespace,
-    '--selector', 'skiff-role-name==autoscaler-metrics',
-    '--output', 'jsonpath={.items[*].metadata.name}')
-    .split
-    .map do |pod_name|
-        capture('kubectl', 'logs', pod_name,
-            '--namespace', namespace,
-            '--container', 'autoscaler-metrics')
-    end
-    .select { |message| message.include? EXPECTED_ERROR }
-    .map { |message| /Currently locked by (.*?) since /.match(message)[1]}
-
 postgres_pod = JSON.load(capture('kubectl', 'get', 'pods',
     '--namespace', namespace,
     '--selector', 'skiff-role-name==autoscaler-postgres',
@@ -77,6 +64,25 @@ run 'kubectl', 'exec', postgres_pod,
     '--dbname', 'autoscaler',
     '--command', 'SELECT * FROM databasechangeloglock'
 
+locked_bys = (1..Float::INFINITY).each do |count|
+    STDOUT.printf "\rWaiting for pod to get stuck (try %s)...", count
+    locked_bys = capture('kubectl', 'get', 'pods',
+                        '--namespace', namespace,
+                        '--selector', 'skiff-role-name==autoscaler-metrics',
+                        '--output', 'jsonpath={.items[*].metadata.name}')
+        .split
+        .map do |pod_name|
+            capture('kubectl', 'logs', pod_name,
+                    '--namespace', namespace,
+                    '--container', 'autoscaler-metrics')
+        end
+        .select { |message| message.include? EXPECTED_ERROR }
+        .map { |message| /Currently locked by (.*?) since /.match(message)[1]}
+
+    break locked_bys unless locked_bys.empty?
+    sleep 1
+end
+puts '' # new line after the wait
 locked_bys.each do |locked_by|
     puts "Releasing lock for #{locked_by}"
     run 'kubectl', 'exec', postgres_pod,

--- a/container-host-files/opt/scf/bin/recovery-autoscaler-metrics-liquidbase-stale-lock
+++ b/container-host-files/opt/scf/bin/recovery-autoscaler-metrics-liquidbase-stale-lock
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+
+# This script recovers from autoscaler-metrics failing to start because it could
+# not continue schema migrations.  The error looks something like:
+
+# Starting Liquibase at Wed, 21 Aug 2019 22:38:00 UTC (version 3.6.3 built at 2019-01-29 11:34:48)
+# Unexpected error running Liquibase: Could not acquire change log lock.  Currently locked by autoscaler-metrics-0.autoscaler-metrics-set.cf.svc.cluster.local (172.16.0.173) since 8/21/19, 9:20 PM
+# liquibase.exception.LockException: Could not acquire change log lock.  Currently locked by autoscaler-metrics-0.autoscaler-metrics-set.cf.svc.cluster.local (172.16.0.173) since 8/21/19, 9:20 PM
+#         at liquibase.lockservice.StandardLockService.waitForLock(StandardLockService.java:230)
+#         at liquibase.Liquibase.update(Liquibase.java:184)
+#         at liquibase.Liquibase.update(Liquibase.java:179)
+#         at liquibase.integration.commandline.Main.doMigration(Main.java:1220)
+#         at liquibase.integration.commandline.Main.run(Main.java:199)
+#         at liquibase.integration.commandline.Main.main(Main.java:137)
+
+require 'json'
+require 'open3'
+
+EXPECTED_ERROR='Could not acquire change log lock.  Currently locked by'
+
+def capture(*args)
+    stdout, status = Open3.capture2(*args)
+    return stdout if status.success?
+    cmd = args.dup
+    cmd.shift while Hash.try_convert(cmd.first)
+    cmd.pop while Hash.try_convert(cmd.last)
+    fail %Q<"#{cmd.join(' ')}" failed with exit status #{status.exitstatus}>
+end
+
+def namespace
+    $namespace ||= JSON.parse(capture('helm list --output json'))['Releases']
+        .select { |r| r['Status'].downcase == 'deployed' }
+        .select { |r| r['Chart'].start_with? 'cf-' }
+        .first['Namespace']
+end
+
+def run(*args)
+    Process.wait Process.spawn(*args)
+    return if $?.success?
+    cmd = args.dup
+    cmd.shift while Hash.try_convert(cmd.first)
+    cmd.pop while Hash.try_convert(cmd.last)
+    fail %Q<"#{cmd.join(' ')}" failed with exit status #{$?.exitstatus}>
+end
+
+locked_bys = capture('kubectl', 'get', 'pods',
+    '--namespace', namespace,
+    '--selector', 'skiff-role-name==autoscaler-metrics',
+    '--output', 'jsonpath={.items[*].metadata.name}')
+    .split
+    .map do |pod_name|
+        capture('kubectl', 'logs', pod_name,
+            '--namespace', namespace,
+            '--container', 'autoscaler-metrics')
+    end
+    .select { |message| message.include? EXPECTED_ERROR }
+    .map { |message| /Currently locked by (.*?) since /.match(message)[1]}
+
+postgres_pod = JSON.load(capture('kubectl', 'get', 'pods',
+    '--namespace', namespace,
+    '--selector', 'skiff-role-name==autoscaler-postgres',
+    '--output', 'json'))['items']
+    .find { |pod|
+        pod['status']['conditions']
+            .find {|status| status['type'] == 'Ready'}['status'] == 'True'
+    }['metadata']['name']
+
+psql_binary = capture('kubectl', 'exec', postgres_pod,
+    '--namespace', namespace,
+    '--', 'sh', '-c', 'echo /var/vcap/packages/postgres-*/bin/psql').split.first
+
+run 'kubectl', 'exec', postgres_pod,
+    '--namespace', namespace,
+    '--',
+    psql_binary,
+    '--username', 'postgres',
+    '--dbname', 'autoscaler',
+    '--command', 'SELECT * FROM databasechangeloglock'
+
+locked_bys.each do |locked_by|
+    puts "Releasing lock for #{locked_by}"
+    run 'kubectl', 'exec', postgres_pod,
+        '--namespace', namespace,
+        '--',
+        psql_binary,
+        '--username', 'postgres',
+        '--dbname', 'autoscaler',
+        '--command', %Q<UPDATE databasechangeloglock SET locked = FALSE WHERE lockedby = '#{locked_by}'>
+end


### PR DESCRIPTION
## Description

This adds a script that attempts to recover a stale lock for the `autoscaler-metrics` database.  This can occur if the `autoscaler-metrics` pod was terminated while it's holding the lock, as for some unfathomable reason the library implements locking by inserting data into a table, instead of just using actual (possibly row-level) locking.

## Test plan

1. Deploy SCF, and wait for everything to be ready.
2. Delete the `autoscaler-metrics` pod.
3. Watch the logs of the `autoscaler-metrics` container as the pod restarts.
4. Delete the pod again once you see the `Starting Liquibase at`… message.
5. Wait for the respawned pod until you see error traces about `liquibase.exception.LockException: Could not acquire change log lock.`
6. Run the script and see that it fixes things.
