### PR TITLE
Use object versions supported in K8s 1.16

### DIFF
--- a/container-host-files/etc/scf/config/scripts/configure-HA-hosts.sh
+++ b/container-host-files/etc/scf/config/scripts/configure-HA-hosts.sh
@@ -48,7 +48,7 @@ find_cluster_ha_hosts() {
         local statefulset_name replicas i
         for ((i = 0 ; i < 5 ; i ++)) ; do
             statefulset_name="$(k8s_api api/v1 "/pods/${HOSTNAME}" | json_get [\'metadata\'][\'labels\'][\'app.kubernetes.io/component\'])"
-            replicas=$(k8s_api apis/apps/v1beta1 "/statefulsets/${statefulset_name}" | json_get [\'spec\'][\'replicas\'])
+            replicas=$(k8s_api apis/apps/v1"/statefulsets/${statefulset_name}" | json_get [\'spec\'][\'replicas\'])
 
             if [ "${statefulset_name}" != "" -a "${replicas}" != "" ]; then
                 break

--- a/make/assets/nfs-provisioner/deployment.yaml
+++ b/make/assets/nfs-provisioner/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     app: nfs-provisioner
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: nfs-provisioner
 spec:

--- a/make/assets/nfs-provisioner/psp.yaml
+++ b/make/assets/nfs-provisioner/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: nfs-provisioner

--- a/packer/scripts/setup-pod-security-policies.sh
+++ b/packer/scripts/setup-pod-security-policies.sh
@@ -9,7 +9,7 @@ set -o errexit -o xtrace
 # and should only be assigned to highly trusted users.
 kubectl create -f - <<EOF
 {
-  "apiVersion": "extensions/v1beta1",
+  "apiVersion": "policy/v1beta1",
   "kind": "PodSecurityPolicy",
   "metadata": {
     "annotations": {
@@ -58,7 +58,7 @@ EOF
 # users and service accounts.
 kubectl create -f - <<EOF
 {
-  "apiVersion": "extensions/v1beta1",
+  "apiVersion": "policy/v1beta1",
   "kind": "PodSecurityPolicy",
   "metadata": {
     "annotations": {

--- a/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_server_kube.yaml
+++ b/src/scf-release/src/acceptance-tests-brain/test-resources/nfs_server_kube.yaml
@@ -1,7 +1,7 @@
 ---
 # nfs-test-server role
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "nfs-test-server"


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Fixes #2763 

## How Has This Been Tested?
Haven't tested yet

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

The documentation mentions very old Kubernetes versions, but after this change, it will require Kubernetes 1.10.