### PR TITLE
acceptance-tests-brain: testutils: fix typo

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
@@ -237,7 +237,7 @@ end
 
 # Show the status of a Kubernetes namespace
 def show_resources_in_namespace(namespace, *resource_types)
-    run "kubectl get #{resource_types.join(',')} --namespace #{namespace} --output-wide"
+    run "kubectl get #{resource_types.join(',')} --namespace #{namespace} --output=wide"
 end
 
 def print_all_container_logs_in_namespace(ns)


### PR DESCRIPTION
## Description
Fixes a typo from #2860.

## Motivation and Context
`kubectl --output` takes an argument; `--output-wide` is not a flag.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
