### PR TITLE
Bump configgin to store exported properties in secrets

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -328,7 +328,7 @@ pipeline {
         )
         string(
             name: 'FISSILE_STEMCELL_VERSION',
-            defaultValue: '12SP4-2.gfc2305c-0.228',
+            defaultValue: '12SP4-4.ga824718-0.230',
             description: 'Fissile stemcell version used as docker image tag',
         )
         booleanParam(

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+352.g17b53d96"
+export FISSILE_VERSION="7.0.0+360.g0ec8d681"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"
@@ -27,7 +27,7 @@ export ISTIO_VERSION="1.1.5"
 export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$//')
 
 # Used in: .envrc
-export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-38.g82067a9-30.95}
+export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-40.gae38cc7-30.95}
 
 # Used in: bin/generate-dev-certs.sh
 

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2652,6 +2652,9 @@ configuration:
       - apiGroups: [apps]
         resources: [statefulsets]
         verbs: [get, patch]
+      - apiGroups: [""]
+        resources: [secrets]
+        verbs: [create, get, delete]
       psp-role:
       - apiGroups: [extensions]
         resourceNames: [default]


### PR DESCRIPTION
* Bump to stemcell to include new configgin version.
* Bump to fissile to set `KUBERNETES_CONTAINER_NAME`.
* Provide access to secrets from configgin role.
* Bump to uaa for secrets access from configgin role.

This can be tested locally with the `./update-stemcell.sh` script from the configgin repo while the new stemcell is not yet available.