### PR TITLE
Add liveness & readiness probes

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/adapter.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/adapter.yaml
@@ -18,5 +18,9 @@
       healthcheck:
         adapter:
           readiness:
+            # The healthcheck port is bound to localhost only
             exec:
-              command: ['curl', '--fail', '--head', 'http://127.0.0.1:8080/health']
+              command: [curl, --fail, --head, --silent, http://localhost:8080/health]
+          liveness:
+            exec:
+              command: [pidof, adapter]

--- a/deploy/helm/scf/assets/operations/instance_groups/adapter.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/adapter.yaml
@@ -21,6 +21,3 @@
             # The healthcheck port is bound to localhost only
             exec:
               command: [curl, --fail, --head, --silent, http://localhost:8080/health]
-          liveness:
-            exec:
-              command: [pidof, adapter]

--- a/deploy/helm/scf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/api.yaml
@@ -193,20 +193,16 @@
                 printf "GET /healthz HTTP/1.0\r\n\r\n" |
                 nc -q 2 -U /var/vcap/data/cloud_controller_ng/cloud_controller.sock |
                 grep --silent "200 OK"
-            httpGet:
-              path: /healthz
-              port: 9022
           # We don't want a liveness probe here as we do migration here, and we
-          # do not want to interrupt that.
+          # do not want to interrupt that.  We may want to consider using a
+          # startupProbe in the future (once that feature stabilizes).
           liveness: ~
         local_worker_1:
           readiness: &cc_local_worker_readiness
             exec:
               command: [/usr/bin/pgrep, --full, cc_api_worker]
-          liveness: *cc_local_worker_readiness
         local_worker_2:
           readiness: *cc_local_worker_readiness
-          liveness: *cc_local_worker_readiness
         nginx:
           readiness:
             httpGet:
@@ -239,9 +235,6 @@
             # routing-api does not expose a health check endpoint
             tcpSocket:
               port: 3000
-          liveness:
-            exec:
-              command: [pidof, routing-api]
 
 # Add quarks properties for cc_uploader.
 - type: replace
@@ -262,9 +255,6 @@
             # socket.
             tcpSocket:
               port: 9091
-          liveness:
-            exec:
-              command: [pidof, cc-uploader]
 
 # Add quarks properties for file_server.
 - type: replace
@@ -281,23 +271,14 @@
             httpGet:
               path: /v1/static/file_server/bin/file-server
               port: *file-server-port
-          liveness:
-            exec:
-              command: [pidof, file-server]
 
 # Add quarks properties for statsd_injector.
 - type: replace
-  path: /instance_groups/name=api/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector
+  path: /instance_groups/name=api/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector/readiness/exec/command
   value:
-    readiness:
-      exec:
-        command:
-        - /bin/sh
-        - -c
-        - ss -nlu src localhost:8125 | grep :8125
-    liveness:
-      exec:
-        command: [pidof, statsd-injector]
+  - /bin/sh
+  - -c
+  - ss -nlu src localhost:8125 | grep :8125
 
 # Add quarks properties for policy-server.
 - type: replace
@@ -313,9 +294,6 @@
           readiness:
             httpGet:
               port: 4002
-          liveness:
-            exec:
-              command: [pidof, policy-server]
     post_start:
       condition:
         exec:
@@ -332,9 +310,6 @@
           readiness: &policy_server_internal_readiness
             httpGet:
               port: 31946
-          liveness:
-            exec:
-              command: [pidof, policy-server-internal]
     post_start:
       condition:
         exec:
@@ -344,22 +319,13 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
   value:
-    readiness: &route_registrar_readiness
+    readiness: ~
       # The route registrar doesn't expose anything to indicate if the
-      # routes are healthy; we can only detect that it's still running.
-      exec:
-        command: [pidof, route-registrar]
-    liveness: *route_registrar_readiness
+      # routes are healthy
 
 - type: replace
-  path: /instance_groups/name=api/jobs/name=loggr-udp-forwarder/properties/quarks?/run/healthcheck/loggr-udp-forwarder
-  value:
-    readiness:
-      exec:
-        command: [sh, -c, 'ss -nlu sport = 3457 | grep :3457']
-    liveness:
-      exec:
-        command: [pidof, udp-forwarder]
+  path: /instance_groups/name=api/jobs/name=loggr-udp-forwarder/properties/quarks?/run/healthcheck/loggr-udp-forwarder/readiness/exec/command
+  value: [sh, -c, ss -nlu sport = 3457 | grep :3457]
 
 {{- $root := . -}}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/api_*" }}

--- a/deploy/helm/scf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/api.yaml
@@ -185,17 +185,20 @@
               - bash /var/vcap/jobs/cloud_controller_ng/bin/ccng_monit_http_healthcheck
         cloud_controller_ng:
           readiness: &cloud_controller_ng_readiness
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - >
+                printf "GET /healthz HTTP/1.0\r\n\r\n" |
+                nc -q 2 -U /var/vcap/data/cloud_controller_ng/cloud_controller.sock |
+                grep --silent "200 OK"
             httpGet:
               path: /healthz
               port: 9022
           # We don't want a liveness probe here as we do migration here, and we
           # do not want to interrupt that.
-          #liveness:
-          #  exec:
-          #    command:
-          #    - /usr/bin/pgrep
-          #    - --full
-          #    - /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/bin/cloud_controller
+          liveness: ~
         local_worker_1:
           readiness: &cc_local_worker_readiness
             exec:

--- a/deploy/helm/scf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/api.yaml
@@ -170,12 +170,56 @@
       internal: 9024
     run:
       healthcheck:
+        ccng_monit_http_healthcheck:
+          readiness:
+            # This job exists just to healthcheck cloud_controller_ng; we're
+            # already doing that separately.
+            exec:
+              command: [/bin/true]
+          liveness:
+            exec:
+              command:
+              - /usr/bin/pgrep
+              - --full
+              - --exact
+              - bash /var/vcap/jobs/cloud_controller_ng/bin/ccng_monit_http_healthcheck
         cloud_controller_ng:
           readiness: &cloud_controller_ng_readiness
+            httpGet:
+              path: /healthz
+              port: 9022
+          # We don't want a liveness probe here as we do migration here, and we
+          # do not want to interrupt that.
+          #liveness:
+          #  exec:
+          #    command:
+          #    - /usr/bin/pgrep
+          #    - --full
+          #    - /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/bin/cloud_controller
+        local_worker_1:
+          readiness: &cc_local_worker_readiness
             exec:
-              command: [curl, --fail, --head, --silent, http://127.0.0.1:9022/healthz]
+              command: [/usr/bin/pgrep, --full, cc_api_worker]
+          liveness: *cc_local_worker_readiness
+        local_worker_2:
+          readiness: *cc_local_worker_readiness
+          liveness: *cc_local_worker_readiness
+        nginx:
+          readiness:
+            httpGet:
+              httpHeaders:
+              - name: Host
+                value: api
+              path: /healthz
+              port: 9024
+              scheme: HTTPS
+          liveness:
+            exec:
+              command: [/usr/bin/pgrep, --full, "nginx: master process"]
     post_start:
-      condition: *cloud_controller_ng_readiness
+      condition:
+        exec:
+          command: [curl, --fail, --head, --silent, http://127.0.0.1:9022/healthz]
 
 # Add quarks properties for routing-api.
 - type: replace
@@ -185,6 +229,16 @@
     - name: routing-api
       protocol: TCP
       internal: 3000
+    run:
+      healthcheck:
+        routing-api:
+          readiness:
+            # routing-api does not expose a health check endpoint
+            tcpSocket:
+              port: 3000
+          liveness:
+            exec:
+              command: [pidof, routing-api]
 
 # Add quarks properties for cc_uploader.
 - type: replace
@@ -197,6 +251,17 @@
     - name: https
       protocol: TCP
       internal: 9091
+    run:
+      healthcheck:
+        cc_uploader:
+          readiness:
+            # cc-uploader does not have a health check endpoint; just use a TCP
+            # socket.
+            tcpSocket:
+              port: 9091
+          liveness:
+            exec:
+              command: [pidof, cc-uploader]
 
 # Add quarks properties for file_server.
 - type: replace
@@ -210,18 +275,26 @@
       healthcheck:
         file_server:
           readiness:
-            tcpSocket:
+            httpGet:
+              path: /v1/static/file_server/bin/file-server
               port: *file-server-port
+          liveness:
+            exec:
+              command: [pidof, file-server]
 
 # Add quarks properties for statsd_injector.
 - type: replace
-  path: /instance_groups/name=api/jobs/name=statsd_injector/properties/quarks?
+  path: /instance_groups/name=api/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector
   value:
-    ports:
-    # TODO: Can we remove this port?
-    - name: statsd
-      protocol: TCP
-      internal: 8125
+    readiness:
+      exec:
+        command:
+        - /bin/sh
+        - -c
+        - ss -nlu src localhost:8125 | grep :8125
+    liveness:
+      exec:
+        command: [pidof, statsd-injector]
 
 # Add quarks properties for policy-server.
 - type: replace
@@ -234,14 +307,17 @@
     run:
       healthcheck:
         policy-server:
-          readiness: &policy_server_readiness
+          readiness:
+            httpGet:
+              port: 4002
+          liveness:
             exec:
-              command:
-              - sh
-              - -c
-              - ss -nlt | grep "LISTEN.*:4002"
+              command: [pidof, policy-server]
     post_start:
-      condition: *policy_server_readiness
+      condition:
+        exec:
+          # policy-server doesn't support HTTP HEAD requests
+          command: [curl, --fail, --silent, http://localhost:4002/]
 
 # Add quarks properties for policy-server-internal.
 - type: replace
@@ -249,16 +325,38 @@
   value:
     run:
       healthcheck:
-        policy-server:
+        policy-server-internal:
           readiness: &policy_server_internal_readiness
+            httpGet:
+              port: 31946
+          liveness:
             exec:
-              command:
-              - sh
-              - -c
-              # TODO: Use curl to call port 31946.
-              - ss -nlt | grep "LISTEN.*:4003"
+              command: [pidof, policy-server-internal]
     post_start:
-      condition: *policy_server_internal_readiness
+      condition:
+        exec:
+          # policy-server-internal doesn't support HTTP HEAD requests
+          command: [curl, --fail, --silent, http://localhost:31946/]
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
+  value:
+    readiness: &route_registrar_readiness
+      # The route registrar doesn't expose anything to indicate if the
+      # routes are healthy; we can only detect that it's still running.
+      exec:
+        command: [pidof, route-registrar]
+    liveness: *route_registrar_readiness
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=loggr-udp-forwarder/properties/quarks?/run/healthcheck/loggr-udp-forwarder
+  value:
+    readiness:
+      exec:
+        command: [sh, -c, 'ss -nlu sport = 3457 | grep :3457']
+    liveness:
+      exec:
+        command: [pidof, udp-forwarder]
 
 {{- $root := . -}}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/api_*" }}

--- a/deploy/helm/scf/assets/operations/instance_groups/cc-worker.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/cc-worker.yaml
@@ -42,4 +42,3 @@
     readiness: &cloud_controller_worker_readiness
       exec:
         command: [/usr/bin/pgrep, --full, cc-worker-cloud_controller_worker]
-    liveness: *cloud_controller_worker_readiness

--- a/deploy/helm/scf/assets/operations/instance_groups/cc-worker.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/cc-worker.yaml
@@ -35,3 +35,11 @@
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/credhub_api?/hostname
   value: {{ .Values.deployment_name }}-credhub
+# Add quarks properties for cloud_controller_worker
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/quarks?/run/healthcheck/worker_1
+  value:
+    readiness: &cloud_controller_worker_readiness
+      exec:
+        command: [/usr/bin/pgrep, --full, cc-worker-cloud_controller_worker]
+    liveness: *cloud_controller_worker_readiness

--- a/deploy/helm/scf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/database.yaml
@@ -96,6 +96,9 @@
               - --defaults-file=/var/vcap/jobs/mysql/config/mylogin.cnf
               - ping
           liveness:
+            # Check for mysql, as we go through a bunch of control scripts
+            # before the actual database server is run; ensure that all of that
+            # is succeeding and we actually have a DB.
             exec:
               command: [pidof, mysqld]
     bpm:

--- a/deploy/helm/scf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/database.yaml
@@ -95,6 +95,9 @@
               - /var/vcap/packages/mariadb/bin/mysqladmin
               - --defaults-file=/var/vcap/jobs/mysql/config/mylogin.cnf
               - ping
+          liveness:
+            exec:
+              command: [pidof, mysqld]
     bpm:
       processes:
       - name: mariadb_ctrl

--- a/deploy/helm/scf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/diego-api.yaml
@@ -60,9 +60,6 @@
               - --caCertFile=/var/vcap/jobs/locket/config/certs/ca.crt
               - --clientCertFile=/var/vcap/jobs/locket/config/certs/server.crt
               - --clientKeyFile=/var/vcap/jobs/locket/config/certs/server.key
-          liveness:
-            exec:
-              command: [pidof, locket]
 
 # Add quarks properties for bbs.
 - type: replace
@@ -78,9 +75,6 @@
           readiness:
             httpGet:
               port: 8890
-          liveness:
-            exec:
-              command: [pidof, bbs]
     post_start:
       condition:
         exec:

--- a/deploy/helm/scf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/diego-api.yaml
@@ -19,6 +19,9 @@
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/advertisement_base_hostname?
   value: {{ .Values.deployment_name }}-diego-api
 - type: replace
+  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/health_addr?
+  value: 0.0.0.0:8890
+- type: replace
   path: /instance_groups/name=diego-api/jobs/name=cfdot/properties/bbs?/hostname
   value: 127.0.0.1
 - type: replace
@@ -41,6 +44,25 @@
     - name: locket
       protocol: TCP
       internal: 8891
+    run:
+      healthcheck:
+        locket:
+          readiness:
+            exec:
+              command:
+              - /var/vcap/packages/cfdot/bin/cfdot
+              - locks
+              - --locketAPILocation=localhost:8891
+              # We need to both give --skipCertVerify and provide a CA cert;
+              # skipping the former ends up with context deadline exceeded, and
+              # skipping the latter errors out failing to read file ""
+              - --skipCertVerify
+              - --caCertFile=/var/vcap/jobs/locket/config/certs/ca.crt
+              - --clientCertFile=/var/vcap/jobs/locket/config/certs/server.crt
+              - --clientKeyFile=/var/vcap/jobs/locket/config/certs/server.key
+          liveness:
+            exec:
+              command: [pidof, locket]
 
 # Add quarks properties for bbs.
 - type: replace
@@ -53,14 +75,19 @@
     run:
       healthcheck:
         bbs:
-          readiness: &bbs_readiness
+          readiness:
+            httpGet:
+              port: 8890
+          liveness:
             exec:
-              command:
-              - sh
-              - -c
-              - ss -nlt | grep "LISTEN.*:8889"
+              command: [pidof, bbs]
     post_start:
-      condition: *bbs_readiness
+      condition:
+        exec:
+          command:
+          - sh
+          - -c
+          - ss -nlt sport = 8889 | grep "LISTEN.*:8889"
 
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=cfdot/properties/quarks?/bpm/processes

--- a/deploy/helm/scf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/diego-cell.yaml
@@ -57,11 +57,16 @@
     run:
       healthcheck:
         garden:
-          readiness: &garden_readiness
+          readiness:
             exec:
-              command: [sh, -c, 'ss -nlt | grep "LISTEN.*:17019"']
+              command: [curl, --head, --fail, --silent, http://127.0.0.1:17019/debug/vars]
+          liveness:
+            exec:
+              command: [pidof, gdn]
     post_start:
-      condition: *garden_readiness
+      condition:
+        exec:
+          command: [sh, -c, 'ss -nlt sport = 17019 | grep "LISTEN.*:17019"']
 
 # Add quarks properties for route_emitter.
 - type: replace
@@ -73,6 +78,9 @@
           readiness: &route_emitter_readiness
             exec:
               command: [curl, --fail, --silent, http://127.0.0.1:17011/ping]
+          liveness:
+            exec:
+              command: [pidof, route-emitter]
     post_start:
       condition: *route_emitter_readiness
 
@@ -81,9 +89,6 @@
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/quarks?
   value:
     ports:
-    - name: rep
-      protocol: TCP
-      internal: 1800
     - name: rep-tls
       protocol: TCP
       internal: 1801
@@ -94,11 +99,25 @@
           - SYS_ADMIN
       healthcheck:
         rep:
-          readiness: &rep_readiness
+          readiness:
             exec:
-              command: [sh, -c, 'ss -nlt | grep "LISTEN.*:1800"']
+              command:
+              - curl
+              - --head
+              - --fail
+              - --insecure
+              - --cert
+              - /var/vcap/jobs/rep/config/certs/tls.crt
+              - --key
+              - /var/vcap/jobs/rep/config/certs/tls.key
+              - https://127.0.0.1:1800/ping
+          liveness:
+            exec:
+              command: [pidof, rep]
     post_start:
-      condition: *rep_readiness
+      condition:
+        exec:
+          command: [sh, -c, 'ss -nlt sport = 1800 | grep "LISTEN.*:1800"']
 
 # Set the unconfined AppArmor profile for bpm-pre-start-rep in order to perform mounts.
 # This works in combination with CAP_SYS_ADMIN Linux capability.

--- a/deploy/helm/scf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/diego-cell.yaml
@@ -60,9 +60,6 @@
           readiness:
             exec:
               command: [curl, --head, --fail, --silent, http://127.0.0.1:17019/debug/vars]
-          liveness:
-            exec:
-              command: [pidof, gdn]
     post_start:
       condition:
         exec:
@@ -78,9 +75,6 @@
           readiness: &route_emitter_readiness
             exec:
               command: [curl, --fail, --silent, http://127.0.0.1:17011/ping]
-          liveness:
-            exec:
-              command: [pidof, route-emitter]
     post_start:
       condition: *route_emitter_readiness
 
@@ -111,9 +105,6 @@
               - --key
               - /var/vcap/jobs/rep/config/certs/tls.key
               - https://127.0.0.1:1800/ping
-          liveness:
-            exec:
-              command: [pidof, rep]
     post_start:
       condition:
         exec:

--- a/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
@@ -41,9 +41,6 @@
           readiness:
             exec:
               command: [curl, --fail, --head, --silent, http://localhost:14825/health]
-          liveness:
-            exec:
-              command: [pidof, doppler]
 
 # Add quarks properties for log-cache.
 - type: replace
@@ -63,9 +60,6 @@
             httpGet:
               port: 6060
               path: /debug/pprof/cmdline
-          liveness:
-            exec:
-              command: [pidof, log-cache]
 
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=log-cache-gateway/properties/quarks?/run/healthcheck/log-cache-gateway
@@ -75,9 +69,6 @@
       # and isn't easily configurable
       exec:
         command: [curl, --fail, --head, --silent, http://localhost:6063/debug/pprof/cmdline]
-    liveness:
-      exec:
-        command: [pidof, log-cache-gateway]
 
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=log-cache-nozzle/properties/quarks?/run/healthcheck/log-cache-nozzle
@@ -87,9 +78,6 @@
       # and isn't easily configurable
       exec:
         command: [curl, --fail, --head, --silent, http://localhost:6061/debug/pprof/cmdline]
-    liveness:
-      exec:
-        command: [pidof, log-cache-nozzle]
 
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/envs?
@@ -101,23 +89,15 @@
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/run/healthcheck/log-cache-expvar-forwarder
   value:
-    readiness:
-      # TODO: find a better readiness probe; currently we have nothing.
-      exec:
-        command: [/bin/true]
-    liveness:
-      exec:
-        command: [pidof, log-cache-expvar-forwarder]
+    readiness: ~
+      # We do not have a good thing to use as a readiness probe
 
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
   value:
-    readiness: &route_registrar_readiness
+    readiness: ~
       # The route registrar doesn't expose anything to indicate if the
-      # routes are healthy; we can only detect that it's still running.
-      exec:
-        command: [pidof, route-registrar]
-    liveness: *route_registrar_readiness
+      # routes are healthy
 
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/quarks?/run/healthcheck/log-cache-cf-auth-proxy
@@ -127,6 +107,3 @@
       # and isn't easily configurable
       exec:
         command: [curl, --fail, --head, --silent, http://localhost:6065/debug/pprof/cmdline]
-    liveness:
-      exec:
-        command: [pidof, log-cache-cf-auth-proxy]

--- a/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
@@ -35,8 +35,20 @@
     - name: log-cache-proxy # log-cache-cf-auth-proxy
       protocol: TCP
       internal: 8083
+    run:
+      healthcheck:
+        doppler:
+          readiness:
+            exec:
+              command: [curl, --fail, --head, --silent, http://localhost:14825/health]
+          liveness:
+            exec:
+              command: [pidof, doppler]
 
 # Add quarks properties for log-cache.
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache/properties/health_addr?
+  value: "::6060"
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=log-cache/properties/quarks?
   value:
@@ -44,7 +56,40 @@
     - name: log-cache
       protocol: TCP
       internal: 8080
+    run:
+      healthcheck:
+        log-cache:
+          readiness:
+            httpGet:
+              port: 6060
+              path: /debug/pprof/cmdline
+          liveness:
+            exec:
+              command: [pidof, log-cache]
 
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-gateway/properties/quarks?/run/healthcheck/log-cache-gateway
+  value:
+    readiness:
+      # Unfortunately, by default the health port listens on localhost only
+      # and isn't easily configurable
+      exec:
+        command: [curl, --fail, --head, --silent, http://localhost:6063/debug/pprof/cmdline]
+    liveness:
+      exec:
+        command: [pidof, log-cache-gateway]
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-nozzle/properties/quarks?/run/healthcheck/log-cache-nozzle
+  value:
+    readiness:
+      # Unfortunately, by default the health port listens on localhost only
+      # and isn't easily configurable
+      exec:
+        command: [curl, --fail, --head, --silent, http://localhost:6061/debug/pprof/cmdline]
+    liveness:
+      exec:
+        command: [pidof, log-cache-nozzle]
 
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/envs?
@@ -53,3 +98,35 @@
     value: {{ .Values.deployment_name }}-doppler:8080
   - name: INSTANCE_ID
     value: "0"
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/run/healthcheck/log-cache-expvar-forwarder
+  value:
+    readiness:
+      # TODO: find a better readiness probe; currently we have nothing.
+      exec:
+        command: [/bin/true]
+    liveness:
+      exec:
+        command: [pidof, log-cache-expvar-forwarder]
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
+  value:
+    readiness: &route_registrar_readiness
+      # The route registrar doesn't expose anything to indicate if the
+      # routes are healthy; we can only detect that it's still running.
+      exec:
+        command: [pidof, route-registrar]
+    liveness: *route_registrar_readiness
+
+- type: replace
+  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/quarks?/run/healthcheck/log-cache-cf-auth-proxy
+  value:
+    readiness:
+      # Unfortunately, by default the health port listens on localhost only
+      # and isn't easily configurable
+      exec:
+        command: [curl, --fail, --head, --silent, http://localhost:6065/debug/pprof/cmdline]
+    liveness:
+      exec:
+        command: [pidof, log-cache-cf-auth-proxy]

--- a/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
@@ -45,9 +45,6 @@
           readiness:
             exec:
               command: [curl, --fail, --silent, --head, http://localhost:14825/health]
-          liveness:
-            exec:
-              command: [pidof, trafficcontroller]
 
 # Add quarks properties for reverse_log_proxy.
 - type: replace
@@ -66,29 +63,17 @@
           readiness:
             exec:
               command: [curl, --fail, --silent, --head, http://localhost:14826/health]
-          liveness:
-            exec:
-              command: [pidof, rlp]
 
 - type: replace
   path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway/properties/quarks?/bpm/processes/name=reverse_log_proxy_gateway/env/PPROF_PORT?
   value: "33045"
 - type: replace
-  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway/properties/quarks?/run/healthcheck/reverse_log_proxy_gateway
-  value:
-    readiness:
-      exec:
-        command: [curl, --fail, --head, --silent, http://localhost:33045/debug/pprof/cmdline]
-    liveness:
-      exec:
-        command: [pidof, rlp-gateway]
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway/properties/quarks?/run/healthcheck/reverse_log_proxy_gateway/readiness/exec/command
+  value: [curl, --fail, --head, --silent, http://localhost:33045/debug/pprof/cmdline]
 
 - type: replace
   path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
   value:
-    readiness: &route_registrar_readiness
+    readiness: ~
       # The route registrar doesn't expose anything to indicate if the
-      # routes are healthy; we can only detect that it's still running.
-      exec:
-        command: [pidof, route-registrar]
-    liveness: *route_registrar_readiness
+      # routes are healthy

--- a/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/log-api.yaml
@@ -39,8 +39,20 @@
     - name: dropsonde
       protocol: TCP
       internal: 8081
+    run:
+      healthcheck:
+        loggregator_trafficcontroller:
+          readiness:
+            exec:
+              command: [curl, --fail, --silent, --head, http://localhost:14825/health]
+          liveness:
+            exec:
+              command: [pidof, trafficcontroller]
 
 # Add quarks properties for reverse_log_proxy.
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy/properties/reverse_log_proxy?/health_addr
+  value: "localhost:14826"
 - type: replace
   path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy/properties/quarks?
   value:
@@ -48,3 +60,35 @@
     - name: grpc-egress
       protocol: TCP
       internal: 8082
+    run:
+      healthcheck:
+        reverse_log_proxy:
+          readiness:
+            exec:
+              command: [curl, --fail, --silent, --head, http://localhost:14826/health]
+          liveness:
+            exec:
+              command: [pidof, rlp]
+
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway/properties/quarks?/bpm/processes/name=reverse_log_proxy_gateway/env/PPROF_PORT?
+  value: "33045"
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway/properties/quarks?/run/healthcheck/reverse_log_proxy_gateway
+  value:
+    readiness:
+      exec:
+        command: [curl, --fail, --head, --silent, http://localhost:33045/debug/pprof/cmdline]
+    liveness:
+      exec:
+        command: [pidof, rlp-gateway]
+
+- type: replace
+  path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
+  value:
+    readiness: &route_registrar_readiness
+      # The route registrar doesn't expose anything to indicate if the
+      # routes are healthy; we can only detect that it's still running.
+      exec:
+        command: [pidof, route-registrar]
+    liveness: *route_registrar_readiness

--- a/deploy/helm/scf/assets/operations/instance_groups/nats.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/nats.yaml
@@ -18,6 +18,3 @@
               - sh
               - -c
               - ss -nlt sport = 4222 | grep "LISTEN.*:4222" && ss -nlt sport = 4223 | grep "LISTEN.*:4223"
-          liveness:
-            exec:
-              command: [pidof, gnatsd]

--- a/deploy/helm/scf/assets/operations/instance_groups/nats.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/nats.yaml
@@ -14,4 +14,10 @@
         nats:
           readiness:
             exec:
-              command: ['sh', '-c', 'ss -nlt | grep "LISTEN.*:4222" && ss -nlt | grep "LISTEN.*:4223"']
+              command:
+              - sh
+              - -c
+              - ss -nlt sport = 4222 | grep "LISTEN.*:4222" && ss -nlt sport = 4223 | grep "LISTEN.*:4223"
+          liveness:
+            exec:
+              command: [pidof, gnatsd]

--- a/deploy/helm/scf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/router.yaml
@@ -32,9 +32,6 @@
             httpGet:
               port: 8080
               path: /health
-          liveness:
-            exec:
-              command: [pidof, gorouter]
     post_start:
       condition:
         exec:
@@ -46,9 +43,6 @@
     readiness:
       exec:
         command: [sh, -c, 'ss -nlu sport = 3457 | grep :3457']
-    liveness:
-      exec:
-        command: [pidof, udp-forwarder]
 
 # Add necessary labels to the router instance group so that the service can select it to create the
 # endpoint.

--- a/deploy/helm/scf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/router.yaml
@@ -28,11 +28,27 @@
     run:
       healthcheck:
         gorouter:
-          readiness: &gorouter_readiness
+          readiness:
+            httpGet:
+              port: 8080
+              path: /health
+          liveness:
             exec:
-              command: ['curl', '--fail', '--head', 'http://127.0.0.1:8080/health']
+              command: [pidof, gorouter]
     post_start:
-      condition: *gorouter_readiness
+      condition:
+        exec:
+          command: [curl, --fail, --head, http://127.0.0.1:8080/health]
+
+- type: replace
+  path: /instance_groups/name=router/jobs/name=loggr-udp-forwarder/properties/quarks?/run/healthcheck/loggr-udp-forwarder
+  value:
+    readiness:
+      exec:
+        command: [sh, -c, 'ss -nlu sport = 3457 | grep :3457']
+    liveness:
+      exec:
+        command: [pidof, udp-forwarder]
 
 # Add necessary labels to the router instance group so that the service can select it to create the
 # endpoint.

--- a/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
@@ -84,14 +84,14 @@
 
 # Add quarks properties for the scheduler job.
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/quarks?
+  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/quarks?/run/healthcheck/scheduler
   value:
-    run:
-      healthcheck:
-        scheduler:
-          readiness:
-            exec:
-              command: ['curl', '--fail', '--head', 'http://127.0.0.1:8080/health']
+    readiness:
+      exec:
+        command: [curl, --fail, --head, --silent, http://127.0.0.1:8080/health]
+    liveness:
+      exec:
+        command: [pidof, scheduler]
 
 # Add quarks properties for the auctioneer job.
 - type: replace
@@ -105,10 +105,63 @@
       healthcheck:
         auctioneer:
           readiness:
+            # There is no health check, just depend on the port being open
+            tcpSocket:
+              port: 9016
+          liveness:
             exec:
-              command: ['curl', '--fail', '--head', 'http://127.0.0.1:8080/health']
+              command: [pidof, auctioneer]
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/quarks?/run/healthcheck/cloud_controller_clock
+  value:
+    readiness: &cc_clock_readiness
+      # There is no good readiness check for the scheduled tasks
+      exec:
+        command: [pgrep, --full, clock:start]
+    liveness: *cc_clock_readiness
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/quarks?/run/healthcheck/cc_deployment_updater
+  value:
+    readiness:
+      exec:
+        command:
+        # We should sleep about once every 5 seconds; check that the last entry was no more than 2 cycles ago
+        - sh
+        - -c
+        - tac /var/vcap/sys/log/cc_deployment_updater/cc_deployment_updater.log | grep --max-count=1 Sleeping | jq -r '(now - .timestamp) < 10'
+    liveness:
+      exec:
+        command: [pgrep, --full, deployment_updater:start]
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector
+  value:
+    readiness:
+      exec:
+        command:
+        - /bin/sh
+        - -c
+        - ss -nlu src localhost:8125 | grep :8125
+    liveness:
+      exec:
+        command: [pidof, statsd-injector]
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=tps/properties/quarks?/run/healthcheck/watcher
+  value:
+    readiness:
+      exec:
+        command: [curl, --fail, --silent, http://127.0.0.1:17015/debug/pprof/cmdline]
+    liveness:
+      exec:
+        command: [pidof, tps-watcher]
 
 # Add quarks properties for the ssh_proxy job.
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/diego/ssh_proxy/disable_healthcheck_server
+  value: false
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/quarks?
   value:
@@ -116,6 +169,25 @@
     - name: ssh-proxy
       protocol: TCP
       internal: 2222
+    run:
+      healthcheck:
+        ssh_proxy:
+          readiness:
+            httpGet:
+              port: 2223
+          liveness:
+            exec:
+              command: [pidof, ssh-proxy]
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=log-cache-scheduler/properties?/quarks/run/healthcheck/log-cache-scheduler
+  value:
+    readiness:
+      exec:
+        command: [curl, --fail, --silent, http://localhost:6064/debug/pprof/cmdline]
+    liveness:
+      exec:
+        command: [pidof, log-cache-scheduler]
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cfdot/properties/quarks?/bpm/processes
@@ -128,6 +200,17 @@
     value: {{ .Values.deployment_name }}-scheduler:8080
   - name: INSTANCE_ID
     value: "0"
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/run/healthcheck/log-cache-expvar-forwarder
+  value:
+    readiness:
+      # TODO: find a better readiness probe; currently we have nothing.
+      exec:
+        command: [/bin/true]
+    liveness:
+      exec:
+        command: [pidof, log-cache-expvar-forwarder]
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/provides?

--- a/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
@@ -89,9 +89,6 @@
     readiness:
       exec:
         command: [curl, --fail, --head, --silent, http://127.0.0.1:8080/health]
-    liveness:
-      exec:
-        command: [pidof, scheduler]
 
 # Add quarks properties for the auctioneer job.
 - type: replace
@@ -108,18 +105,14 @@
             # There is no health check, just depend on the port being open
             tcpSocket:
               port: 9016
-          liveness:
-            exec:
-              command: [pidof, auctioneer]
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/quarks?/run/healthcheck/cloud_controller_clock
   value:
-    readiness: &cc_clock_readiness
+    readiness:
       # There is no good readiness check for the scheduled tasks
       exec:
         command: [pgrep, --full, clock:start]
-    liveness: *cc_clock_readiness
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/quarks?/run/healthcheck/cc_deployment_updater
@@ -136,27 +129,12 @@
         command: [pgrep, --full, deployment_updater:start]
 
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector
-  value:
-    readiness:
-      exec:
-        command:
-        - /bin/sh
-        - -c
-        - ss -nlu src localhost:8125 | grep :8125
-    liveness:
-      exec:
-        command: [pidof, statsd-injector]
+  path: /instance_groups/name=scheduler/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector/readiness/exec/command
+  value: [/bin/sh, -c, ss -nlu src localhost:8125 | grep :8125]
 
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=tps/properties/quarks?/run/healthcheck/watcher
-  value:
-    readiness:
-      exec:
-        command: [curl, --fail, --silent, http://127.0.0.1:17015/debug/pprof/cmdline]
-    liveness:
-      exec:
-        command: [pidof, tps-watcher]
+  path: /instance_groups/name=scheduler/jobs/name=tps/properties/quarks?/run/healthcheck/watcher/readiness/exec/command
+  value: [curl, --fail, --silent, http://127.0.0.1:17015/debug/pprof/cmdline]
 
 # Add quarks properties for the ssh_proxy job.
 - type: replace
@@ -175,19 +153,10 @@
           readiness:
             httpGet:
               port: 2223
-          liveness:
-            exec:
-              command: [pidof, ssh-proxy]
 
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=log-cache-scheduler/properties?/quarks/run/healthcheck/log-cache-scheduler
-  value:
-    readiness:
-      exec:
-        command: [curl, --fail, --silent, http://localhost:6064/debug/pprof/cmdline]
-    liveness:
-      exec:
-        command: [pidof, log-cache-scheduler]
+  path: /instance_groups/name=scheduler/jobs/name=log-cache-scheduler/properties?/quarks/run/healthcheck/log-cache-scheduler/readiness/exec/command
+  value: [curl, --fail, --silent, http://localhost:6064/debug/pprof/cmdline]
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cfdot/properties/quarks?/bpm/processes
@@ -204,13 +173,8 @@
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/run/healthcheck/log-cache-expvar-forwarder
   value:
-    readiness:
-      # TODO: find a better readiness probe; currently we have nothing.
-      exec:
-        command: [/bin/true]
-    liveness:
-      exec:
-        command: [pidof, log-cache-expvar-forwarder]
+    readiness: ~
+      # We do not have a good thing to use as a readiness probe
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/provides?

--- a/deploy/helm/scf/assets/operations/instance_groups/singleton-blobstore.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/singleton-blobstore.yaml
@@ -45,19 +45,13 @@
           readiness:
             exec:
               command: [test, -S, /var/vcap/data/blobstore/signer.sock]
-          liveness:
-            exec:
-              command: [pidof, blobstore_url_signer]
 
 - type: replace
   path: /instance_groups/name=singleton-blobstore/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
   value:
-    readiness: &route_registrar_readiness
+    readiness: ~
       # The route registrar doesn't expose anything to indicate if the
-      # routes are healthy; we can only detect that it's still running.
-      exec:
-        command: [pidof, route-registrar]
-    liveness: *route_registrar_readiness
+      # routes are healthy.
 
 {{- $root := . -}}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/singleton-blobstore_*" }}

--- a/deploy/helm/scf/assets/operations/instance_groups/singleton-blobstore.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/singleton-blobstore.yaml
@@ -34,11 +34,30 @@
       security_context:
         runAsUser: 1000 # vcap
       healthcheck:
-        nginx: &nginx_healthcheck
+        nginx:
+          readiness:
+            tcpSocket:
+              port: 8080
+          liveness:
+            exec:
+              command: [pgrep, --full, 'nginx: master process']
+        url_signer:
           readiness:
             exec:
-              command: ['sh', '-c', 'ss -nlt | grep "LISTEN.*:8080" && ss -nlt | grep "LISTEN.*:4443"']
-        url_signer: *nginx_healthcheck
+              command: [test, -S, /var/vcap/data/blobstore/signer.sock]
+          liveness:
+            exec:
+              command: [pidof, blobstore_url_signer]
+
+- type: replace
+  path: /instance_groups/name=singleton-blobstore/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
+  value:
+    readiness: &route_registrar_readiness
+      # The route registrar doesn't expose anything to indicate if the
+      # routes are healthy; we can only detect that it's still running.
+      exec:
+        command: [pidof, route-registrar]
+    liveness: *route_registrar_readiness
 
 {{- $root := . -}}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/singleton-blobstore_*" }}

--- a/deploy/helm/scf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/uaa.yaml
@@ -33,11 +33,37 @@
     run:
       healthcheck:
         uaa:
+          # UAA has a long period of cert import, so we can't set up a liveness
+          # check without killing it accidentally.
           readiness: &uaa_readiness
             exec:
               command: ['sh', '-c', '/var/vcap/jobs/uaa/bin/health_check']
     post_start:
       condition: *uaa_readiness
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
+  value:
+    readiness: &route_registrar_readiness
+      # The route registrar doesn't expose anything to indicate if the
+      # routes are healthy; we can only detect that it's still running.
+      exec:
+        command: [pidof, route-registrar]
+    liveness: *route_registrar_readiness
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector
+  value:
+    readiness:
+      exec:
+        command:
+        - /bin/sh
+        - -c
+        - ss -nlu src localhost:8125 | grep :8125
+    liveness:
+      exec:
+        command: [pidof, statsd-injector]
+
 
 {{- $root := . -}}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/uaa_*" }}

--- a/deploy/helm/scf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/uaa.yaml
@@ -44,25 +44,13 @@
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
   value:
-    readiness: &route_registrar_readiness
+    readiness: ~
       # The route registrar doesn't expose anything to indicate if the
-      # routes are healthy; we can only detect that it's still running.
-      exec:
-        command: [pidof, route-registrar]
-    liveness: *route_registrar_readiness
+      # routes are healthy.
 
 - type: replace
-  path: /instance_groups/name=uaa/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector
-  value:
-    readiness:
-      exec:
-        command:
-        - /bin/sh
-        - -c
-        - ss -nlu src localhost:8125 | grep :8125
-    liveness:
-      exec:
-        command: [pidof, statsd-injector]
+  path: /instance_groups/name=uaa/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector/readiness/exec/command
+  value: [/bin/sh, -c, ss -nlu src localhost:8125 | grep :8125]
 
 
 {{- $root := . -}}


### PR DESCRIPTION
## Description

This series of commits adds liveness and readiness probes for most jobs (I didn't touch the addons yet).

In general, the liveness probes are mostly checking that the correct process is running.  The readiness probes check for a health endpoint where available; some of them check `ppro` or `expvar` output, which isn't exactly correct but at least checks that something responds.  Unfortunately most processes do not have truly useful health check endpoints.

Notably, UAA & CCNG do not have liveness probes set, as they both have a long bootstrap step (cert import and db migration / seeding, respectively) that is run under a different executable.  We may be able to get away with moving those into pre-start steps, but that would have to be separate PRs. (And IIRC, we did do so for CCNG, but it wasn't an often-used configuration by upstream.)

## Test plan

- Deploy SCF
- Manually check that each pod has ~4 processes without liveness / readiness probes (because those are from the loggregator agent addon).
