### PR TITLE
v3 - Added mechanism for allowing user provided job properties

### DIFF
--- a/deploy/helm/scf/templates/_helpers.tpl
+++ b/deploy/helm/scf/templates/_helpers.tpl
@@ -55,3 +55,25 @@ Get the metadata name for an ops file.
 {{- range $key := $keys }}{{ $obj = index $obj $key }}{{ end }}
 {{- $obj | quote }}
 {{- end }}
+
+{{/*
+Flatten the `toFlatten` map into `flattened`. The `flattened` map contains only one layer of keys
+flattened and separated by `separator`.
+*/}}
+{{- define "scf.flatten" -}}
+  {{- $flattened := index . "flattened" }}
+  {{- $toFlatten := index . "toFlatten" }}
+  {{- $separator := hasKey . "separator" | ternary (index . "separator") "/" }}
+  {{- $_prefix := hasKey . "_prefix" | ternary (index . "_prefix") "" }}
+
+  {{- if (kindIs "map" $toFlatten) }}
+    {{- range $key, $value := $toFlatten }}
+      {{- $newPrefix := printf "%s%s%s" $_prefix $separator $key }}
+      {{- include "scf.flatten" (dict "flattened" $flattened "toFlatten" $value "_prefix" $newPrefix "separator" $separator) }}
+    {{- end }}
+  {{- else }}
+    {{- $key := $_prefix }}
+    {{- $value := $toFlatten }}
+    {{- $_ := set $flattened $key $value }}
+  {{- end }}
+{{- end -}}

--- a/deploy/helm/scf/templates/bosh_deployment.yaml
+++ b/deploy/helm/scf/templates/bosh_deployment.yaml
@@ -47,3 +47,5 @@ spec:
   - name: {{ $ops | quote }}
     type: configmap
 {{- end }}
+  - name: user-provided-properties
+    type: configmap

--- a/deploy/helm/scf/templates/properties.yaml
+++ b/deploy/helm/scf/templates/properties.yaml
@@ -14,11 +14,13 @@ metadata:
 data:
   ops: |-
     {{- range $instanceGroupName, $instanceGroup := .Values.properties }}
-    {{- range $jobName, $properties := $instanceGroup }}
-    {{- range $propertyKey, $propertyValue := $properties }}
+      {{- range $jobName, $properties := $instanceGroup }}
+        {{- $flattened := dict }}
+        {{- include "scf.flatten" (dict "flattened" $flattened "toFlatten" $properties) }}
+        {{- range $propertyPath, $value := $flattened }}
     - type: replace
-      path: /instance_groups/name={{ $instanceGroupName }}/jobs/name={{ $jobName }}/properties?/{{ $propertyKey | replace "." "/" }}
-      value: {{ $propertyValue | toJson }}
-    {{- end }}
-    {{- end }}
+      path: /instance_groups/name={{ $instanceGroupName }}/jobs/name={{ $jobName }}/properties?{{ $propertyPath }}
+      value: {{ $value | toJson }}
+        {{- end }}
+      {{- end }}
     {{- end }}

--- a/deploy/helm/scf/templates/properties.yaml
+++ b/deploy/helm/scf/templates/properties.yaml
@@ -1,0 +1,24 @@
+# This ConfigMap creates an ops-file containing the user provided properties.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-provided-properties
+  labels:
+    app.kubernetes.io/component: operations
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "scf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "scf.chart" . }}
+data:
+  ops: |-
+    {{- range $instanceGroupName, $instanceGroup := .Values.properties }}
+    {{- range $jobName, $properties := $instanceGroup }}
+    {{- range $propertyKey, $propertyValue := $properties }}
+    - type: replace
+      path: /instance_groups/name={{ $instanceGroupName }}/jobs/name={{ $jobName }}/properties?/{{ $propertyKey | replace "." "/" }}
+      value: {{ $propertyValue | toJson }}
+    {{- end }}
+    {{- end }}
+    {{- end }}

--- a/deploy/helm/scf/values.yaml
+++ b/deploy/helm/scf/values.yaml
@@ -3,10 +3,13 @@ deployment_name: scf
 
 # Set or override job properties. The first level of the map is the instance group name. The second
 # level of the map is the job name. E.g.:
-#   properties:
-#     adapter:
-#       adapter:
-#         scalablesyslog.adapter.logs.addr: scf-log-api:8082
+#  properties:
+#    adapter:
+#      adapter:
+#        scalablesyslog:
+#          adapter:
+#            logs:
+#              addr: scf-log-api:8082
 properties: {}
 
 releases:

--- a/deploy/helm/scf/values.yaml
+++ b/deploy/helm/scf/values.yaml
@@ -1,6 +1,14 @@
 system_domain: ~
 deployment_name: scf
 
+# Set or override job properties. The first level of the map is the instance group name. The second
+# level of the map is the job name. E.g.:
+#   properties:
+#     adapter:
+#       adapter:
+#         scalablesyslog.adapter.logs.addr: scf-log-api:8082
+properties: {}
+
 releases:
   # The defaults for all releases, where we do not otherwise override them.
   defaults:


### PR DESCRIPTION
## Description

Adding a mechanism that allows a user to provide job properties via Helm values.

Resolves #2766 

## Test plan

Set some properties and assert they took effect. E.g. add the following to `values.yaml`:

```yaml
properties:
  adapter:
    adapter:
      quarks:
        ports:
        - name: adapter
          protocol: TCP
          internal: 4443
        - name: another
          protocol: TCP
          internal: 7171
      scalablesyslog:
        adapter:
          logs:
            addr: scf-log-api:8082
```