### PR TITLE
make/kube: use correct helm apiVersion

### DIFF
--- a/make/kube
+++ b/make/kube
@@ -24,7 +24,7 @@ fissile build "${BUILD_TARGET}"
 
 if [ "${BUILD_TARGET}" = "helm" ]; then
     cat > "${FISSILE_OUTPUT_DIR}/Chart.yaml" << EOF
-apiVersion: ${APP_VERSION}
+apiVersion: v1
 appVersion: ${PRODUCT_VERSION}
 description: A Helm chart for SUSE Cloud Foundry
 name: cf


### PR DESCRIPTION
## Description

The apiVersion field in helm's Chart.yaml is for the Helm API version, and not for the app version.  We still have appVersion and version tags.

jsc#CAP-817

## Motivation and Context
This is breaking the Eirini pipeline.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
