### PR TITLE
Changes to RC pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -444,19 +444,17 @@ pipeline {
 
                     echo "All files changed since last build: ${all_files}"
 
-                    if (getBuildType() == BuildType.ReleaseCandidate) {
-                        HashSet<String> changelogFiles = ["CHANGELOG.md"]
-                        if (!changelogFiles.containsAll(all_files)) {
-                            currentBuild.rawBuild.result = hudson.model.Result.NOT_BUILT
-                            echo "RESULT: ${currentBuild.rawBuild.result}"
-                            throw new hudson.AbortException('Exiting pipeline early (non-changelog commit on RC branch)')
-                        }
-                    } else {
-                        if (areIgnoredFiles(all_files)) {
-                            currentBuild.rawBuild.result = hudson.model.Result.NOT_BUILT
-                            echo "RESULT: ${currentBuild.rawBuild.result}"
-                            throw new hudson.AbortException('Exiting pipeline early')
-                        }
+                    switch (getBuildType()) {
+                        case BuildType.ReleaseCandidate:
+                            // RC builds are manually-triggered only
+                            // Allow all builds
+                            break
+                        default:
+                            if (areIgnoredFiles(all_files)) {
+                                currentBuild.rawBuild.result = hudson.model.Result.NOT_BUILT
+                                echo "RESULT: ${currentBuild.rawBuild.result}"
+                                throw new hudson.AbortException('Exiting pipeline early')
+                            }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -576,7 +576,7 @@ pipeline {
                             echo "Found expected version: ${expectedVersion}"
 
                             def glob = "*scf-sle-${expectedVersion}.*.zip"
-                            def files = s3FindFiles(bucket: params.S3_BUCKET, path: "${params.S3_PREFIX}${distSubDir()}", glob: glob)
+                            def files = s3FindFiles(bucket: params.S3_BUCKET, path: "${params.S3_PREFIX}${distSubDir(false)}", glob: glob)
                             if (files.size() > 0) {
                                 error "found a file that matches our current version: ${files[0].name}"
                             }
@@ -1041,7 +1041,7 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
                                 if (prefix){
                                     prefix = prefix.substring(0, prefix.length() - 1) + '/'
                                 }
-                                def subdir = "${params.S3_PREFIX}${distSubDir()}${prefix}${env.BUILD_TAG}/"
+                                def subdir = "${params.S3_PREFIX}${distSubDir(false)}${prefix}${env.BUILD_TAG}/"
                                 s3Upload(
                                     file: 'cleaned-build.log',
                                     bucket: "${params.S3_LOG_BUCKET}",

--- a/make/include/versioning
+++ b/make/include/versioning
@@ -11,8 +11,6 @@ GIT_DESCRIBE=${GIT_DESCRIBE:-$(git describe --tags --long)}
 GIT_BRANCH=${GIT_BRANCH:-$(git name-rev --name-only HEAD | sed -e 's/[^-a-zA-Z0-9_.]/_/g')}
 
 GIT_TAG=${GIT_TAG:-${GIT_DESCRIBE%-*-*}} # Remove the last two hyphen-separated sections
-# shellcheck disable=2001 # can't use ${x//y} or ${x%y} here
-GIT_TAG="$(echo "${GIT_TAG}" | sed 's@-rc[0-9]\+$@@')" # Remove trailing "-rc1" marker
 GIT_COMMITS=${GIT_COMMITS:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $(NF - 1) }' )}
 GIT_SHA=${GIT_SHA:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $NF }' )}
 


### PR DESCRIPTION
## Description

This makes a couple separate changes to RC releases:

- Always build RC builds, don't filter based on changes.  This needs to be coupled with disabling polling in Jenkins, so that we must manually trigger all builds.
- Upload bundles on RC & nightly after testing, for jsc#CAP-631
- Keep the `-rc1` suffix in the release artifacts, so that we can push them directly to the helm repo.  Unfortunately this means the output will _not_ match the final bits. :warning: please review this more and make sure this is what we want.

## Test plan

- Set `GIT_TAG` to an RC release manually
- `make bundle-dist`
