### PR TITLE
Added support for external database server for CCDB &c.

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -286,7 +286,6 @@ properties:
     - name: ccdb
       tag: cc
     db_scheme: mysql
-    port: 3306
   cf-usb:
     broker:
       username: broker-admin

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -430,6 +430,7 @@ instance_groups:
         run:
           privileged: true
 - name: mysql
+  default_feature: mysql
   scripts:
   - scripts/create_mysql_data_tmp.sh # Deprecated. Should go away with cf-mysql-release.
   - scripts/chown_vcap_store.sh
@@ -525,7 +526,7 @@ instance_groups:
       properties.engine_config.binlog.enabled: false
       properties.engine_config.galera.enabled: true
       properties.monit_startup_timeout: 300
-      properties.seeded_databases: >
+      properties.seeded_databases: &seeded_databases >
         [
           {"name":"ccdb","username":"ccadmin","password":"((MYSQL_CCDB_ROLE_PASSWORD))"},
           {"name":"diego","username":"diego","password":"((MYSQL_DIEGO_PASSWORD))"},
@@ -543,6 +544,7 @@ instance_groups:
       properties.tls.server.certificate: ((MYSQL_SERVER_CERT))
       properties.tls.server.private_key: ((MYSQL_SERVER_CERT_KEY))
 - name: mysql-proxy
+  default_feature: mysql
   scripts:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
@@ -917,7 +919,7 @@ instance_groups:
           privileged: true
   configuration:
     templates:
-      properties.dns_health_check_host: 'mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)).'
+      properties.dns_health_check_host: 'nats-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)).'
 - name: routing-api
   environment_scripts:
   - scripts/go_log_level.sh
@@ -974,7 +976,7 @@ instance_groups:
   - sequential-startup
   configuration:
     templates:
-      properties.dns_health_check_host: 'mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)).'
+      properties.dns_health_check_host: 'nats-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)).'
 - name: api-group
   environment_scripts:
   - scripts/configure-HA-hosts.sh
@@ -2103,9 +2105,18 @@ instance_groups:
           "uaa.((KUBERNETES_NAMESPACE)).svc",
           "uaa.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"
         ]
