### PR TITLE
Set INSTANCE_ID to reference pod-ordinal label

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/doppler.yaml
@@ -80,12 +80,15 @@
         command: [curl, --fail, --head, --silent, http://localhost:6061/debug/pprof/cmdline]
 
 - type: replace
-  path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/envs?
+  path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/envs
   value:
   - name: INSTANCE_ADDR
     value: {{ .Values.deployment_name }}-doppler:8080
   - name: INSTANCE_ID
-    value: "0"
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.labels['fissile.cloudfoundry.org/pod-ordinal']
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/run/healthcheck/log-cache-expvar-forwarder
   value:

--- a/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/scheduler.yaml
@@ -163,12 +163,15 @@
   value: []
 
 - type: replace
-  path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/envs?
+  path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/envs
   value:
   - name: INSTANCE_ADDR
     value: {{ .Values.deployment_name }}-scheduler:8080
   - name: INSTANCE_ID
-    value: "0"
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.labels['fissile.cloudfoundry.org/pod-ordinal']
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=log-cache-expvar-forwarder/properties/quarks?/run/healthcheck/log-cache-expvar-forwarder


### PR DESCRIPTION
Instead of hardcoding the pod ordinal, we should rely on the label that the cf-operator sets for us. This will allow HA setups.