### PR TITLE
(Option to) use helm/stable NATS chart

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 workspace(name = "scf")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("//dev/kind:binary.bzl", "kind_binary")
 load("//dev/minikube:binary.bzl", "minikube_binary")
 load("//rules/external_binary:def.bzl", "external_binary")
@@ -71,4 +71,11 @@ filegroup(
     sha256 = project.metrics_server.sha256,
     strip_prefix = "metrics-server-{}".format(project.metrics_server.version),
     url = "https://github.com/kubernetes-incubator/metrics-server/archive/v{}.tar.gz".format(project.metrics_server.version),
+)
+
+http_file(
+    name = "helm_charts_stable_nats",
+    downloaded_file_path = "nats.tgz",
+    sha256 = project.helm_charts_stable_nats.sha256,
+    urls = ["https://kubernetes-charts.storage.googleapis.com/nats-{}.tgz".format(project.helm_charts_stable_nats.version)],
 )

--- a/def.bzl
+++ b/def.bzl
@@ -21,6 +21,10 @@ project = struct(
             },
         ],
     ),
+    helm_charts_stable_nats = struct(
+        version = "4.0.0",
+        sha256 = "15bc7ea023ce663f6480131f1e0b8a937679de8019d481183ab158ac9e33fb02",
+    ),
     kubernetes = struct(
         version = "1.14.6",
         platforms = [

--- a/deploy/helm/scf/BUILD.bazel
+++ b/deploy/helm/scf/BUILD.bazel
@@ -19,6 +19,12 @@ pkg_tar(
     ],
 )
 
+pkg_tar(
+    name = "helm_charts_stable_nats",
+    package_dir = "charts",
+    srcs = ["@helm_charts_stable_nats//file"],
+)
+
 helm_package(
     name = "chart",
     srcs = [
@@ -26,6 +32,7 @@ helm_package(
     ],
     tars = [
         ":cf_deployment",
+        ":helm_charts_stable_nats",
         "//bosh/releases:pre_render_scripts",
     ],
     chart_name = "scf",

--- a/deploy/helm/scf/assets/operations/features/nats-external.yaml
+++ b/deploy/helm/scf/assets/operations/features/nats-external.yaml
@@ -1,5 +1,34 @@
-{{- if (index .Values.features "external-nats") }}
+{{- if .Values.nats.external }}
 # Disable the built-in NATS BOSH release, and use a helm chart instead.
 - type: remove
   path: /instance_groups/name=nats
+
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/nats?
+  value: &nats-config
+    machines: [ {{ $.Values.deployment_name }}-nats-client ]
+    port: 4222
+    user: {{ $.Values.nats.auth.user }}
+    password: {{ $.Values.nats.auth.password }}
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=route_emitter/properties/diego/route_emitter/nats?
+  value: *nats-config
+
+{{- range ( list "api" "doppler" "log-api" "singleton-blobstore" "uaa" ) }}
+- type: replace
+  path: /instance_groups/name={{.}}/jobs/name=route_registrar/properties/nats?
+  value: *nats-config
+{{- end }}
+
+{{- if .Values.features.eirini }}
+# If Eirini is enabled, force the NATS password manually
+- type: replace
+  path: /instance_groups/name=eirini/jobs/name=opi/properties/opi/nats_ip
+  value: {{ .Values.deployment_name }}-nats-client
+- type: replace
+  path: /instance_groups/name=eirini/jobs/name=opi/properties/opi/nats_password
+  value: {{ .Values.nats.auth.password }}
+{{- end }}
+
 {{- end }}

--- a/deploy/helm/scf/assets/operations/features/nats-external.yaml
+++ b/deploy/helm/scf/assets/operations/features/nats-external.yaml
@@ -1,0 +1,5 @@
+{{- if (index .Values.features "external-nats") }}
+# Disable the built-in NATS BOSH release, and use a helm chart instead.
+- type: remove
+  path: /instance_groups/name=nats
+{{- end }}

--- a/deploy/helm/scf/assets/operations/features/set_suse_buildpacks.yaml
+++ b/deploy/helm/scf/assets/operations/features/set_suse_buildpacks.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.features.suse_buildpacks }}
 - type: replace
   path: /releases/name=binary-buildpack
   value:
@@ -77,3 +78,4 @@
     url: "https://s3.amazonaws.com/suse-final-releases/dotnet-core-buildpack-release-2.2.13.1.tgz"
     version: "2.2.13.1"
     sha1: "2891486988d66aaae783c6f8df506695a916201b"
+{{- end }}

--- a/deploy/helm/scf/templates/bosh_deployment.yaml
+++ b/deploy/helm/scf/templates/bosh_deployment.yaml
@@ -15,10 +15,6 @@ spec:
     name: cf-deployment
     type: configmap
   ops:
-{{- if .Values.features.suse_buildpacks }}
-  - name: {{ include "scf.ops-name" "assets/operations/buildpacks/set_suse_buildpacks.yaml" }}
-    type: configmap
-{{- end }}
 {{- if .Values.features.eirini }}
   - name: ops-use-bits-service
     type: configmap
@@ -39,6 +35,11 @@ spec:
   - name: {{ include "scf.ops-name" $path }}
     type: configmap
 {{- end }}
+{{- range $path, $bytes := .Files.Glob "assets/operations/features/*" }}
+  - name: {{ include "scf.ops-name" $path }}
+    type: configmap
+{{- end }}
+
 {{- if .Values.features.eirini }}
   - name: ops-remove-diego
     type: configmap

--- a/deploy/helm/scf/templates/ops.yaml
+++ b/deploy/helm/scf/templates/ops.yaml
@@ -18,9 +18,6 @@ data:
 {{- end -}}
 
 {{- $root := . -}}
-{{- if .Values.features.suse_buildpacks }}
-{{ include "scf.ops" (dict "Root" $root "Path" "assets/operations/buildpacks/set_suse_buildpacks.yaml") }}
-{{- end }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/temporary/*" }}
 {{ include "scf.ops" (dict "Root" $root "Path" $path) }}
 {{- end }}
@@ -28,5 +25,8 @@ data:
 {{ include "scf.ops" (dict "Root" $root "Path" $path) }}
 {{- end }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/*" }}
+{{ include "scf.ops" (dict "Root" $root "Path" $path) }}
+{{- end }}
+{{- range $path, $bytes := .Files.Glob "assets/operations/features/*" }}
 {{ include "scf.ops" (dict "Root" $root "Path" $path) }}
 {{- end }}

--- a/deploy/helm/scf/values.yaml
+++ b/deploy/helm/scf/values.yaml
@@ -31,6 +31,9 @@ features:
   # published to docker.io.
   suse_buildpacks: false
 
+  # Set this to true to disable the NATS release, and use the official helm chart
+  external-nats: false
+
 operations:
   # A list of configmap names that should be applied to the BOSH manifest.
   custom: []

--- a/deploy/helm/scf/values.yaml
+++ b/deploy/helm/scf/values.yaml
@@ -31,9 +31,6 @@ features:
   # published to docker.io.
   suse_buildpacks: false
 
-  # Set this to true to disable the NATS release, and use the official helm chart
-  external-nats: false
-
 operations:
   # A list of configmap names that should be applied to the BOSH manifest.
   custom: []
@@ -42,3 +39,11 @@ k8s-host-url: ""
 k8s-service-token: ""
 k8s-service-username: ""
 k8s-node-ca: ""
+
+nats:
+  # Set this to true to disable the NATS release, and use the official helm chart
+  # In that case the nats password is required.
+  external: false
+  auth:
+    user:     nats # Erini hard codes this to "nats"
+    password: pikachu


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds support to use the upstream helm chart for NATS, rather than using NATS based on the BOSH release.

## Motivation and Context
Fixes #2723

## How Has This Been Tested?
Brought up (on minikube/libvirt) both with `nats.external = true` and `= false` configurations, and checked that everything looks ready and smoke tests start.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Additional Information:

:warning: The NATS subchart currently still gets deployed even when not used; not sure yet how I'd go about disabling that.