### PR TITLE
Initial commit of acceptance tests

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -1,0 +1,34 @@
+- path: /releases/-
+  type: replace
+  value:
+    name: cf-acceptance-tests
+    url: {{ .Values.releases.defaults.url | quote }}
+    version: 0.0.1
+- path: /instance_groups/-
+  type: replace
+  value:
+    azs:
+    - z1
+    instances: 1
+    jobs:
+    - name: acceptance-tests
+      properties:
+        acceptance_tests:
+          admin_password: ((cf_admin_password))
+          admin_user: admin
+          api: https://api.((system_domain))
+          apps_domain: ((system_domain))
+          include: >-
+            {{ .Values.releases.cf_acceptance_tests.properties.acceptance_tests.include }}
+          skip_ssl_validation: true
+        bpm:
+          enabled: true
+      release: cf-acceptance-tests
+    lifecycle: errand
+    name: acceptance-tests
+    networks:
+    - name: default
+    stemcell: default
+    update:
+      serial: true
+    vm_type: minimal

--- a/deploy/helm/scf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -18,8 +18,6 @@
           admin_user: admin
           api: https://api.((system_domain))
           apps_domain: ((system_domain))
-          include: >-
-            {{ .Values.releases.cf_acceptance_tests.properties.acceptance_tests.include }}
           skip_ssl_validation: true
         bpm:
           enabled: true

--- a/deploy/helm/scf/assets/operations/temporary/cf-acceptance-tests-stemcell.yaml
+++ b/deploy/helm/scf/assets/operations/temporary/cf-acceptance-tests-stemcell.yaml
@@ -1,0 +1,9 @@
+# cf-acceptance-tests is currently only built with a newer stemcell (i.e.
+# the default stemcell isn't currently built of all of our instance groups).
+# Temporarily replace its stemcell until everything is up to date.
+- type: replace
+  path: /releases/name=cf-acceptance-tests/stemcell?
+  value:
+      alias: default
+      os: opensuse-42.3
+      version: 36.g03b4653-30.80-7.0.0_355.gd4df8ff7

--- a/deploy/helm/scf/templates/bosh_deployment.yaml
+++ b/deploy/helm/scf/templates/bosh_deployment.yaml
@@ -23,11 +23,11 @@ spec:
   - name: ops-use-bits-service
     type: configmap
 {{- end }}
-{{- range $path, $bytes := .Files.Glob "assets/operations/temporary/*" }}
+{{- range $path, $bytes := .Files.Glob "assets/operations/instance_groups/*" }}
   - name: {{ include "scf.ops-name" $path }}
     type: configmap
 {{- end }}
-{{- range $path, $bytes := .Files.Glob "assets/operations/instance_groups/*" }}
+{{- range $path, $bytes := .Files.Glob "assets/operations/temporary/*" }}
   - name: {{ include "scf.ops-name" $path }}
     type: configmap
 {{- end }}

--- a/deploy/helm/scf/templates/ops.yaml
+++ b/deploy/helm/scf/templates/ops.yaml
@@ -21,10 +21,10 @@ data:
 {{- if .Values.features.suse_buildpacks }}
 {{ include "scf.ops" (dict "Root" $root "Path" "assets/operations/buildpacks/set_suse_buildpacks.yaml") }}
 {{- end }}
-{{- range $path, $bytes := .Files.Glob "assets/operations/temporary/*" }}
+{{- range $path, $bytes := .Files.Glob "assets/operations/instance_groups/*" }}
 {{ include "scf.ops" (dict "Root" $root "Path" $path) }}
 {{- end }}
-{{- range $path, $bytes := .Files.Glob "assets/operations/instance_groups/*" }}
+{{- range $path, $bytes := .Files.Glob "assets/operations/temporary/*" }}
 {{ include "scf.ops" (dict "Root" $root "Path" $path) }}
 {{- end }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/*" }}

--- a/deploy/helm/scf/values.yaml
+++ b/deploy/helm/scf/values.yaml
@@ -19,10 +19,6 @@ releases:
     stemcell:
       os: opensuse-42.3
       version: 36.g03b4653-30.80-7.0.0_340.g2b599a90
-  cf_acceptance_tests:
-    properties:
-      acceptance_tests:
-        include: "" # e.g. "+docker,-ssh"
 
 sizing:
   HA: false

--- a/deploy/helm/scf/values.yaml
+++ b/deploy/helm/scf/values.yaml
@@ -19,6 +19,10 @@ releases:
     stemcell:
       os: opensuse-42.3
       version: 36.g03b4653-30.80-7.0.0_340.g2b599a90
+  cf_acceptance_tests:
+    properties:
+      acceptance_tests:
+        include: "" # e.g. "+docker,-ssh"
 
 sizing:
   HA: false

--- a/testing/README.md
+++ b/testing/README.md
@@ -6,4 +6,5 @@ After the SCF deployment completed, run:
 
 ```sh
 bazel run //testing/smoke_tests
+bazel run //testing/acceptance_tests
 ```

--- a/testing/acceptance_tests/BUILD.bazel
+++ b/testing/acceptance_tests/BUILD.bazel
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//rules/kubectl:def.bzl", kubectl_patch = "patch")
+load("//:def.bzl", "project")
+
+kubectl_patch(
+    name = "acceptance_tests",
+    namespace = project.namespace,
+    resource_type = "ejob",
+    resource_name = "scf-acceptance-tests",
+    patch_type = "merge",
+    patch_file = ":trigger.yaml",
+)

--- a/testing/acceptance_tests/README.md
+++ b/testing/acceptance_tests/README.md
@@ -1,0 +1,21 @@
+# Acceptance tests
+
+This bazel target starts a run of the [Cloud Foundry Acceptance Tests].
+
+[Cloud Foundry Acceptance Tests]: https://github.com/SUSE/cf-acceptance-tests-release
+## Limiting test suites
+
+To limit the test groups to run, set the BOSH property
+[`acceptance_tests.include`] as documented.  To do so, adjust the `properties`
+key in [`values.yaml`] to specify the groups desired.  For example:
+
+```yaml
+properties:
+  acceptance-tests:
+    acceptance-tests:
+      acceptance_tests:
+        include: "+docker,-ssh"
+```
+
+[`acceptance_tests.include`]:  https://github.com/SUSE/cf-acceptance-tests-release/blob/0.0.1/jobs/acceptance-tests/spec#L47-L54
+[`values.yaml`]: ../../dev/scf/values.yaml

--- a/testing/acceptance_tests/trigger.yaml
+++ b/testing/acceptance_tests/trigger.yaml
@@ -1,0 +1,3 @@
+spec:
+  trigger:
+    strategy: now


### PR DESCRIPTION
## Description

Add initial support for CATS; it runs as an ejob, same as smoke tests.

Requires BOSH release [mook-as/cf-acceptance-tests-release].

[mook-as/cf-acceptance-tests-release]: https://github.com/mook-as/cf-acceptance-tests-release/

Does not pass yet; this is just for the initial support so we can start looking at the failures.

## Test plan

- Deploy SCF
- Wait for everything to go green
- Edit the `acceptance-tests` ejob to have a `strategy` of `now` to trigger the job

## Notes
- We need a pipeline for building the BOSH release later (and a better home for the release)
- See also mook-as/cf-acceptance-tests-release#1
