### PR TITLE
Provide ingress controller for embedded UAA feature

### DIFF
--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -62,9 +62,28 @@ spec:
   tls:
   - secretName: "ingress-tls"
     hosts:
+    {{- if .Values.enable.uaa }}
+    - "*.uaa.{{ .Values.env.DOMAIN }}"
+    {{- end }}
     - "*.{{ .Values.env.DOMAIN }}"
     - "{{ .Values.env.DOMAIN }}"
   rules:
+  {{- if .Values.enable.uaa }}
+  - host: "*.uaa.{{ .Values.env.DOMAIN }}"
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: "uaa-uaa"
+          servicePort: 2793
+  - host: "uaa.{{ .Values.env.DOMAIN }}"
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: "uaa-uaa"
+          servicePort: 2793
+  {{- end }}
   - host: "*.{{ .Values.env.DOMAIN }}"
     http:
       paths:

--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -65,18 +65,18 @@ spec:
     - "*.{{ .Values.env.DOMAIN }}"
     - "{{ .Values.env.DOMAIN }}"
   rules:
-    - host: "*.{{ .Values.env.DOMAIN }}"
-      http:
-        paths:
-          - path: "/"
-            backend:
-              serviceName: "router-gorouter-public"
-              servicePort: 443
-    - host: "{{ .Values.env.DOMAIN }}"
-      http:
-        paths:
-          - path: "/"
-            backend:
-              serviceName: "router-gorouter-public"
-              servicePort: 443
+  - host: "*.{{ .Values.env.DOMAIN }}"
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: "router-gorouter-public"
+          servicePort: 443
+  - host: "{{ .Values.env.DOMAIN }}"
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: "router-gorouter-public"
+          servicePort: 443
 {{- end }}

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1910,6 +1910,8 @@ instance_groups:
       properties.tls.certificate: '"((BBS_REP_CERT))"'                      # cfdot property
       properties.tls.key: ((REP_SERVER_CERT_KEY))
       properties.tls.private_key: '"((BBS_REP_CERT_KEY))"'                  # cfdot property
+      properties.uaa.hostname: '((KUBERNETES_NAMESPACE)).((UAA_HOST))'
+      properties.uaa.port: ((UAA_PORT))
 - name: acceptance-tests-brain
   type: bosh-task
   tags:
@@ -3134,9 +3136,7 @@ configuration:
     properties.uaa.clients.ssh-proxy.secret: '"((UAA_CLIENTS_DIEGO_SSH_PROXY_SECRET))"'
     properties.uaa.clients.tcp_emitter.secret: '"((UAA_CLIENTS_TCP_EMITTER_SECRET))"'
     properties.uaa.clients.tcp_router.secret: '"((UAA_CLIENTS_TCP_ROUTER_SECRET))"'
-    properties.uaa.hostname: '((KUBERNETES_NAMESPACE)).((UAA_HOST))'
     properties.uaa.internal_url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT)) # For loggregator
-    properties.uaa.port: ((UAA_PORT))
     properties.uaa.scim.users: '[{name: admin, password: ((CLUSTER_ADMIN_PASSWORD)), groups: [((CLUSTER_ADMIN_AUTHORITIES))]}]'
     properties.uaa.ssl.port: ((UAA_PORT))
     properties.uaa.tls_port: ((UAA_PORT))


### PR DESCRIPTION
I couldn't find any documentation about how ingress handles overlapping rules; I hope they will be processed in order, so have sorted the more specific host names first:

```
      - host: "*.uaa.{{ .Values.env.DOMAIN }}"
      - host: "uaa.{{ .Values.env.DOMAIN }}"
      - host: "*.{{ .Values.env.DOMAIN }}"
```

I found some references to "longest prefix first", but it is not clear how this interacts with wildcard notation.

  jsc#CAP-675