### PR TITLE
Fixes the position of the eirini within the instance groups of the cf manifest

### DIFF
--- a/deploy/helm/scf/assets/operations/instance_groups/eirini.yaml
+++ b/deploy/helm/scf/assets/operations/instance_groups/eirini.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.features.eirini -}}
 
 - type: replace
-  path: /instance_groups/-
+  path: /instance_groups/0:before
   value:
     name: configure-eirini
     lifecycle: auto-errand
@@ -44,7 +44,7 @@
 
 # Add eirini
 - type: replace
-  path: /instance_groups/-
+  path: /instance_groups/0:after
   value:
     name: eirini
     release: eirini


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

This PR fixes the position of the eirini within the instance groups of the cf manifest. Eirini should start before the cloud controller.


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is required for PR https://github.com/cloudfoundry-incubator/cf-operator/pull/649

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

It has been tested manually by looking at the secret `<name>.with-ops` after the bosh manifest was deployed. We also checked that cf is starting successfully.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
