### PR TITLE
Send mail for `Nightly` builds too. They are a variant of `Develop`.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -999,7 +999,7 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
         failure {
             // Send mail, but only if we're develop or master
             script {
-                if ((params.NOTIFICATION_EMAIL != null) && (getBuildType() in [BuildType.Master, BuildType.Develop])) {
+                if ((params.NOTIFICATION_EMAIL != null) && (getBuildType() in [BuildType.Master, BuildType.Develop, BuildType.Nightly])) {
                     try {
                         withCredentials([string(credentialsId: params.NOTIFICATION_EMAIL, variable: 'NOTIFICATION_EMAIL')]) {
                             mail(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -999,7 +999,7 @@ pass = ${OBS_CREDENTIALS_PASSWORD}
         failure {
             // Send mail, but only if we're develop or master
             script {
-                if ((params.NOTIFICATION_EMAIL != null) && (getBuildType() in [BuildType.Master, BuildType.Develop, BuildType.Nightly])) {
+                if ((params.NOTIFICATION_EMAIL != null) && !(getBuildType() in [BuildType.PullRequest, BuildType.Unknown])) {
                     try {
                         withCredentials([string(credentialsId: params.NOTIFICATION_EMAIL, variable: 'NOTIFICATION_EMAIL')]) {
                             mail(


### PR DESCRIPTION
## Description

Added `Nightly` to the list of buildtypes for which to send mail on failure.

## Motivation and Context

See https://jira.suse.com/browse/CAP-659

## How Has This Been Tested?

This will be tested by manually triggering a nightly scf-develop build.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
