### PR TITLE
scripts: check_swapaccounting: Disable if we have no swap.

### DIFF
--- a/container-host-files/etc/scf/config/scripts/check_swapaccounting.sh
+++ b/container-host-files/etc/scf/config/scripts/check_swapaccounting.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
 
-# This script checks if swapaccounting is enabled on the kernel.
+# This script checks if swap is available, and if yes, if swapaccounting is
+# enabled on the kernel.  It is an error to have swap without swapaccounting (as
+# that would lead to mis-tracking of memory usage).  If there is no swap,
+# however, not having swap accounting is safe; in that case we turn it off for
+# garden as well.
 
-if [ ! -e /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes ]; then
+# If there is no swap, we can drop the swap accounting requirement.
+no_swap="$(awk '/^SwapTotal:/ { print ($2 == 0) ? "true" : "false" }' /proc/meminfo)"
+
+if [ ! "${no_swap}" ] && [ ! -e /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes ]; then
 	red='\033[0;31m'
 	no_color='\033[0m'
 	(>&2 printf "${red}")
@@ -12,3 +19,5 @@ if [ ! -e /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes ]; then
 	sleep 60
 	exit 1
 fi
+
+echo "properties.garden.disable_swap_limit: ${no_swap}" >> /opt/fissile/env2conf.yml


### PR DESCRIPTION
## Description

On systems with swap turned off, we should allow running garden without swap accounting (since there is nothing to account for).  In that case, though, we should also tell garden to disable the swap limit.

This is a draft PR for now, we'd like to get it to pass CATS.

## Test plan

:smile_cat: 
