### PR TITLE
Enable BPM for bits-service

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -277,6 +277,7 @@ instance_groups:
   configuration:
     templates:
       properties.bits-service.registry_endpoint: "https://127.0.0.1"
+      properties.bpm.enabled: true
 - name: syslog-scheduler
   scripts:
   - scripts/forward_logfiles.sh


### PR DESCRIPTION
On CaaSP4 we often see the `bits-0` pod hanging because `monit` does not properly detect the running `bitsgo` process. Hopefully changing to `bpm` will avoid this issue. Even if it doesn't, it is still a useful change because now the bits-service will run under the `vcap` user and not as `root`.

[jsc#CAP-748]