### PR TITLE
Set default probe timeout to 10s and default period to 30s

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -9,8 +9,8 @@ set -o errexit -o nounset
 
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
-export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+352.g17b53d96"
+export FISSILE_FLAVOR="checks"
+export FISSILE_VERSION="7.0.0+355.gabc1e079"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="checks"
-export FISSILE_VERSION="7.0.0+355.gabc1e079"
+export FISSILE_VERSION="7.0.0+356.g566d21b6"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"

--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -1,5 +1,8 @@
 ---
 properties:
+  global-properties:
+    switchboard:
+      renewal: 60
   acceptance_tests:
     admin_user: admin
     skip_ssl_validation: true


### PR DESCRIPTION
Experimental change to help debugging CAP on CaaSP 4.

This PR will be deleted once the experiment is done; it should never be merged!

[jsc#CAP-766]
