### PR TITLE
Jenkins: git: don't fail when unsetting versionsort

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -679,7 +679,9 @@ pipeline {
                         git config --local --replace-all credential.helper \
                             '/bin/bash -c "echo \"username=${GIT_USERNAME}\"; echo \"password=${GIT_PASSWORD}\""'
                         # Figure out what the tag was from earlier in this build pipeline
-                        git config --unset-all versionsort.suffix
+                        if git config --get-all versionsort.suffix ; then
+                            git config --unset-all versionsort.suffix
+                        fi
                         git config --add versionsort.suffix '-alpha'
                         git config --add versionsort.suffix '-beta'
                         git config --add versionsort.suffix '-rc'


### PR DESCRIPTION
This is the `rc` version of #2998.

## Description
`git config --unset-all` will return an error value if the thing to unset wasn't set to start with. Work around this by checking if it exists first.

## Motivation and Context
We are getting failures trying to build the RC because things are bailing halfway through.

## How Has This Been Tested?
Jenkins will deal with it.

## Screenshots (if appropriate):
```
12:30:05 + set -o errexit -o nounset
12:30:05 + git config --local --replace-all credential.helper '/bin/bash -c "echo "username=${GIT_USERNAME}"; echo "password=${GIT_PASSWORD}""'
12:30:05 + git config --unset-all versionsort.suffix
…
ERROR: script returned exit code 5
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
