### PR TITLE
v3 - Allowed custom ops-files to be referenced as configmaps

### DIFF
--- a/deploy/helm/scf/templates/bosh_deployment.yaml
+++ b/deploy/helm/scf/templates/bosh_deployment.yaml
@@ -43,3 +43,7 @@ spec:
   - name: ops-remove-diego
     type: configmap
 {{- end }}
+{{- range $_, $ops := .Values.operations.custom }}
+  - name: {{ $ops | quote }}
+    type: configmap
+{{- end }}

--- a/deploy/helm/scf/values.yaml
+++ b/deploy/helm/scf/values.yaml
@@ -24,6 +24,10 @@ features:
   # published to docker.io.
   suse_buildpacks: false
 
+operations:
+  # A list of configmap names that should be applied to the BOSH manifest.
+  custom: []
+
 k8s-host-url: ""
 k8s-service-token: ""
 k8s-service-username: ""


### PR DESCRIPTION
## Description

Given an existing ops-file as configmap in the namespace, this allows it
to be referenced in the BOSH deployment custom resource through the
operations.custom Helm value.

Resolves #2815.

## Test plan

Create a random ops-file as a configmap in the SCF namespace:

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: <configmap_name>
data:
  ops: |-
    <some_random_ops>
```

When deploying SCF, add to the values:

```yaml
operations:
  custom:
  - <configmap_name>
```

Then assert that the ops-file was applied.