### PR TITLE
Helm ApiVersion should be v1

### DIFF
--- a/make/kube
+++ b/make/kube
@@ -24,7 +24,7 @@ fissile build "${BUILD_TARGET}"
 
 if [ "${BUILD_TARGET}" = "helm" ]; then
     cat > "${FISSILE_OUTPUT_DIR}/Chart.yaml" << EOF
-apiVersion: ${APP_VERSION}
+apiVersion: v1
 appVersion: ${PRODUCT_VERSION}
 description: A Helm chart for SUSE Cloud Foundry
 name: cf


### PR DESCRIPTION
See https://helm.sh/docs/developing_charts/#the-chart-yaml-file
https://github.com/helm/helm/issues/5727

[#169282515]

## Description
Helm v2.15 and v3 now validates apiVersion and it should be v1

## Motivation and Context
SCF charts are broken with helm v2.15

## How Has This Been Tested?
I have used `helm lint` with sample values

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
