### PR TITLE
v3 - Shellcheck managed by Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,19 @@
 workspace(name = "scf")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//dev/kind:binary.bzl", "kind_binary")
+load("//dev/minikube:binary.bzl", "minikube_binary")
+load("//rules/external_binary:def.bzl", "external_binary")
 load("//rules/helm:binary.bzl", "helm_binary")
 load("//rules/kubectl:binary.bzl", "kubectl_binary")
-load("//dev/minikube:binary.bzl", "minikube_binary")
-load("//dev/kind:binary.bzl", "kind_binary")
 load(":def.bzl", "project")
+
+external_binary(
+    name = "shellcheck",
+    darwin = project.shellcheck.platforms.darwin,
+    linux = project.shellcheck.platforms.linux,
+    windows = project.shellcheck.platforms.windows,
+)
 
 http_archive(
     name = "cf_deployment",

--- a/def.bzl
+++ b/def.bzl
@@ -80,4 +80,20 @@ project = struct(
         version = "0.3.3",
         sha256 = "9a8a204a46a4159f5a6bcb508cc51b49cdfb15aa5a034c7910ddca5a435097d4",
     ),
+    shellcheck = struct(
+        platforms = struct(
+            darwin = {
+                "url": "https://storage.googleapis.com/shellcheck/shellcheck-v0.7.0.darwin-x86_64",
+                "sha256": "a5d77cbe4c3e92916bce712b959f6d54392f94bcf8ea84f80ba425a9e72e2afe",
+            },
+            linux = {
+                "url": "https://storage.googleapis.com/shellcheck/shellcheck-v0.7.0.linux-x86_64",
+                "sha256": "c37d4f51e26ec8ab96b03d84af8c050548d7288a47f755ffb57706c6c458e027",
+            },
+            windows = {
+                "url": "https://storage.googleapis.com/shellcheck/shellcheck-v0.7.0.exe",
+                "sha256": "8aafdeff31095613308e92ce6a13e3c41249b51e757fd4fcdfdfc7a81d29286a",
+            },
+        ),
+    ),
 )

--- a/dev/linters/shellcheck.sh
+++ b/dev/linters/shellcheck.sh
@@ -2,20 +2,6 @@
 
 set -o errexit
 
-RED='\033[0;31m'
-NC='\033[0m'
-
-if ! hash shellcheck 2> /dev/null; then
-  >&2 echo -e "${RED}shellcheck not installed${NC}"
-  exit 1
-fi
-
-min_version="0.4.0"
-current_version=$(shellcheck --version | awk '/^version:/{ print $2 }')
-
-if [[ "$(echo -e "${min_version}\\n${current_version}" | sort -V | head -n 1)" != "${min_version}" ]]; then
-  >&2 echo -e "${RED}minimum shellcheck version should be ${min_version}, found installed version ${current_version}${NC}"
-  exit 1
-fi
-
-find . -name '*.sh' -print0 | xargs -0 -n1 shellcheck
+# shellcheck disable=SC2046
+# We want word splitting with find.
+bazel run @shellcheck//executable -- $(find . -name '*.sh')

--- a/rules/external_binary/BUILD.bazel
+++ b/rules/external_binary/BUILD.bazel
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/rules/external_binary/def.bzl
+++ b/rules/external_binary/def.bzl
@@ -1,0 +1,41 @@
+def _external_binary_impl(ctx):
+    info = None
+    if ctx.os.name == 'mac os x':
+        info = ctx.attr.darwin
+        _validade_platform_info("darwin", info)
+    elif ctx.os.name == 'linux':
+        info = ctx.attr.linux
+        _validade_platform_info("linux", info)
+    elif ctx.os.name == 'windows':
+        info = ctx.attr.windows
+        _validade_platform_info("windows", info)
+    else:
+        fail("Unsupported operating system: {}".format(ctx.os.name))
+
+    args = {
+        "url": info.get("url"),
+        "sha256": info.get("sha256", ""),
+        "output": "executable/executable",
+    }
+    if info.get("is_compressed", False):
+        ctx.download_and_extract(**args)
+    else:
+        args["executable"] = True
+        ctx.download(**args)
+
+    build_contents = 'package(default_visibility = ["//visibility:public"])\n'
+    build_contents += 'exports_files(["executable"])\n'
+    ctx.file("executable/BUILD.bazel", build_contents)
+
+external_binary = repository_rule(
+    implementation = _external_binary_impl,
+    attrs = {
+        "darwin": attr.string_dict(),
+        "linux": attr.string_dict(),
+        "windows": attr.string_dict(),
+    },
+)
+
+def _validade_platform_info(platform, info):
+    if not "url" in info:
+        fail("missing attr 'url' in '{}'".format(platform))


### PR DESCRIPTION
## Description

Now that shellcheck publishes OS X binaries (not just Linux and Windows ones), it's easy to manage all the shellcheck binaries using Bazel.

## Test plan

Run `//dev/linters/shellcheck.sh` from a Linux, a Mac and a Windows machines.
