### PR TITLE
Create ~/.kube/config with https endpoint to use RBAC

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,6 +34,7 @@ def provision(config, home, vm_registry_mirror, mounted_custom_setup_scripts)
   config.vm.provision :shell, privileged: true, path: "vagrant/ensure_kubelet_is_running.sh"
   config.vm.provision :shell, privileged: false, path: "vagrant/setup_storage_class.sh"
   config.vm.provision :shell, privileged: false, path: "vagrant/wait_pods_ready.sh"
+  config.vm.provision :shell, privileged: false, path: "vagrant/create_kubeconfig.sh"
   config.vm.provision :shell, privileged: false,
                       env: {"FISSILE_COMPILATION_CACHE_CONFIG" => ENV["FISSILE_COMPILATION_CACHE_CONFIG"]},
                       path: "vagrant/restore_fissile_cache.sh"

--- a/vagrant/create_kubeconfig.sh
+++ b/vagrant/create_kubeconfig.sh
@@ -6,9 +6,9 @@
 
 set -o errexit -o nounset -o xtrace
 
-SECRET=$(kubectl get sa default -n kube-system -o jsonpath="{.secrets[0].name}")
-CA_CRT=$(kubectl get secrets ${SECRET} -n kube-system -o jsonpath="{.data['ca\.crt']}")
-TOKEN=$(kubectl get secrets ${SECRET} -n kube-system -o jsonpath="{.data['token']}" | base64 -d)
+SECRET=$(kubectl get serviceaccount default --namespace kube-system --output jsonpath="{.secrets[0].name}")
+CA_CRT=$(kubectl get secrets ${SECRET} --namespace kube-system --output jsonpath="{.data['ca\.crt']}")
+TOKEN=$(kubectl get secrets ${SECRET} --namespace kube-system --output jsonpath="{.data['token']}" | base64 --decode)
 
 sudo chown -R vagrant:users ~/.kube
 

--- a/vagrant/create_kubeconfig.sh
+++ b/vagrant/create_kubeconfig.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Create ~/.kube/config file that uses the https endpoint to make
+# sure all requests go through rbac validation (requests via the
+# http endpoint bypass all validation).
+
+set -o errexit -o nounset -o xtrace
+
+SECRET=$(kubectl get sa default -n kube-system -o jsonpath="{.secrets[0].name}")
+CA_CRT=$(kubectl get secrets ${SECRET} -n kube-system -o jsonpath="{.data['ca\.crt']}")
+TOKEN=$(kubectl get secrets ${SECRET} -n kube-system -o jsonpath="{.data['token']}" | base64 -d)
+
+sudo chown -R vagrant:users ~/.kube
+
+cat <<EOF >>~/.kube/config
+kind: Config
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: "${CA_CRT}"
+    server: https://localhost:6443
+  name: local
+contexts:
+- context:
+    cluster: local
+    user: admin
+  name: admin-context
+current-context: admin-context
+preferences: {}
+users:
+- name: admin
+  user:
+    token: "${TOKEN}"
+EOF


### PR DESCRIPTION
The default http endpoint bypasses RBAC validation, so all requests are accepted. Which also means that `kubectl --as` doesn't work.

## How Has This Been Tested?

Verify that you can run commands as a restricted service account, and make sure commands that are not supposed to be allowed actually fail, e.g.

```
vagrant@vagrant-kube:~> kubectl --as system:serviceaccount:default:default cluster-info

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
Error from server (Forbidden): services is forbidden: User "system:serviceaccount:default:default" cannot list resource "services" in API group "" in the namespace "kube-system"
```