### PR TITLE
Jenkinsfile: Get the correct secret when testing rotation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -779,6 +779,7 @@ pipeline {
 
                     # Get the last updated secret
                     secret_resource="\$(kubectl get secrets --namespace="${cfNamespace}" --output=name --sort-by=.metadata.resourceVersion | grep secrets- | tail -n1)"
+                    # secret_resource is something like "secret/secrets-2.18.0.1-1", including the resource type
 
                     # Get a random secret that should be rotated (TODO: choose this better)
                     secret_name=internal-ca-cert
@@ -839,6 +840,7 @@ pipeline {
 
                     # Get the secret again to see that they have been rotated
                     secret_resource="\$(kubectl get secrets --namespace="${cfNamespace}" --output=name --sort-by=.metadata.resourceVersion | grep secret- | tail -n1)"
+                    # secret_resource is something like "secret/secrets-2.18.0.1-2", including the resource type
                     new_secret_value="\$(kubectl get --namespace="${cfNamespace}" "\${secret_resource}" -o jsonpath="{.data.\${secret_name}}" | base64 -d)"
 
                     if test "\${old_secret_value}" = "\${new_secret_value}" ; then


### PR DESCRIPTION
## Description
We changed configgin to put exported BOSH properties in secrets; the Jenkins test for rotated secrets is now failing to find the correct secret.  We need to update it to locate the correct secret.

## Motivation and Context
Jenkins builds are failing with:
`Secret \${secret_name} not correctly rotated`

## How Has This Been Tested?
This will trigger CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
