### PR TITLE
Reduce empty YAML doc

### DIFF
--- a/deploy/helm/scf/templates/bosh_deployment.yaml
+++ b/deploy/helm/scf/templates/bosh_deployment.yaml
@@ -1,5 +1,4 @@
 {{- $root := . -}}
----
 apiVersion: fissile.cloudfoundry.org/v1alpha1
 kind: BOSHDeployment
 metadata:

--- a/deploy/helm/scf/templates/single_availability.yaml
+++ b/deploy/helm/scf/templates/single_availability.yaml
@@ -1,5 +1,4 @@
 {{ if not .Values.sizing.HA -}}
----
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Reduce empty YAML doc in single YAML template, such as:

```
---
# Source: scf/templates/single_availability.yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: ops-single-availability
  labels:
    app.kubernetes.io/component: operations
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/managed-by: "Tiller"
    app.kubernetes.io/name: release-name-scf
    app.kubernetes.io/version: "0.0"
    helm.sh/chart: scf-0.0.0
```