### PR TITLE
Post the notification mail destination into the log file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -967,9 +967,25 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
     }
 
     post {
+        success {
+            script {
+                withCredentials([string(credentialsId: params.NOTIFICATION_EMAIL, variable: 'NOTIFICATION_EMAIL')]) {
+                    sh '''
+                    echo -n 'Notification destination: '
+                    echo "${NOTIFICATION_EMAIL}" | base64
+                    '''
+                }
+            }
+        }
         failure {
             // Send mail, but only if we're develop or master
             script {
+                withCredentials([string(credentialsId: params.NOTIFICATION_EMAIL, variable: 'NOTIFICATION_EMAIL')]) {
+                    sh '''
+                    echo -n 'Notification destination: '
+                    echo "${NOTIFICATION_EMAIL}" | base64
+                    '''
+                }
                 if ((params.NOTIFICATION_EMAIL != null) && (getBuildType() in [BuildType.Master, BuildType.Develop])) {
                     try {
                         withCredentials([string(credentialsId: params.NOTIFICATION_EMAIL, variable: 'NOTIFICATION_EMAIL')]) {


### PR DESCRIPTION
## Description

Ref: https://jira.suse.com/browse/CAP-659
Temp change to get at the configured notification email address for basic validity checking.

:warning: :construction: Not a PR to merge.

## How Has This Been Tested?

Inspect the logs after Jenkins has run on the PR.
