### PR TITLE
Jenkins: git: don't fail when unsetting versionsort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [2.19.0] - 2019-10-17
+
+## Added
+- Support for external CF-related databases, including CCDB & UAA when embedded in SCF
+- Support for eirini to run on GKE and EKS
+- Support for eirini to run on CRI-O-based Kubernetes environments
+- Ingress controller now available for UAA embedded in SCF
+- AUDIT_WRITE capabilities added for CRI-O
+
+## Changed
+- Eirini will use cflinuxfs3 as its default stack
+- Moved to stack-associated (or stackful) buildpacks, away from multi-stack
+- Enabled BPM for bits-service for reliability
+- garden.disable_swap_limit set to "true" to remove the need for swap accounting
+- Bumped binary-buildpack release to 1.0.35
+- Bumped cf-acceptance-tests to 9.5
+- Bumped cflinuxfs3 to 0.135.0
+- Bumped dotnetcore-buildpack release to 2.3.0
+- Bumped eirini release to 0.0.21
+- Bumped go-buildpack release to 1.9.1
+- Bumped java-buildpack release to 4.23.0
+- Bumped nginx-buildpack release to 1.1.0
+- Bumped nodejs-buildpack release to 1.7.0
+- Bumped php-buildpack release to 4.4.0
+- Bumped python-buildpack release to 1.6.37
+- Bumped ruby-buildpack release to 1.8.1
+- Bumped scf-helper release to 1.0.7
+- Bumped staticfile-buildpack release to 1.5.0
+- Bumped SLE12 & SLE15 stacks
+
+## Fixed
+- Enforced odd number of mysql replicas for HA scenarios to improve consistency with PXC
+- eirini-cert-copier no longer appears when scheduler is diego
+- Improved mysql-proxy active/passive handling
+
 ## [2.18.0] - 2019-08-26
 
 ## Added

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -679,7 +679,9 @@ pipeline {
                         git config --local --replace-all credential.helper \
                             '/bin/bash -c "echo \"username=${GIT_USERNAME}\"; echo \"password=${GIT_PASSWORD}\""'
                         # Figure out what the tag was from earlier in this build pipeline
-                        git config --unset-all versionsort.suffix
+                        if git config --get-all versionsort.suffix ; then
+                            git config --unset-all versionsort.suffix
+                        fi
                         git config --add versionsort.suffix '-alpha'
                         git config --add versionsort.suffix '-beta'
                         git config --add versionsort.suffix '-rc'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -778,12 +778,17 @@ pipeline {
                     . make/include/secrets
 
                     # Get the last updated secret
-                    secret_resource="\$(kubectl get secrets --namespace="${cfNamespace}" --output=jsonpath='{.items[-1:].metadata.name}' --sort-by=.metadata.resourceVersion)"
+                    secret_resource="\$(kubectl get secrets --namespace="${cfNamespace}" --output=name --sort-by=.metadata.resourceVersion | grep secrets- | tail -n1)"
+                    # secret_resource is something like "secret/secrets-2.18.0.1-1", including the resource type
 
                     # Get a random secret that should be rotated (TODO: choose this better)
                     secret_name=internal-ca-cert
                     # And its value
-                    old_secret_value="\$(kubectl get secret --namespace="${cfNamespace}" "\${secret_resource}" -o jsonpath="{.data.\${secret_name}}" | base64 -d)"
+                    old_secret_value="\$(kubectl get --namespace="${cfNamespace}" "\${secret_resource}" -o jsonpath="{.data.\${secret_name}}" | base64 -d)"
+
+                    if test -z "\${old_secret_value}" ; then
+                        echo "Secret \${secret_name} is missing in resource \${secret_resource}"
+                    fi
 
                     # Run helm upgrade with a new kube setting to test that secrets are regenerated
 
@@ -834,8 +839,9 @@ pipeline {
                     kubectl get pods --all-namespaces
 
                     # Get the secret again to see that they have been rotated
-                    secret_resource="\$(kubectl get secrets --namespace="${cfNamespace}" --output=jsonpath='{.items[-1:].metadata.name}' --sort-by=.metadata.resourceVersion)"
-                    new_secret_value="\$(kubectl get secret --namespace="${cfNamespace}" "\${secret_resource}" -o jsonpath="{.data.\${secret_name}}" | base64 -d)"
+                    secret_resource="\$(kubectl get secrets --namespace="${cfNamespace}" --output=name --sort-by=.metadata.resourceVersion | grep secret- | tail -n1)"
+                    # secret_resource is something like "secret/secrets-2.18.0.1-2", including the resource type
+                    new_secret_value="\$(kubectl get --namespace="${cfNamespace}" "\${secret_resource}" -o jsonpath="{.data.\${secret_name}}" | base64 -d)"
 
                     if test "\${old_secret_value}" = "\${new_secret_value}" ; then
                         echo "Secret \${secret_name} not correctly rotated"

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -35,7 +35,7 @@ export GOLANG_VERSION=1.7
 
 # Used in: make/include/versioning
 
-export PRODUCT_VERSION="1.5.0"
+export PRODUCT_VERSION="1.5.1"
 export CF_VERSION="9.5.0"
 
 # Show versions, if called on its own.

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -164,9 +164,9 @@ releases:
   version: "1.81.42"
   sha1: "e794ebb130f0e8acb1a9643775d57df6b5aab994"
 - name: sle15
-  url: "https://s3.amazonaws.com/suse-final-releases/sle15-release-10.53.tgz"
-  version: "10.53"
-  sha1: "c135c04ddefbfb69afa5302eb2d49d5be01c2ce1"
+  url: "https://s3.amazonaws.com/suse-final-releases/sle15-release-10.54.tgz"
+  version: "10.54"
+  sha1: "218a063e26c15e30b5e7ba523d4344a4221727b4"
 - name: app-autoscaler
   version: "1.2.1"
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=1.2.1"


### PR DESCRIPTION
## Description
`git config --unset-all` will return an error value if the thing to unset wasn't set to start with. Work around this by checking if it exists first.

## Motivation and Context
We are getting failures trying to build the RC because things are bailing halfway through.

## How Has This Been Tested?
Jenkins will deal with it.

## Screenshots (if appropriate):
```
12:30:05 + set -o errexit -o nounset
12:30:05 + git config --local --replace-all credential.helper '/bin/bash -c "echo "username=${GIT_USERNAME}"; echo "password=${GIT_PASSWORD}""'
12:30:05 + git config --unset-all versionsort.suffix
…
ERROR: script returned exit code 5
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
