### PR TITLE
Annotate APP_VERSION to a custom Chart field

### DIFF
--- a/make/kube
+++ b/make/kube
@@ -29,6 +29,7 @@ appVersion: ${PRODUCT_VERSION}
 description: A Helm chart for SUSE Cloud Foundry
 name: cf
 version: ${GIT_TAG}
+scfVersion: ${APP_VERSION}
 EOF
     cp chart-parts/* "${FISSILE_OUTPUT_DIR}/templates/"
     ruby bin/image-list.rb "${FISSILE_OUTPUT_DIR}"


### PR DESCRIPTION
Helm ignores additional fields, and we need to carry on metadata to
identify the chart versioning (cf version, commit hash).

The commit is not only useful to identify the chart, but it is actually
used by pipelines to match SCF tags against the released charts.

CAP-877