### PR TITLE
Jenkinsfile: allow version bump on RC branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -445,8 +445,8 @@ pipeline {
                     echo "All files changed since last build: ${all_files}"
 
                     if (getBuildType() == BuildType.ReleaseCandidate) {
-                        HashSet<String> changelogFiles = ["CHANGELOG.md"]
-                        if (!changelogFiles.containsAll(all_files)) {
+                        HashSet<String> allowedFiles = ["CHANGELOG.md", "bin/common/versions.sh"]
+                        if (!allowedFiles.containsAll(all_files)) {
                             currentBuild.rawBuild.result = hudson.model.Result.NOT_BUILT
                             echo "RESULT: ${currentBuild.rawBuild.result}"
                             throw new hudson.AbortException('Exiting pipeline early (non-changelog commit on RC branch)')


### PR DESCRIPTION
## Description

When we update the changelog, it is also a good opportunity to bump the product version if appropriate.  Allow that change when checking if we should be automatically building a new RC.

Manual RC builds are, as before, unaffected.

## Test plan

We'll see in the next RC (probably post-1.5).