### PR TITLE
Added leader election for mysql-proxy switchboard.

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -140,9 +140,9 @@ releases:
   version: "1.0.5"
   sha1: "eed1eed8d1b2bb20968c4a028d67fb095b606ae8"
 - name: scf-helper
-  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.5.tgz"
-  version: "1.0.5"
-  sha1: "c06bd583eb655ce9ed562f812ede5a6ace27d9d2"
+  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.7.tgz"
+  version: "1.0.7"
+  sha1: "d8f4eb845f18dfd89dbad2a7aab7284d81151367"
 - name: "bits-service"
   version: "2.28.0"
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=2.28.0"
@@ -550,6 +550,14 @@ instance_groups:
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates.
     release: scf-helper
+  - name: switchboard-leader
+    release: scf-helper
+  - name: bpm
+    release: bpm
+    properties:
+      bosh_containerization:
+        run:
+          privileged: true
   - name: proxy
     release: pxc
     provides:
@@ -574,6 +582,7 @@ instance_groups:
           capabilities: []
           memory: 2500
           virtual-cpus: 2
+          active-passive-probe: /var/vcap/jobs/switchboard-leader/bin/readiness/switchboard
           healthcheck:
             readiness:
               command:
@@ -590,13 +599,8 @@ instance_groups:
                       values:
                       - mysql
                   topologyKey: "beta.kubernetes.io/os"
-  - name: bpm
-    release: bpm
-    properties:
-      bosh_containerization:
-        run:
-          privileged: true
   tags:
+  - active-passive
   - sequential-startup
   configuration:
     templates:
@@ -2567,7 +2571,7 @@ configuration:
         verbs: [get, list, patch]
       - apiGroups: [""]
         resources: [services]
-        verbs: [get]
+        verbs: [get, list, patch]
       - apiGroups: [apps]
         resources: [statefulsets]
         verbs: [get, patch]


### PR DESCRIPTION
## Description

Controlling ticket is https://jira.suse.com/browse/CAP-168

Role manifest update for testing a new scf-helper release.

Subordinate UAA PR = https://github.com/SUSE/uaa-fissile-release/pull/168
Subordinate scf-helper PR = https://github.com/SUSE/scf-helper-release/pull/24

## Test plan

  - Check this branch out somewhere (`/path/to/scf-checkout`).
    Update the submodules to get the associated UAA PR.
  - Get a checkout of https://github.com/SUSE/scf-helper-release/pull/24
  - In the check out run
    ```
    bosh reset-release
    bosh create-release --force --tarball /path/to/scf-checkout/output/scf-helper-release.tgz
    ```

  - In the SCF checkout start a vagrant box as usual
  - Build as usual.
  - Start as usual.
  - Place
    ```
    #!/bin/bash
    N="${1:-cf}"
    kubectl describe svc -n "${N}" mysql-proxy-proxy | grep -v ^Target | grep -v ^Port | grep -v io/
    echo
    pods=$(kubectl get pod -n "${N}" | grep mysql-proxy- | awk '{ print $1 }')
    for pod in $pods
    do
      kubectl describe pod -n "${N}" $pod | grep skiff-role
      echo
    done
    exit
    ```
    into a script, for example `w.sh` and then use
    ```
    watch -c "w.sh cf ; w.sh uaa"
    ```
    to watch the state of the uaa and scf mysql proxy services, and the annotations for the leader election.
   Only one of the proxy pods should be marked active.

  - Update and resize the number of database and proxy pods. Watch the re-election.
