### PR TITLE
[wip/tests] Create separate instance group for extensions

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -349,6 +349,10 @@ properties:
         user: nats
     ssh_proxy:
       enable_cf_auth: true
+  eirini-persi:
+    # picking 443 as default for webhook extensions
+    # otherwise GKE needs specific fw rules for each operator port
+    operator_webhook_port: 443
   enable_consul_service_registration: false
   encryption:
     active_key_label: smorgasbrod

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -181,36 +181,6 @@ instance_groups:
         run:
           capabilities: [ALL]
           privileged: true
-  - name: eirini-persi-broker
-    release: eirini
-    properties:
-      bosh_containerization:
-        run:
-          scaling:
-            min: 1
-            max: 1
-            ha: 1
-          memory: 256
-          virtual-cpus: 2
-        ports:
-        - name: broker
-          protocol: TCP
-          internal: 8999
-  - name: eirini-persi
-    release: eirini
-    properties:
-      bosh_containerization:
-        run:
-          scaling:
-            min: 1
-            max: 1
-            ha: 1
-          memory: 256
-          virtual-cpus: 2
-        ports:
-        - name: webhook
-          protocol: TCP
-          internal: 2999
   - name: eirini-loggregator-bridge
     release: eirini
     properties:
@@ -238,6 +208,61 @@ instance_groups:
         - name: opi-server
           protocol: TCP
           internal: 8085
+- name: eirini-persi
+  if_feature: eirini
+  environment_scripts:
+  - scripts/configure-HA-hosts.sh
+  - scripts/go_log_level.sh
+  scripts:
+  - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
+  post_config_scripts:
+  - scripts/bpm_kube_dns.rb
+  jobs:
+  - name: global-properties # needs to be first so images use it for processing monit templates.
+    release: scf-helper
+  - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
+    release: scf
+  - name: patch-properties
+    release: scf-helper
+  - name: bpm
+    release: bpm
+    properties:
+      bosh_containerization:
+        run:
+          capabilities: [ALL]
+          privileged: true
+  - name: eirini-persi-broker
+    release: eirini
+    properties:
+      bosh_containerization:
+        run:
+          scaling:
+            min: 1
+            max: 1
+            ha: 1
+          memory: 256
+          virtual-cpus: 2
+        ports:
+        - name: broker
+          protocol: TCP
+          internal: 8999
+  - name: eirini-persi
+    release: eirini
+    properties:
+      bosh_containerization:
+        run:
+          service-account: eirini
+          scaling:
+            min: 1
+            max: 1
+            ha: 1
+          memory: 256
+          virtual-cpus: 2
+        ports:
+        - name: webhook
+          protocol: TCP
+          internal: 443
 - name: bits
   environment_scripts:
   - scripts/configure-HA-hosts.sh
@@ -2963,7 +2988,7 @@ configuration:
     properties.eirini-persi.kube_service_host: "((KUBERNETES_SERVICE_HOST))"
     properties.eirini-persi.kube_service_port: "((KUBERNETES_SERVICE_PORT))"
     properties.eirini-persi.namespace: "((EIRINI_KUBE_NAMESPACE))"
-    properties.eirini-persi.operator_webhook_host: "((EIRINI_EIRINI_PERSI_SERVICE_HOST))"
+    properties.eirini-persi.operator_webhook_host: "((EIRINI_PERSI_EIRINI_PERSI_SERVICE_HOST))"
     properties.eirini.cert_copier_image: "((EIRINI_CERT_COPIER_IMAGE))"
     properties.external_cert: '"((LOG_CACHE_CF_AUTH_PROXY_EXTERNAL_CERT))"'
     properties.external_key: '"((LOG_CACHE_CF_AUTH_PROXY_EXTERNAL_CERT_KEY))"'
@@ -3764,10 +3789,6 @@ variables:
     default: 'eirini/recipe-downloader:0.2.0'
     description: "Downloads app-bits and buildpacks from the bits-service"
     imagename: true
-- name: EIRINI_EIRINI_PERSI_SERVICE_HOST
-  options:
-    type: environment
-    description: "The Eirini extensions service ClusterIP (automatically set by Kubernetes)"
 - name: EIRINI_EXECUTOR_IMAGE
   options:
     default: 'eirini/recipe-executor:0.2.0'
@@ -3781,6 +3802,10 @@ variables:
   options:
     default: 'eirini'
     description: "The namespace used by Eirini for deploying applications."
+- name: EIRINI_PERSI_EIRINI_PERSI_SERVICE_HOST
+  options:
+    type: environment
+    description: "The Eirini extensions service ClusterIP (automatically set by Kubernetes)"
 - name: EIRINI_PERSI_NFS_BROKER_PASSWORD
   options:
     description: Basic auth password to verify on incoming Service Broker requests


### PR DESCRIPTION
Split the persi extension in its own pod. Having the extension in its own instance group
has the benefit of better tracking of issues. More importantly
allows us to specify a fixed port for mutating webhooks for a better
support out of the box ( which some
providers, like GKE, may require manual firewall configuration steps to
allow the kubeapi to reach the extension running on the cluster )

cc: @jimmykarily 
