### PR TITLE
Better check for CRI-O. Must not have docker.

### DIFF
--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -82,12 +82,18 @@ function having_category() {
 
 echo "Testing $(green "${category}")"
 
-if has_command crictl ; then
-    # cri-o based system
-    green "cri-o system, will not have docker"
-    crio=1
-else
-    crio=0
+# Notes
+# - CaaSP 3 : Has docker, has crictl - Docker based
+# - CaaSP 4 : No  docker, has crictl - CRI-O  based
+
+crio=0
+if ! has_command docker ; then
+    # No docker, but ...
+    if has_command crictl ; then
+	# ... cri-o => cri-o based system
+	green "cri-o system, without docker"
+	crio=1
+    fi
 fi
 
 # swap should be accounted

--- a/bin/dev/kube-ready-state-check.sh
+++ b/bin/dev/kube-ready-state-check.sh
@@ -90,9 +90,9 @@ crio=0
 if ! has_command docker ; then
     # No docker, but ...
     if has_command crictl ; then
-	# ... cri-o => cri-o based system
-	green "cri-o system, without docker"
-	crio=1
+        # ... cri-o => cri-o based system
+        green "cri-o system, without docker"
+        crio=1
     fi
 fi
 


### PR DESCRIPTION
CaaSP3 is docker based, has both docker and crictl.

## Description

Added a condition to the check for a cri-o system, treat system with both `docker` and `crictl` as docker-based. Example: CaaSP 3.

## Motivation and Context

See https://jira.suse.com/browse/CAP-749

## How Has This Been Tested?

Will be tested manually on CaaSP 3 and 4 systems.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
