### PR TITLE
jsc#CAP-554: Allow default stemcell to be configured

### DIFF
--- a/deploy/helm/scf/assets/operations/set_opensuse_stemcells.yaml
+++ b/deploy/helm/scf/assets/operations/set_opensuse_stemcells.yaml
@@ -1,10 +1,7 @@
 # This ops file sets the openSUSE stemcells.
 
-- type: remove
-  path: /stemcells/alias=default/alias
-
 - type: replace
-  path: /stemcells/-
+  path: /stemcells/alias=default
   value:
     alias: default
     os: ((stemcell-os))

--- a/deploy/helm/scf/assets/operations/set_opensuse_stemcells.yaml
+++ b/deploy/helm/scf/assets/operations/set_opensuse_stemcells.yaml
@@ -4,8 +4,8 @@
   path: /stemcells/alias=default
   value:
     alias: default
-    os: ((stemcell-os))
-    version: ((stemcell-version))
+    os: ((releases-defaults-stemcell-os))
+    version: ((releases-defaults-stemcell-version))
 
 - type: replace
   path: /addons/name=loggregator_agent/include/stemcell/os=ubuntu-xenial/os

--- a/deploy/helm/scf/assets/operations/set_opensuse_stemcells.yaml
+++ b/deploy/helm/scf/assets/operations/set_opensuse_stemcells.yaml
@@ -1,17 +1,19 @@
 # This ops file sets the openSUSE stemcells.
 
-- type: replace
-  path: /stemcells/alias=default/os
-  value: opensuse-42.3
+- type: remove
+  path: /stemcells/alias=default/alias
 
 - type: replace
-  path: /stemcells/alias=default/version
-  value: 36.g03b4653-30.80-7.0.0_340.g2b599a90
+  path: /stemcells/-
+  value:
+    alias: default
+    os: ((stemcell-os))
+    version: ((stemcell-version))
 
 - type: replace
   path: /addons/name=loggregator_agent/include/stemcell/os=ubuntu-xenial/os
-  value: opensuse-42.3
+  value: default
 
 - type: replace
   path: /addons/name=forwarder_agent/include/stemcell/os=ubuntu-xenial/os
-  value: opensuse-42.3
+  value: default

--- a/deploy/helm/scf/templates/implicit_vars.yaml
+++ b/deploy/helm/scf/templates/implicit_vars.yaml
@@ -26,5 +26,5 @@ stringData:
 {{ include "scf.implicit-var" (list . "system_domain") }}
 {{ include "scf.implicit-var" (list . "deployment_name") }}
 {{ include "scf.implicit-var" (list . "releases.defaults.url") }}
-{{ include "scf.implicit-var" (list . "stemcell.os") }}
-{{ include "scf.implicit-var" (list . "stemcell.version") }}
+{{ include "scf.implicit-var" (list . "releases.defaults.stemcell.os") }}
+{{ include "scf.implicit-var" (list . "releases.defaults.stemcell.version") }}

--- a/deploy/helm/scf/templates/implicit_vars.yaml
+++ b/deploy/helm/scf/templates/implicit_vars.yaml
@@ -26,3 +26,5 @@ stringData:
 {{ include "scf.implicit-var" (list . "system_domain") }}
 {{ include "scf.implicit-var" (list . "deployment_name") }}
 {{ include "scf.implicit-var" (list . "releases.defaults.url") }}
+{{ include "scf.implicit-var" (list . "stemcell.os") }}
+{{ include "scf.implicit-var" (list . "stemcell.version") }}

--- a/deploy/helm/scf/values.yaml
+++ b/deploy/helm/scf/values.yaml
@@ -1,6 +1,10 @@
 system_domain: ~
 deployment_name: scf
 
+stemcell:
+  os: opensuse-42.3
+  version: 36.g03b4653-30.80-7.0.0_340.g2b599a90
+
 releases:
   # The defaults for all releases, where we do not otherwise override them.
   defaults:

--- a/deploy/helm/scf/values.yaml
+++ b/deploy/helm/scf/values.yaml
@@ -1,14 +1,13 @@
 system_domain: ~
 deployment_name: scf
 
-stemcell:
-  os: opensuse-42.3
-  version: 36.g03b4653-30.80-7.0.0_340.g2b599a90
-
 releases:
   # The defaults for all releases, where we do not otherwise override them.
   defaults:
     url: docker.io/cfcontainerization
+    stemcell:
+      os: opensuse-42.3
+      version: 36.g03b4653-30.80-7.0.0_340.g2b599a90
 
 sizing:
   HA: false


### PR DESCRIPTION
## Description

This allows us to configure the default stemcell.  Note, however, the image name is still constructed via joining various parts; it's
`((releases-defaults-url))/((release-name)):((stemcell-os))-((stemcell-version))-((release-version))`.

## Test plan

- Run a normal build, everything stays working
- Edit `dev/scf/values.yaml` to add `stemcell: { os: foo, version: bar }` and see the different docker image used when you apply (check the `bpm` pod).

I'm happy to modify the helm chart `values.yaml` layout &c. if there are better names / placements for things.  I tried to put it under `releases/defaults` but it didn't seem to make any sense.