### PR TITLE
Bump stemcell version to include configgin 0.19.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -328,7 +328,7 @@ pipeline {
         )
         string(
             name: 'FISSILE_STEMCELL_VERSION',
-            defaultValue: '12SP4-4.ga824718-0.230',
+            defaultValue: '12SP4-5.g4792c5a-0.230',
             description: 'Fissile stemcell version used as docker image tag',
         )
         booleanParam(

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -27,7 +27,7 @@ export ISTIO_VERSION="1.1.5"
 export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$//')
 
 # Used in: .envrc
-export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-40.gae38cc7-30.95}
+export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-41.g3784e76-30.95}
 
 # Used in: bin/generate-dev-certs.sh
 

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -180,9 +180,12 @@ releases:
   version: "1.0.5"
   sha1: "eed1eed8d1b2bb20968c4a028d67fb095b606ae8"
 - name: scf-helper
-  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.7.tgz"
-  version: "1.0.7"
-  sha1: "d8f4eb845f18dfd89dbad2a7aab7284d81151367"
+  url: "file:///home/vagrant/scf/output/scf-helper-release.tgz"
+  version: "2"
+  sha1: "abcd2"
+  #url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.7.tgz"
+  #version: "1.0.7"
+  #sha1: "d8f4eb845f18dfd89dbad2a7aab7284d81151367"
 - name: "bits-service"
   version: "2.28.0"
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=2.28.0"
@@ -787,6 +790,8 @@ instance_groups:
           internal: 24053
   - name: route_registrar
     release: routing
+    consumes:
+      nats: {ignore: true}
   - name: bpm
     release: bpm
     properties:
@@ -1112,6 +1117,7 @@ instance_groups:
   scripts:
   - scripts/patches/fix_blobstore_send_timeout.sh
   - scripts/patches/fix_nodejs_buildpack.sh
+  - scripts/patches/fix_logcache_ca_cert.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/use_routing_api_private_endpoint.sh
   - scripts/patches/fix_monit_rsyslog.sh
@@ -1127,8 +1133,13 @@ instance_groups:
     release: scf
   - name: patch-properties
     release: scf-helper
+  - name: wait-for-database
+    release: scf-helper
   - name: cloud_controller_ng
     release: capi
+    consumes:
+      # XXX needs a patch to set the cert: capi-release/jobs/cloud_controller_ng/templates/logcache_tls_ca.crt.erb
+      log-cache: {ignore: true}
     properties:
       bosh_containerization:
         # XXX Maintain old service name for backwards compatiblities so apps keep running
@@ -1173,6 +1184,8 @@ instance_groups:
           internal: 8125
   - name: route_registrar
     release: routing
+    consumes:
+      nats: {ignore: true}
   - name: bpm
     release: bpm
     properties:
@@ -1231,6 +1244,15 @@ instance_groups:
       properties.cc.logcache_tls.subject_name: "log-cache"
       properties.cc.temporary_use_logcache: true
       properties.route_registrar.routes: '[{"name": "api", "port": 9022, "tls_port": 9024, "server_cert_domain_san": "api-set", "tags": {"component": "CloudController"}, "uris": ["api.((DOMAIN))"], "registration_interval": "10s"}]'
