### PR TITLE
v3 - Added temporary cf_cli.sh for creating cf-cli pod

### DIFF
--- a/dev/cf_cli/README.md
+++ b/dev/cf_cli/README.md
@@ -1,0 +1,4 @@
+# cf-cli
+
+The `cf_cli.sh` script contained in this directory is a temporary helper script that creates a pod
+with cf-cli configured.

--- a/dev/cf_cli/cf_cli.sh
+++ b/dev/cf_cli/cf_cli.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+namespace="scf"
+deployment_name="scf"
+pod_name="cf-terminal"
+api_ip=""
+echo "Waiting for endpoint..."
+while true; do
+  api_ip=$(kubectl describe endpoints -n "${namespace}" "${deployment_name}-router" | awk 'match($0, /  Addresses:[ ]+(.*)/, ip) { print ip[1] }')
+  if [ -n "${api_ip}" ]; then break; fi
+  sleep 3
+done
+admin_password=$(kubectl get secret --namespace "${namespace}" "${deployment_name}.var-cf-admin-password" -o jsonpath='{.data.password}' | base64 --decode)
+system_domain=$(kubectl get secret --namespace "${namespace}" "${deployment_name}.var-system-domain" -o jsonpath='{.data.value}' | base64 --decode)
+
+kubectl delete pod --namespace "${namespace}" "${pod_name}" || true
+kubectl create --namespace "${namespace}" -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "${pod_name}"
+spec:
+  hostAliases:
+  - ip: "${api_ip}"
+    hostnames:
+    - "app1.${system_domain}"
+    - "app2.${system_domain}"
+    - "app3.${system_domain}"
+    - "login.${system_domain}"
+    - "api.${system_domain}"
+    - "uaa.${system_domain}"
+    - "doppler.${system_domain}"
+  containers:
+  - name: cf-terminal
+    image: governmentpaas/cf-cli
+    command: ["bash", "-c"]
+    args:
+    - |-
+      set -o errexit
+      cf api --skip-ssl-validation "api.${system_domain}"
+      cf login -u admin -p "${admin_password}"
+      cf create-org demo
+      cf target -o demo
+      cf create-space demo
+      cf target -s demo
+      cf enable-feature-flag diego_docker
+      sleep 3600000
+EOF

--- a/dev/cf_cli/cf_cli.sh
+++ b/dev/cf_cli/cf_cli.sh
@@ -5,11 +5,11 @@ set -o errexit -o nounset
 namespace="scf"
 deployment_name="scf"
 pod_name="cf-terminal"
-api_ip=""
+router_endpoint=""
 echo "Waiting for endpoint..."
 while true; do
-  api_ip=$(kubectl describe endpoints -n "${namespace}" "${deployment_name}-router" | awk 'match($0, /  Addresses:[ ]+(.*)/, ip) { print ip[1] }')
-  if [ -n "${api_ip}" ]; then break; fi
+  router_endpoint=$(kubectl describe endpoints -n "${namespace}" "${deployment_name}-router" | awk 'match($0, /  Addresses:[ ]+(.*)/, ip) { print ip[1] }')
+  if [ -n "${router_endpoint}" ]; then break; fi
   sleep 3
 done
 admin_password=$(kubectl get secret --namespace "${namespace}" "${deployment_name}.var-cf-admin-password" -o jsonpath='{.data.password}' | base64 --decode)
@@ -23,7 +23,7 @@ metadata:
   name: "${pod_name}"
 spec:
   hostAliases:
-  - ip: "${api_ip}"
+  - ip: "${router_endpoint}"
     hostnames:
     - "app1.${system_domain}"
     - "app2.${system_domain}"

--- a/dev/cf_cli/cf_cli.sh
+++ b/dev/cf_cli/cf_cli.sh
@@ -15,6 +15,8 @@ done
 admin_password=$(kubectl get secret --namespace "${namespace}" "${deployment_name}.var-cf-admin-password" -o jsonpath='{.data.password}' | base64 --decode)
 system_domain=$(kubectl get secret --namespace "${namespace}" "${deployment_name}.var-system-domain" -o jsonpath='{.data.value}' | base64 --decode)
 
+echo "Found router endpoint: ${router_endpoint}"
+
 kubectl delete pod --namespace "${namespace}" "${pod_name}" || true
 kubectl create --namespace "${namespace}" -f - <<EOF
 apiVersion: v1


### PR DESCRIPTION
## Description

This temporary script helps with accessing the CF cluster from within the k8s cluster.

## Test plan

1. Deploy SCF v3.
2. Execute the `cf_cli.sh` script.
3. Check that the `cf-terminal` pod was created and configured the cf-cli.
4. Get a shell session to the `cf-terminal` pod and perform cf-cli operations.
