### PR TITLE
Use kube csr feature for opi-registry in eirini

### DIFF
--- a/chart-parts/_helpers.tpl
+++ b/chart-parts/_helpers.tpl
@@ -1,0 +1,18 @@
+{{/*
+Define the standard labels that will be applied to all objects in this chart.
+*/}}
+{{- define "scf.labels" }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+{{- end }}
+
+{{/*
+Define the role based labels that will be applied to all objects in this chart.
+*/}}
+{{- define "scf.role-labels" }}
+    app.kubernetes.io/component: {{ quote . }}
+    skiff-role-name: {{ quote . }}
+{{- end }}

--- a/chart-parts/cluster-roles.yaml
+++ b/chart-parts/cluster-roles.yaml
@@ -1,0 +1,136 @@
+{{- if and (eq (printf "%s" .Values.kube.auth) "rbac") (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1") }}
+
+{{- if .Values.enable.eirini }}
+
+# eirini-webhook cluster role for eirini service account.
+# Used to implement eirinix extensions.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "fissile.SanitizeName" (printf "%s-eirini-webhook" .Release.Namespace) }}
+  labels:
+    {{- template "scf.role-labels" "eirini-webhook" }}
+    {{- template "scf.labels" . }}
+rules:
+- apiGroups: ['admissionregistration.k8s.io']
+  resources: ['mutatingwebhookconfigurations']
+  verbs:     ['*']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "fissile.SanitizeName" (printf "%s-eirini-webhook" .Release.Namespace) }}
+  labels:
+    {{- template "scf.role-labels" "eirini-webhook" }}
+    {{- template "scf.labels" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fissile.SanitizeName" (printf "%s-eirini-webhook" .Release.Namespace) }}
+subjects:
+- kind: ServiceAccount
+  name: eirini
+  namespace: {{.Release.Namespace}}
+
+# eirini-csr cluster role for secret-generator service account.
+# Used to create certificate signing requests for the opi-registry certificate.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "fissile.SanitizeName" (printf "%s-eirini-csr" .Release.Namespace) }}
+  labels:
+    {{- template "scf.role-labels" "eirini-csr" }}
+    {{- template "scf.labels" . }}
+rules:
+- apiGroups: [certificates.k8s.io]
+  resources: [certificatesigningrequests]
+  verbs:     [create, get, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "fissile.SanitizeName" (printf "%s-eirini-csr" .Release.Namespace) }}
+  labels:
+    {{- template "scf.role-labels" "eirini-csr" }}
+    {{- template "scf.labels" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fissile.SanitizeName" (printf "%s-eirini-csr" .Release.Namespace) }}
+subjects:
+- kind: ServiceAccount
+  name: secret-generator
+  namespace: {{ .Release.Namespace }}
+
+{{- if eq (toString .Values.env.KUBE_CSR_AUTO_APPROVAL) "true" }}
+
+# eirini-csr-approver cluster role for secret-generator service account.
+# Used to auto-aaprove certificate signing requests for the opi-registry certificate.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "fissile.SanitizeName" (printf "%s-eirini-csr-approver" .Release.Namespace) }}
+  labels:
+    {{- template "scf.role-labels" "eirini-csr-approver" }}
+    {{- template "scf.labels" . }}
+rules:
+- apiGroups: [certificates.k8s.io]
+  resources: [certificatesigningrequests/approval]
+  verbs:     [update]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "fissile.SanitizeName" (printf "%s-eirini-csr-approver" .Release.Namespace) }}
+  labels:
+    {{- template "scf.role-labels" "eirini-csr-approver" }}
+    {{- template "scf.labels" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fissile.SanitizeName" (printf "%s-eirini-csr-approver" .Release.Namespace) }}
+subjects:
+- kind: ServiceAccount
+  name: secret-generator
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+
+{{- else }}{{/* if .Values.enable.eirini */}}
+
+# diego-node-reader role for garden-runc service account.
+# Used to read the node labels to determine the availability zone for diego-cell.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "fissile.SanitizeName" (printf "%s-diego-node-reader" .Release.Namespace) }}
+  labels:
+    {{- template "scf.role-labels" "diego-node-reader" }}
+    {{- template "scf.labels" . }}
+rules:
+- apiGroups: [""]
+  resources: [nodes]
+  verbs:     [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "fissile.SanitizeName" (printf "%s-diego-node-reader" .Release.Namespace) }}
+  labels:
+    {{- template "scf.role-labels" "diego-node-reader" }}
+    {{- template "scf.labels" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fissile.SanitizeName" (printf "%s-diego-node-reader" .Release.Namespace) }}
+subjects:
+- kind: ServiceAccount
+  name: garden-runc
+  namespace: {{ .Release.Namespace }}
+
+{{- end }}
+
+{{- end }}

--- a/chart-parts/eirini-namespace.yaml
+++ b/chart-parts/eirini-namespace.yaml
@@ -6,6 +6,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{.Values.env.EIRINI_KUBE_NAMESPACE | quote}}
+  labels:
+    {{- template "scf.role-labels" "eirini-namespace" }}
+    {{- template "scf.labels" . }}
 {{- end }}
 
 {{- if and (eq (printf "%s" .Values.kube.auth) "rbac") (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1") }}
@@ -13,7 +16,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: eirini
+  name: eirini-namespace-admin
   namespace: {{.Values.env.EIRINI_KUBE_NAMESPACE | quote}}
 rules:
 - apiGroups: ['*']
@@ -23,12 +26,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: eirini
+  name: eirini-namespace-admin
   namespace: {{.Values.env.EIRINI_KUBE_NAMESPACE | quote}}
+  labels:
+    {{- template "scf.role-labels" "eirini-namespace-admin" }}
+    {{- template "scf.labels" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: eirini
+  name: eirini-namespace-admin
 subjects:
 - kind: ServiceAccount
   name: eirini

--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -12,12 +12,8 @@ metadata:
   name: "ingress-tls"
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/component: "ingress-tls"
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
-    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
-    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+    {{- template "scf.role-labels" "ingress-tls" }}
+    {{- template "scf.labels" . }}
 data:
   tls.crt: {{ .Values.ingress.tls.crt | default "" | b64enc | quote }}
   tls.key: {{ .Values.ingress.tls.key | default "" | b64enc | quote }}
@@ -52,12 +48,8 @@ metadata:
     {{ $_ := set .Values.ingress.annotations "nginx.org/websocket-services" "router-gorouter-public" }}
 {{ toYaml .Values.ingress.annotations | indent 4 }}
   labels:
-    app.kubernetes.io/component: "ingress"
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
-    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
-    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+    {{- template "scf.role-labels" "ingress" }}
+    {{- template "scf.labels" . }}
 spec:
   tls:
   - secretName: "ingress-tls"

--- a/chart-parts/opi-registry-service.yaml
+++ b/chart-parts/opi-registry-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.enable.eirini }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: opi-registry
+  labels:
+    {{- template "scf.role-labels" "opi-registry" }}
+    {{- template "scf.labels" . }}
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app.kubernetes.io/component: bits
+  type: NodePort
+{{- end }}

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -140,9 +140,9 @@ releases:
   version: "1.0.5"
   sha1: "eed1eed8d1b2bb20968c4a028d67fb095b606ae8"
 - name: scf-helper
-  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.4.tgz"
-  version: "1.0.4"
-  sha1: "1ac9ec02495ca1660089fdb4343336666fc058eb"
+  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.5.tgz"
+  version: "1.0.5"
+  sha1: "c06bd583eb655ce9ed562f812ede5a6ace27d9d2"
 - name: "bits-service"
   version: "2.28.0"
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=2.28.0"

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -140,9 +140,9 @@ releases:
   version: "1.0.5"
   sha1: "eed1eed8d1b2bb20968c4a028d67fb095b606ae8"
 - name: scf-helper
-  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.3.tgz"
-  version: "1.0.3"
-  sha1: "c6187d732f0b49f837bdadd0221fe0d91eb55515"
+  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.4.tgz"
+  version: "1.0.4"
+  sha1: "1ac9ec02495ca1660089fdb4343336666fc058eb"
 - name: "bits-service"
   version: "2.28.0"
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=2.28.0"
@@ -161,6 +161,8 @@ instance_groups:
   if_feature: eirini
   environment_scripts:
   - scripts/configure-HA-hosts.sh
+  # eirini-bosh-release already includes kubectl package, so we don't need get-kubectl job from scf-release.
+  - scripts/set-opi-registry-port.sh
   - scripts/go_log_level.sh
   scripts:
   - scripts/forward_logfiles.sh
@@ -279,7 +281,8 @@ instance_groups:
           internal: 443
   configuration:
     templates:
-      properties.route_registrar.routes: '[{"name":"bits-service","tls_port":443,"uris":["bits.((DOMAIN))", "registry.((DOMAIN))"],"registration_interval":"20s","server_cert_domain_san":"bits","tags":{"component":"bits-service"}}]'
+      properties.bits-service.registry_endpoint: "https://127.0.0.1"
+      properties.route_registrar.routes: '[{"name":"bits-service","tls_port":443,"uris":["bits.((DOMAIN))"],"registration_interval":"20s","server_cert_domain_san":"bits","tags":{"component":"bits-service"}}]'
 - name: syslog-scheduler
   scripts:
   - scripts/forward_logfiles.sh
@@ -2116,9 +2119,11 @@ instance_groups:
           service-account: secret-generator
   configuration:
     templates:
+      properties.scf.secrets.auto_approval: ((KUBE_CSR_AUTO_APPROVAL))
       properties.scf.secrets.cert_expiration: ((CERT_EXPIRATION))
       properties.scf.secrets.cluster_domain: ((KUBERNETES_CLUSTER_DOMAIN))
       properties.scf.secrets.domain: ((DOMAIN))
+      properties.scf.secrets.env: '["FEATURE_EIRINI_ENABLED=((FEATURE_EIRINI_ENABLED))"]'
       properties.scf.secrets.generation: ((KUBE_SECRETS_GENERATION_COUNTER))
       properties.scf.secrets.is_install: ((HELM_IS_INSTALL))
       properties.scf.secrets.name: ((KUBE_SECRETS_GENERATION_NAME))
@@ -2139,6 +2144,9 @@ instance_groups:
           memory: 256
           virtual-cpus: 1
           service-account: eirini
+  configuration:
+    templates:
+      properties.eirini.run_cert_copier: ""
 - name: post-deployment-setup
   type: bosh-task
   jobs:
@@ -2600,18 +2608,6 @@ configuration:
         resources: [pods/portforward]
         verbs: [create]
     cluster-roles:
-      node-reader-role:
-      - apiGroups: [""]
-        resources: [nodes]
-        verbs: [get, list, watch]
-      mutating-webhook-role:
-      - apiGroups: ["admissionregistration.k8s.io"]
-        resources: [mutatingwebhookconfigurations]
-        verbs: ['*']
-      daemonset-role:
-      - apiGroups: [extensions]
-        resources: [daemonsets]
-        verbs: [create, get, list, delete, update]
       test-cluster-role:
       - apiGroups: [""]
         resources: [namespaces]
@@ -2649,7 +2645,6 @@ configuration:
         - configMap
         - secret
         - emptyDir
-        - hostPath # Needed for the Eirini Cert copier ( /etc/docker )
         - downwardAPI
         - projected
         - persistentVolumeClaim
@@ -2666,10 +2661,8 @@ configuration:
         roles: [configgin-role, test-role-sits, psp-role]
       garden-runc:
         roles: [configgin-role, psp-role]
-        cluster-roles: [node-reader-role]
       eirini:
         roles: [configgin-role, secrets-role, psp-role]
-        cluster-roles: [mutating-webhook-role, daemonset-role]
   templates:
     az: '"((KUBE_AZ))"'
     id: ((HOSTNAME))
@@ -2782,7 +2775,6 @@ configuration:
     properties.bits-service.packages.webdav_config.public_endpoint: https://blobstore.((DOMAIN))
     properties.bits-service.private_endpoint: "https://bits-bits-service.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"
     properties.bits-service.public_endpoint: "https://bits.((DOMAIN))"
-    properties.bits-service.registry_endpoint: "https://registry.((DOMAIN))"
     properties.bits-service.signing_users: '[{"username": "admin", "password": "((BITS_ADMIN_USERS_PASSWORD))"}]'
     properties.bits-service.tls.cert: ((BITS_SERVICE_SSL_CERT))
     properties.bits-service.tls.key: ((BITS_SERVICE_SSL_CERT_KEY))
@@ -3057,7 +3049,7 @@ configuration:
     # TODO: this needs to be fixed upstream - it should be an array
     properties.opi.nats_ip: "nats-0.nats-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"
     properties.opi.nats_password: "((NATS_PASSWORD))"
-    properties.opi.registry_address: "registry.((DOMAIN))"
+    properties.opi.registry_address: "127.0.0.1:((OPI_REGISTRY_NODEPORT))"
     properties.opi.registry_password: "((EIRINI_REGISTRY_PASSWORD))"
     properties.opi.registry_username: "((EIRINI_REGISTRY_USERNAME))"
     properties.opi.server_cert: "((EIRINI_SERVER_CERT))"
@@ -3447,12 +3439,13 @@ variables:
 - name: BITS_SERVICE_SSL_CERT
   options:
     secret: true
-    ca: INTERNAL_CA_CERT
+    ca: '{{if eq .FEATURE_EIRINI_ENABLED "true"}}~{{else}}INTERNAL_CA_CERT{{end}}'
     role_name: bits
     description: PEM-encoded client certificate.
     required: true
     alternative_names:
     - bits-bits-service.{{.KUBERNETES_NAMESPACE}}.svc.{{.KUBERNETES_CLUSTER_DOMAIN}}
+    - 127.0.0.1
   type: certificate
 - name: BITS_SERVICE_SSL_CERT_KEY
   options:
@@ -3954,6 +3947,7 @@ variables:
   options:
     secret: true
     is_ca: true
+    append_kube_ca: '{{.FEATURE_EIRINI_ENABLED}}'
     description: PEM-encoded CA certificate used to sign the TLS certificate used
       by all components to secure their communications.
     required: true
@@ -4020,6 +4014,11 @@ variables:
     description: >
       This is an environment variable built-in by fissile.
       It's set to a numeric index for roles with multiple replicas.
+- name: KUBE_CSR_AUTO_APPROVAL
+  options:
+    default: false
+    description: >
+      Allow the secrets-generator to auto-approve the kube cert signing requests it makes.
 - name: KUBE_NATS_CLUSTER_IPS
   options:
     type: environment
@@ -4296,6 +4295,10 @@ variables:
     description: Comma separated list of IP addresses and domains which should not
       be directoed through a proxy, if any.
     required: false
+- name: OPI_REGISTRY_NODEPORT
+  options:
+    type: environment
+    description: "OPI registry port on the localhost nodePort"
 - name: PERSI_NFS_ALLOWED_OPTIONS
   options:
     description: Comma separated list of white-listed options that may be set during

--- a/container-host-files/etc/scf/config/scripts/set-opi-registry-port.sh
+++ b/container-host-files/etc/scf/config/scripts/set-opi-registry-port.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Locate the kubectl binary.
+kubectl="/var/vcap/packages/kubectl/bin/kubectl"
+
+set +x
+export OPI_REGISTRY_NODEPORT=$(${kubectl} get svc -n ${KUBERNETES_NAMESPACE} opi-registry \
+                                          -o jsonpath='{.spec.ports[0].nodePort}')


### PR DESCRIPTION
The old mechanism of using a docker cert copying daemon set does not work with non-docker based container runtimes. It also has problems when the host filesystem is not writable by the daemon set.

The new mechanism uses the kube certificate service to sign a cert for the registry. This still requires the kube CA to be installed such that the container runtimes on each worker node will trust it.

This commit uses a nodePort service on `127.0.0.1` for the registry:

* Can't use `registry.$DOMAIN` because it uses the wildcard cert from the gorouter. Also we don't want to expose the registry publicly.

* Can't use `bits-bits-service.$NS.svc.cluster.local` because the name doesn't resolve outside the cluster (container runtime cannot pull from there).

* Can't use `localhost` because it doesn't work (for unknown reasons).

All cluster-roles are moved out of the rolemanifest into `chart-parts/` so that only the ones used in a specific configuration are defined and bound to the service accounts.

[jsc#CAP-587]