+      properties.uaadb.address: &cf-internal-database-host >
+        ((#DB_EXTERNAL_HOST))
+          ((DB_EXTERNAL_HOST))
+        ((/DB_EXTERNAL_HOST))
+        ((^DB_EXTERNAL_HOST))
+          mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
+        ((/DB_EXTERNAL_HOST))
+      properties.uaadb.port: &cf-internal-database-port >
+        ((#DB_EXTERNAL_HOST))((DB_EXTERNAL_PORT))((/DB_EXTERNAL_HOST))((^DB_EXTERNAL_HOST))3306((/DB_EXTERNAL_HOST))
       properties.uaadb.roles: '[{"name": "uaaadmin", "password": "((UAADB_PASSWORD))", "tag": "admin"}]'
-      properties.wait-for-database.hostname: mysql-set
-      properties.wait-for-database.port: 3306
+      properties.wait-for-database.hostname: *cf-internal-database-host
+      properties.wait-for-database.port: *cf-internal-database-port
 - name: secret-generation
   type: bosh-task
   jobs:
@@ -2158,6 +2169,8 @@ instance_groups:
     release: scf-helper
   - name: authorize-internal-ca # needs to be second as it is a dependency of other jobs.
     release: scf
+  - name: database-seeder
+    release: scf-helper
   - name: uaa-create-user
     release: scf
   - name: configure-scf
@@ -2171,6 +2184,15 @@ instance_groups:
           flight-stage: post-flight
           memory: 256
           virtual-cpus: 1
+  configuration:
+    templates:
+      properties.database-seeder.driver: ((#DB_EXTERNAL_HOST))((DB_EXTERNAL_DRIVER))((/DB_EXTERNAL_HOST))
+      properties.database-seeder.host: ((DB_EXTERNAL_HOST))
+      properties.database-seeder.password: ((DB_EXTERNAL_PASSWORD))
+      properties.database-seeder.port: ((DB_EXTERNAL_PORT))
+      properties.database-seeder.sslmode: ((DB_EXTERNAL_SSL_MODE))
+      properties.database-seeder.username: ((DB_EXTERNAL_USER))
+      properties.seeded_databases: *seeded_databases
 - name: credhub-user
   if_feature: credhub
   environment_scripts:
@@ -2219,9 +2241,9 @@ instance_groups:
       properties.credhub.authentication.uaa.url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
       properties.credhub.authorization.acls.enabled: false
       properties.credhub.data_storage.database: "credhub_user"
-      properties.credhub.data_storage.host: mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
+      properties.credhub.data_storage.host: *cf-internal-database-host
       properties.credhub.data_storage.password: ((MYSQL_CREDHUB_USER_PASSWORD))
-      properties.credhub.data_storage.port: 3306
+      properties.credhub.data_storage.port: *cf-internal-database-port
       properties.credhub.data_storage.require_tls: false
       properties.credhub.data_storage.tls_ca: ((INTERNAL_CA_CERT))
       properties.credhub.data_storage.type: "mysql"
@@ -2864,7 +2886,8 @@ configuration:
     properties.cc.staging_timeout_in_seconds: ((STAGING_TIMEOUT))
     properties.cc.staging_upload_password: '"((STAGING_UPLOAD_PASSWORD))"'
     properties.cc.uaa.internal_url: ((KUBERNETES_NAMESPACE)).((UAA_HOST))
-    properties.ccdb.address: mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
+    properties.ccdb.address: *cf-internal-database-host
+    properties.ccdb.port: *cf-internal-database-port
     properties.ccdb.roles: '[{"name": "ccadmin", "password": "((MYSQL_CCDB_ROLE_PASSWORD))", "tag": "admin"}]'
     properties.cf-sle12.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))((#ROOTFS_TRUSTED_CERTS))\n((/ROOTFS_TRUSTED_CERTS))((INTERNAL_CA_CERT))"'
     properties.cf-usb.broker.external_url: '"https://cf-usb.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):24054"'
@@ -2872,7 +2895,7 @@ configuration:
     properties.cf-usb.broker.server_cert: '"((CF_USB_BROKER_SERVER_CERT))"'
     properties.cf-usb.broker.server_key: '"((CF_USB_BROKER_SERVER_CERT_KEY))"'
     properties.cf-usb.management.uaa.secret: '"((UAA_CLIENTS_CF_USB_SECRET))"'
-    properties.cf-usb.mysql_address: 'mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))'
+    properties.cf-usb.mysql_address: *cf-internal-database-host
     properties.cf-usb.mysql_password: "((MYSQL_CF_USB_PASSWORD))"
     properties.cf.insecure_api_url: http://api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):9022 # For post-deployment-setup, because cf cli has no client certs.
     properties.cflinuxfs3-rootfs.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))((#ROOTFS_TRUSTED_CERTS))\n((/ROOTFS_TRUSTED_CERTS))((INTERNAL_CA_CERT))"'
@@ -2906,13 +2929,13 @@ configuration:
     properties.diego.bbs.server_cert: '"((BBS_SERVER_CRT))"'
     properties.diego.bbs.server_key: '"((BBS_SERVER_CRT_KEY))"'
     properties.diego.bbs.sql.ca_cert: ((INTERNAL_CA_CERT))
-    properties.diego.bbs.sql.db_host: mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
+    properties.diego.bbs.sql.db_host: *cf-internal-database-host
     properties.diego.bbs.sql.db_password: ((MYSQL_DIEGO_PASSWORD))
     properties.diego.executor.disk_capacity_mb: ((DIEGO_CELL_DISK_CAPACITY_MB))
     properties.diego.executor.memory_capacity_mb: ((DIEGO_CELL_MEMORY_CAPACITY_MB))
     properties.diego.file_server.log_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
     properties.diego.locket.log_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
-    properties.diego.locket.sql.db_host: '"mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"'
+    properties.diego.locket.sql.db_host: *cf-internal-database-host
     properties.diego.locket.sql.db_password: '"((MYSQL_DIEGO_LOCKET_PASSWORD))"'
     properties.diego.rep.bbs.api_location: diego-api-bbs.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8889
     properties.diego.rep.cell_id: ((HOSTNAME))
@@ -3007,7 +3030,7 @@ configuration:
     properties.nats.machines: ((KUBE_NATS_CLUSTER_IPS))((#KUBE_SIZING_NATS_COUNT))((/KUBE_SIZING_NATS_COUNT))
     properties.nats.password: '"((NATS_PASSWORD))"'
     properties.nfsbroker.allowed_options: '"((PERSI_NFS_ALLOWED_OPTIONS))"'
-    properties.nfsbroker.db_hostname: 'mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))'
+    properties.nfsbroker.db_hostname: *cf-internal-database-host
     properties.nfsbroker.db_password: '"((MYSQL_PERSI_NFS_PASSWORD))"'
     properties.nfsbroker.default_options: '"((PERSI_NFS_DEFAULT_OPTIONS))"'
     properties.nfsbroker.password: '"((PERSI_NFS_BROKER_PASSWORD))"'
@@ -3055,7 +3078,7 @@ configuration:
     properties.router.balancing_algorithm: '"((ROUTER_BALANCING_ALGORITHM))"'
     properties.router.client_cert_validation: '"((ROUTER_CLIENT_CERT_VALIDATION))"'
     # We use mysql because it comes up without any other dependencies and its critical for the cluster
-    properties.router.dns_health_check_host: 'mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)).'
+    properties.router.dns_health_check_host: 'nats-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)).'
     properties.router.force_forwarded_proto_https: ((FORCE_FORWARDED_PROTO_AS_HTTPS))
     properties.router.forwarded_client_cert: "((ROUTER_FORWARDED_CLIENT_CERT))"
     properties.router.logging_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
@@ -3069,7 +3092,7 @@ configuration:
     properties.routing_api.log_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
     properties.routing_api.port: 3000((#KUBERNETES_NAMESPACE))((/KUBERNETES_NAMESPACE))
     properties.routing_api.router_groups: '[{"name":"default-tcp", "type":"tcp", "reservable_ports":"((KUBE_SIZING_TCP_ROUTER_PORTS_TCP_ROUTE_MIN))-((KUBE_SIZING_TCP_ROUTER_PORTS_TCP_ROUTE_MAX))"}]'
-    properties.routing_api.sqldb.host: "mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"
+    properties.routing_api.sqldb.host: *cf-internal-database-host
     properties.routing_api.sqldb.password: "((MYSQL_ROUTING_API_PASSWORD))"
     properties.routing_api.system_domain: '"((DOMAIN))"'
     properties.routing_api.uri: '"http://routing-api-routing-api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"'
@@ -3646,6 +3669,49 @@ variables:
     description: Key for encrypting sensitive values in the Cloud Controller database.
     required: true
   type: password
+- name: DB_EXTERNAL_DRIVER
+  options:
+    immutable: true
+    description: >
+      Database driver to use for the external database server used to manage the
+      CF-internal databases.  Only used if DB_EXTERNAL_HOST is set.  Currently
+      only `mysql` is valid.
+    default: mysql
+- name: DB_EXTERNAL_HOST
+  options:
+    immutable: true
+    description: >
+      Hostname for an external database server to use for the CF-internal databases
+      (such as for the cloud controller database).  If not set, the internal database
+      is used.
+    default: null
+- name: DB_EXTERNAL_PASSWORD
+  options:
+    immutable: true
+    description: >
+      Administrator password for an external database server; this is required
+      to create the necessary databases.  Only used if DB_EXTERNAL_HOST is set.
+    secret: true
+- name: DB_EXTERNAL_PORT
+  options:
+    immutable: true
+    description: >
+      Port for an external database server to use for the CF-internal databases.
+      Only used if DB_EXTERNAL_HOST is set.
+    default: "3306"
+- name: DB_EXTERNAL_SSL_MODE
+  options:
+    immutable: true
+    description: >
+      TLS configuration for the external database server to use for the
+      CF-internal databases.  Only used if DB_EXTERNAL_HOST is set.  Valid
+      values depend on which database driver is in use.
+- name: DB_EXTERNAL_USER
+  options:
+    immutable: true
+    description: >
+      Administrator user name for an external database server; this is required
+      to create the necessary databases.  Only used if DB_EXTERNAL_HOST is set.
 - name: DEFAULT_APP_DISK_IN_MB
   options:
     default: 1024

--- a/src/scf-release/packages/sql-readiness/packaging
+++ b/src/scf-release/packages/sql-readiness/packaging
@@ -7,7 +7,6 @@ export PATH="${PATH}:${GOROOT}/bin:/var/vcap/packages/git/bin"
 export GOBIN="${BOSH_INSTALL_TARGET}/bin"
 
 mkdir -p "${GOBIN}"
-ls -l $PWD acceptance-tests-brain acceptance-tests-brain/sql-readiness
 export GO111MODULE=on
 cd acceptance-tests-brain/sql-readiness
 go install -mod=vendor


### PR DESCRIPTION
## Description

Ticket: https://jira.suse.com/browse/CAP-711

Subordinate pull requests:
  - https://github.com/SUSE/uaa-fissile-release/pull/171 (included here as submodule)
  - https://github.com/SUSE/scf-helper-release/pull/26 (See test description for integration for testing. After testing, __before merge__ :warning:, an update to the role manifests of UAA and SCF is required.)

:warning: This PR moots https://github.com/SUSE/scf/pull/2741 :warning:

This adds the option to use an external database server for the
CF-internal databases (CCDB, CF-USB, etc.), and UAA. This lets
administrators handle their own database backups if necessary.

A new job (found in the scf-helper-release) is used to initialize the
databases, using the same configuration that the mysql-release uses in
mariadb_ctrl.  The user must supply the external database host, port,
and credentials.

Currently this only supports MySQL/MariaDB databases.

Since the expression to calculate the correct internal database host,
port, etc.  is a bit complex, YAML anchors are used to avoid repeating
ourselves.

A feature guard is added to the internal database (proxy) roles,
enabling the user to manually disable them when using an external
database.

Note: The various routing roles (tcp-router, router, routing-api) used
the internal mysql service for the DNS health checks. This has been
changed to use the nats servicve instead, given that the mysql pods
can now be disabled by a feature flag (see previous paragraph).

## Motivation and Context

See above

## How Has This Been Tested?

Description will be in the ticket.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
