### PR TITLE
Go to the default of an active binlog for our pxc config.

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -650,7 +650,7 @@ instance_groups:
 
       properties.db_password: ((MYSQL_ADMIN_PASSWORD))
       properties.endpoint_password: ((MYSQL_GALERA_HEALTHCHECK_ENDPOINT_PASSWORD))
-      properties.engine_config.binlog.enabled: false
+      properties.engine_config.binlog.enabled: true
       properties.engine_config.galera.enabled: true
       properties.monit_startup_timeout: 300
       properties.seeded_databases: &seeded_databases >

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -650,7 +650,6 @@ instance_groups:
 
       properties.db_password: ((MYSQL_ADMIN_PASSWORD))
       properties.endpoint_password: ((MYSQL_GALERA_HEALTHCHECK_ENDPOINT_PASSWORD))
-      properties.engine_config.binlog.enabled: true
       properties.engine_config.galera.enabled: true
       properties.monit_startup_timeout: 300
       properties.seeded_databases: &seeded_databases >


### PR DESCRIPTION
## Description

Reactivated the default state for pxc binlog: enabled=true.

Subordinate UAA PR = https://github.com/SUSE/uaa-fissile-release/pull/176

## Motivation and Context

Ticket: https://jira.suse.com/browse/CAP-990

PXC falls over after a restart with the following errors seen in the pxc-mysql log:

```
2019-09-10T20:02:57.636429Z 0 [ERROR] Found 1 prepared transactions! It means that mysqld was not shut down properly last time and critical recovery information (last binlog or tc.log file) was manually deleted after a crash. You have to start mysqld with --tc-heuristic-
recover switch to commit or rollback pending transactions.

2019-09-10T20:02:57.636437Z 0 [ERROR] Aborting
```

This appears to be happening due to the fact that binlogs are not turned on when galera is turned off which is the default setup:

https://github.com/cloudfoundry-incubator/pxc-release/blob/7e943914df3a990d454b12cc5698418c254ce3b4/jobs/pxc-mysql/templates/galera-init-config.yml.erb#L10

https://github.com/cloudfoundry-incubator/pxc-release/blob/7e943914df3a990d454b12cc5698418c254ce3b4/jobs/pxc-mysql/spec#L252

We should look into turning on galera, at least in a PXC HA setup and explore the ramifications. Testing this will be complicated - maybe lot of killing the pod and kube restarts to see if we still see this error.

---

Actually we were not running the default setup. We were running with galera enabled, and binlog disabled, explicitly. The PR changes this to galera and binlog enabled.

## How Has This Been Tested?

  - Started CF cluster in SA mode.
  - Upgraded CF cluster to db HA, 5 pods.
  - Ran a script which kills each db pod in sequence, and waits for the pod to recover before it goes to the next, ad infinitum.
  - Ran a script in parallel to run the various test suites (smoke, brain, cat) to generate db transactions. Also ad infinitum.
  - Hope that the cluster is not running into the reported issue.

This was in the vagrant box.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