+      properties.wait-for-database.hostname: &cf-internal-database-host >
+        ((#DB_EXTERNAL_HOST))
+          ((DB_EXTERNAL_HOST))
+        ((/DB_EXTERNAL_HOST))
+        ((^DB_EXTERNAL_HOST))
+          mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
+        ((/DB_EXTERNAL_HOST))
+      properties.wait-for-database.port: &cf-internal-database-port >
+        ((#DB_EXTERNAL_HOST))((DB_EXTERNAL_PORT))((/DB_EXTERNAL_HOST))((^DB_EXTERNAL_HOST))3306((/DB_EXTERNAL_HOST))
 - name: cc-worker
   environment_scripts:
   - scripts/override-default-stack.sh
@@ -1317,6 +1339,8 @@ instance_groups:
           internal: 4443
   - name: route_registrar
     release: routing
+    consumes:
+      nats: {ignore: true}
   - name: bpm
     release: bpm
     properties:
@@ -1448,9 +1472,13 @@ instance_groups:
       properties.tls.cert: '"((LOG_CACHE_CERT))"'
       properties.tls.key: '"((LOG_CACHE_CERT_KEY))"'
 - name: doppler
+  environment_scripts:
+  - scripts/configure-HA-hosts.sh
   scripts:
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
+  # Don't use bosh link to get the RLP address and port
+  - scripts/patches/set_logs_provider_addr.sh
   post_config_scripts:
   - scripts/bpm_kube_dns.rb
   jobs:
@@ -1463,6 +1491,8 @@ instance_groups:
     # gateway_addr - default - ":8081"
   - name: log-cache-nozzle
     release: log-cache
+    consumes:
+      reverse_log_proxy: {ignore: true}
     # mostly default, logs_provider cert, see below
   - name: log-cache-cf-auth-proxy
     release: log-cache
@@ -1472,6 +1502,8 @@ instance_groups:
   - name: log-cache
     release: log-cache
     # certs, see below
+    provides:
+      log-cache: {}
     properties:
       bosh_containerization:
         ports:
@@ -1534,6 +1566,8 @@ instance_groups:
           privileged: true
   - name: route_registrar
     release: routing
+    consumes:
+      nats: {ignore: true}
   configuration:
     templates:
       properties.cc.ca_cert: '"((INTERNAL_CA_CERT))"'
@@ -1681,6 +1715,8 @@ instance_groups:
           internal: 8081
   - name: reverse_log_proxy
     release: loggregator
+    provides:
+      reverse_log_proxy: {}
     properties:
       bosh_containerization:
         ports:
@@ -1697,6 +1733,8 @@ instance_groups:
           internal: 8088
   - name: route_registrar
     release: routing
+    consumes:
+      nats: {ignore: true}
   - name: bpm
     release: bpm
     properties:
@@ -2191,8 +2229,6 @@ instance_groups:
   jobs:
   - name: global-uaa-properties # needs to be first so images use it for processing monit templates
     release: scf-helper
-  - name: wait-for-database
-    release: scf-helper
   - name: uaa
     release: uaa
     properties:
@@ -2222,6 +2258,8 @@ instance_groups:
           external: 2793
           internal: 8443
           public: true
+  - name: wait-for-database
+    release: scf-helper
   tags:
   - sequential-startup
   configuration:
@@ -2252,15 +2290,8 @@ instance_groups:
           "uaa.((KUBERNETES_NAMESPACE)).svc",
           "uaa.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"
         ]
-      properties.uaadb.address: &cf-internal-database-host >
-        ((#DB_EXTERNAL_HOST))
-          ((DB_EXTERNAL_HOST))
-        ((/DB_EXTERNAL_HOST))
-        ((^DB_EXTERNAL_HOST))
-          mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
-        ((/DB_EXTERNAL_HOST))
-      properties.uaadb.port: &cf-internal-database-port >
-        ((#DB_EXTERNAL_HOST))((DB_EXTERNAL_PORT))((/DB_EXTERNAL_HOST))((^DB_EXTERNAL_HOST))3306((/DB_EXTERNAL_HOST))
+      properties.uaadb.address: *cf-internal-database-host
+      properties.uaadb.port: *cf-internal-database-port
       properties.uaadb.roles: '[{"name": "uaaadmin", "password": "((UAADB_PASSWORD))", "tag": "admin"}]'
       properties.wait-for-database.hostname: *cf-internal-database-host
       properties.wait-for-database.port: *cf-internal-database-port
@@ -2372,6 +2403,8 @@ instance_groups:
           internal: 8844
   - name: route_registrar
     release: routing
+    consumes:
+      nats: {ignore: true}
   - name: bpm
     release: bpm
     properties:
@@ -2489,6 +2522,8 @@ instance_groups:
           internal: 9101
   - name: route_registrar
     release: routing
+    consumes:
+      nats: {ignore: true}
   - name: bpm
     release: bpm
     properties:
@@ -2744,7 +2779,7 @@ configuration:
         verbs: [get, patch]
       - apiGroups: [""]
         resources: [secrets]
-        verbs: [create, get, delete]
+        verbs: [create, get, update, delete]
       psp-role:
       - apiGroups: [extensions]
         resourceNames: [default]

--- a/container-host-files/etc/scf/config/scripts/patches/fix_logcache_ca_cert.sh
+++ b/container-host-files/etc/scf/config/scripts/patches/fix_logcache_ca_cert.sh
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+set -e
+
+PATCH_DIR=/var/vcap/jobs-src/cloud_controller_ng/templates
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+patch -d "$PATCH_DIR" --force -p0 <<'PATCH'
+--- logcache_tls_ca.crt.erb
++++ logcache_tls_ca.crt.erb
+@@ -1,5 +1,5 @@
+ <%=
+-  result = ''
++  result = p('cc.mutual_tls.ca_cert')
+   if_link("log-cache") do |log_cache|
+     result = log_cache.p('tls.ca_cert')
+   end
+PATCH
+
+touch "${SENTINEL}"
+
+exit 0

--- a/container-host-files/etc/scf/config/scripts/patches/set_logs_provider_addr.sh
+++ b/container-host-files/etc/scf/config/scripts/patches/set_logs_provider_addr.sh
@@ -1,0 +1,37 @@
+#! /usr/bin/env bash
+set -e
+
+# Break circular bosh-link between doppler and log-api
+
+PATCH_DIR=/var/vcap/jobs-src/log-cache-nozzle/templates
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+patch -d "$PATCH_DIR" --force -p0 <<'PATCH'
+--- bpm.yml.erb
++++ bpm.yml.erb
+@@ -3,7 +3,6 @@
+   certDir = "#{jobDir}/config/certs"
+ 
+   lc = link("log-cache")
+-  rlp = link('reverse_log_proxy')
+ %>
+ ---
+ processes:
+@@ -13,7 +12,7 @@ processes:
+     HEALTH_PORT: "<%= p('health_port') %>"
+ 
+     # Logs Provider
+-    LOGS_PROVIDER_ADDR: "<%= "#{rlp.address}:#{rlp.p('reverse_log_proxy.egress.port')}" %>"
++    LOGS_PROVIDER_ADDR: "<%= "log-api-reverse-log-proxy.#{ENV['KUBERNETES_NAMESPACE']}.svc.#{ENV['KUBERNETES_CLUSTER_DOMAIN']}:8082" %>"
+     LOGS_PROVIDER_CA_FILE_PATH:   "<%= "#{certDir}/logs_provider_ca.crt" %>"
+     LOGS_PROVIDER_CERT_FILE_PATH: "<%= "#{certDir}/logs_provider.crt" %>"
+     LOGS_PROVIDER_KEY_FILE_PATH:  "<%= "#{certDir}/logs_provider.key" %>"
+PATCH
+
+touch "${SENTINEL}"
+
+exit 0

--- a/src/scf-release/jobs/configure-scf/templates/run.erb
+++ b/src/scf-release/jobs/configure-scf/templates/run.erb
@@ -88,10 +88,10 @@ UAA_ENDPOINT="<%= p('scf.uaa.internal-url') %>"
 API_ENDPOINT="<%= p('cf.insecure_api_url') %>"
 
 status "Waiting for CC ..."
-retry 240 30s cf api $CF_SKIP "$API_ENDPOINT"
+retry 1440 5s cf api $CF_SKIP "$API_ENDPOINT"
 
 status "Waiting for UAA ..."
-retry 240 30s curl --connect-timeout 5 --fail --header 'Accept: application/json' $UAA_ENDPOINT/info
+retry 1440 5s curl --connect-timeout 5 --fail --header 'Accept: application/json' $UAA_ENDPOINT/info
 
 insert_cf_client_auth_token.rb "$UAA_ENDPOINT" scf_auto_config:<%= p("uaa.clients.scf_auto_config.secret").shellescape %> ${CURL_SKIP}
 
@@ -134,7 +134,7 @@ if [ "$BROKER_NAME" != "eirini-persi-broker" ] || [ "$BROKER_PLANS" != "[]" ]; t
       -u "${BROKER_USERNAME}:${BROKER_PASSWORD}"
       "${BROKER_URL}/v2/catalog"
    )
-   retry 240 30s "${CATALOG_REQUEST[@]}"
+   retry 1440 5s "${CATALOG_REQUEST[@]}"
 
    cf create-service-broker "$BROKER_NAME" "$BROKER_USERNAME" "$BROKER_PASSWORD" "$BROKER_URL" || cf update-service-broker "$BROKER_NAME" "$BROKER_USERNAME" "$BROKER_PASSWORD" "$BROKER_URL"
 

--- a/src/scf-release/jobs/uaa-create-user/templates/run.erb
+++ b/src/scf-release/jobs/uaa-create-user/templates/run.erb
@@ -69,7 +69,7 @@ uaac_ssl = properties.ssl.skip_cert_verify ? '--skip-ssl-validation' : ''
 UAA_ZONE_ID="${KUBERNETES_NAMESPACE:-scf}"
 
 status "Waiting for root UAA to be available..."
-retry 240 30s curl ${SILENT} --connect-timeout 5 --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("scf.uaa.root-zone.url") %>/info'
+retry 1440 5s curl ${SILENT} --connect-timeout 5 --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("scf.uaa.root-zone.url") %>/info'
 
 # We need to create the zone manually
 status "Checking for UAA zone ${UAA_ZONE_ID}..."
@@ -132,7 +132,7 @@ status "Populating clients..."
 <% end %>
 
 status "Waiting for UAA zone to be available ..."
-retry 240 30s curl ${SILENT} --connect-timeout 5 --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("uaa.url") %>/info'
+retry 1440 5s curl ${SILENT} --connect-timeout 5 --fail <%= curl_ssl %> --header 'Accept: application/json' '<%= p("uaa.url") %>/info'
 
 status "Logging in to %s" '<%= p("uaa.url") %>'
 uaac target <%= uaac_ssl %> <%= p("uaa.url") %>

--- a/src/scf-release/jobs/wait-for-uaa/templates/pre-start.erb
+++ b/src/scf-release/jobs/wait-for-uaa/templates/pre-start.erb
@@ -39,6 +39,6 @@ CURL_SKIP="<%= properties.skip_ssl_validation ? '--insecure' : '' %>"
 UAA_ENDPOINT="<%= p('uaa.url') %>"
 
 status "Waiting for UAA ..."
-retry 240 30s curl --connect-timeout 5 --fail --header 'Accept: application/json' $UAA_ENDPOINT/info
+retry 1440 5s curl --connect-timeout 5 --fail --header 'Accept: application/json' $UAA_ENDPOINT/info
 
 exit 0


### PR DESCRIPTION
That configgin version will  no longer update the statefulset pod templated for bosh links imported from other jobs included in the same instance group.

This should avoid having the mysql role triggering a restart upon deployment.

[scf#CAP-150]
