### PR TITLE
bin/common: bump fissile version

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+348.gc8fb3864"
+export FISSILE_VERSION="7.0.0+352.g17b53d96"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"


### PR DESCRIPTION
This picks up cloudfoundry-incubator/fissile#515 to add support for Kubernetes 1.16