### PR TITLE
v3 - Fixed cloud_controller_ng -> log-cache mTLS

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/api.yaml
@@ -38,12 +38,8 @@
 
 # Set the correct names for the cc_logcache_tls certificate.
 - type: replace
-  path: /variables/name=cc_logcache_tls/options/common_name
+  path: /variables/name=cc_logcache_tls/options/alternative_names/-
   value: ((deployment-name))-api
-- type: replace
-  path: /variables/name=cc_logcache_tls/options/alternative_names
-  value:
-  - ((deployment-name))-api
 
 # Set the correct names for the cc_tls certificate.
 - type: replace

--- a/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
@@ -16,6 +16,11 @@
   path: /instance_groups/name=doppler/jobs/name=route_registrar/properties/route_registrar?/routing_api/oauth_url
   value: https://((deployment-name))-uaa:8443
 
+# Change the log_cache_ca CN to avoid clashing with the other log-cache certificate CNs.
+- type: replace
+  path: /variables/name=log_cache_ca/options/common_name
+  value: log-cache-ca
+
 # Add quarks properties for doppler.
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=doppler/properties/quarks?


### PR DESCRIPTION
## Description

This fixes the error on `cloud_controller_ng`:
```
E0822 21:19:47.976388536     662 ssl_transport_security.cc:1239] Handshake failed with fatal error SSL_ERROR_SSL: error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED.
```
