### PR TITLE
Retry various helm/kubectl failures to overcome low-level glitches

### DIFF
--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -99,21 +99,21 @@ class MiniBrokerTest
             run "kubectl get namespace #{minibroker_namespace} 2> /dev/null || kubectl create namespace #{minibroker_namespace}"
             run "helm init --client-only"
             run_with_retry 30, 5 do
-              run(*%W(helm upgrade #{helm_release} minibroker
-                --install
-                --wait
-                --repo #{minibroker_repo}
-                --devel
-                --reset-values
-                --namespace #{minibroker_namespace}
-                --set helmRepoUrl=#{kubernetes_repo}
-                --set deployServiceCatalog=false
-                --set defaultNamespace=#{minibroker_pods_namespace}
-                --set kube.registry.hostname=index.docker.io
-                --set kube.organization=splatform
-                --set image=minibroker:latest
-                --set imagePullPolicy=Always
-              ))
+                run(*%W(helm upgrade #{helm_release} minibroker
+                    --install
+                    --wait
+                    --repo #{minibroker_repo}
+                    --devel
+                    --reset-values
+                    --namespace #{minibroker_namespace}
+                    --set helmRepoUrl=#{kubernetes_repo}
+                    --set deployServiceCatalog=false
+                    --set defaultNamespace=#{minibroker_pods_namespace}
+                    --set kube.registry.hostname=index.docker.io
+                    --set kube.organization=splatform
+                    --set image=minibroker:latest
+                    --set imagePullPolicy=Always
+                ))
             end
 
             broker_url = "http://#{helm_release}-minibroker.#{minibroker_namespace}.svc.cluster.local"

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -98,7 +98,8 @@ class MiniBrokerTest
 
             run "kubectl get namespace #{minibroker_namespace} 2> /dev/null || kubectl create namespace #{minibroker_namespace}"
             run "helm init --client-only"
-            run(*%W(helm upgrade #{helm_release} minibroker
+            run_with_retry 30, 5 do
+              run(*%W(helm upgrade #{helm_release} minibroker
                 --install
                 --wait
                 --repo #{minibroker_repo}
@@ -112,7 +113,8 @@ class MiniBrokerTest
                 --set kube.organization=splatform
                 --set image=minibroker:latest
                 --set imagePullPolicy=Always
-            ))
+              ))
+            end
 
             broker_url = "http://#{helm_release}-minibroker.#{minibroker_namespace}.svc.cluster.local"
 

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -158,12 +158,12 @@ class MiniBrokerTest
                 raise "Failed to create service instance #{service_instance} after #{elapsed} seconds."
             end
 
-            STDERR.puts "#{c_bold}# Show instance...#{c_reset}"
+            puts "#{c_blue}# Show instance...#{c_reset}"
             run "cf service #{service_instance}"
 
             wait_for_namespace minibroker_pods_namespace
 
-            STDERR.puts "#{c_bold}# Setup complete, entering user testcase#{c_reset}"
+            puts "#{c_bold}# Setup complete, entering user testcase#{c_reset}"
             yield self
 
             @success = true

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/minibroker_helper.rb
@@ -155,9 +155,13 @@ class MiniBrokerTest
                 elapsed = failed_service_creation - started_service_creation
                 raise "Failed to create service instance #{service_instance} after #{elapsed} seconds."
             end
+
+            STDERR.puts "#{c_bold}# Show instance...#{c_reset}"
             run "cf service #{service_instance}"
+
             wait_for_namespace minibroker_pods_namespace
 
+            STDERR.puts "#{c_bold}# Setup complete, entering user testcase#{c_reset}"
             yield self
 
             @success = true

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
@@ -195,15 +195,18 @@ end
 # Poll the status of a Kubernetes namespace, until all the pods in that
 # namespace are ready and all the jobs have run.
 def wait_for_namespace(namespace, sleep_duration=10)
+    STDERR.puts "#{c_bold}# Waiting for: #{namespace}, in increments of #{sleep_duration}s#{c_reset}"
     loop do
-        output = capture("kubectl get pods --namespace #{namespace} --no-headers")
-        ready = !output.empty?
-        output.each_line do |line|
-            name, readiness, status, restarts, age = line.split
-            next if status == 'Completed'
-            next if status == 'Running' && /^(\d+)\/\1$/ =~ readiness
+        output, status = capture_with_status("kubectl get pods --namespace #{namespace} --no-headers")
+        ready = status.success? && !output.empty?
+        if ready
+          output.each_line do |line|
+            name, readiness, state, restarts, age = line.split
+            next if state == 'Completed'
+            next if state == 'Running' && /^(\d+)\/\1$/ =~ readiness
             puts "# Waiting for: #{line}"
             ready = false
+          end
         end
         break if ready
         sleep sleep_duration
@@ -253,11 +256,12 @@ end
 
 # Wait for a cf service asynchronous operation to complete.
 def wait_for_async_service_operation(service_instance_name, retries=0)
+    duration = 5
+    STDERR.puts "#{c_bold}# Waiting for service instance #{service_instance} to complete operation, at most #{retries} retries, in increments of #{duration}s#{c_reset}"
     service_instance_guid = capture("cf service --guid #{service_instance_name}")
     return { success: false, reason: :not_found } if service_instance_guid == 'FAILED'
     attempts = 0
     loop do
-        puts "# Waiting for service instance #{service_instance} to complete operation..."
         service_instance_info = cf_curl("/v2/service_instances/#{service_instance_guid}")
         return { success: true } unless service_instance_info['entity']
         return { success: true } unless service_instance_info['entity']['last_operation']
@@ -265,7 +269,7 @@ def wait_for_async_service_operation(service_instance_name, retries=0)
         state = service_instance_info['entity']['last_operation']['state']
         return { success: true } if state != 'in progress'
         return { success: false, reason: :max_retries } if attempts >= retries
-        sleep 5
+        sleep duration
         attempts += 1
     end
 end
@@ -277,6 +281,7 @@ def cf_curl(*args)
 end
 
 def wait_for_statefulset(namespace, statefulset, sleep_duration=10)
+    STDERR.puts "#{c_bold}# Waiting for statefulset #{statefulset}, in increments of #{sleep_duration}s#{c_reset}"
     loop do
         break if statefulset_ready(namespace, statefulset)
         sleep sleep_duration

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/testutils.rb
@@ -42,7 +42,7 @@ def use_global_timeout(shutdown_time=60)
             main_thread.raise e
         else
             # Timeout reached
-            STDERR.puts "\e[0;1;31mGlobal timeout triggered at #{DateTime.now}\e[0m"
+            puts "\e[0;1;31mGlobal timeout triggered at #{DateTime.now}\e[0m"
             main_thread.raise Timeout::Error, "timeout reached after #{sleep_duration} seconds"
         end
     end
@@ -83,8 +83,8 @@ def _print_command(*args)
     cmd.pop if cmd.last.is_a? Hash
     opts = $opts.dup
     opts.merge! args.last if args.last.is_a? Hash
-    STDERR.puts "#{c_bold}+ #{cmd.join(" ")}#{c_reset}" if opts[:xtrace]
-    STDERR.flush
+    puts "#{c_bold}+ #{cmd.join(" ")}#{c_reset}" if opts[:xtrace]
+    STDOUT.flush
 end
 
 # Run the given command line, and return the exit status (as a Process::Status).
@@ -195,7 +195,7 @@ end
 # Poll the status of a Kubernetes namespace, until all the pods in that
 # namespace are ready and all the jobs have run.
 def wait_for_namespace(namespace, sleep_duration=10)
-    STDERR.puts "#{c_bold}# Waiting for: #{namespace}, in increments of #{sleep_duration}s#{c_reset}"
+    puts "#{c_blue}# Waiting for: #{namespace}, every #{sleep_duration}s#{c_reset}"
     loop do
         output, status = capture_with_status("kubectl get pods --namespace #{namespace} --no-headers")
         ready = status.success? && !output.empty?
@@ -257,7 +257,7 @@ end
 # Wait for a cf service asynchronous operation to complete.
 def wait_for_async_service_operation(service_instance_name, retries=0)
     duration = 5
-    STDERR.puts "#{c_bold}# Waiting for service instance #{service_instance} to complete operation, at most #{retries} retries, in increments of #{duration}s#{c_reset}"
+    puts "#{c_blue}# Waiting for service instance #{service_instance} to complete, every #{duration}s, #{retries} times#{c_reset}"
     service_instance_guid = capture("cf service --guid #{service_instance_name}")
     return { success: false, reason: :not_found } if service_instance_guid == 'FAILED'
     attempts = 0
@@ -281,7 +281,7 @@ def cf_curl(*args)
 end
 
 def wait_for_statefulset(namespace, statefulset, sleep_duration=10)
-    STDERR.puts "#{c_bold}# Waiting for statefulset #{statefulset}, in increments of #{sleep_duration}s#{c_reset}"
+    puts "#{c_blue}# Waiting for statefulset #{statefulset}, every #{sleep_duration}s#{c_reset}"
     loop do
         break if statefulset_ready(namespace, statefulset)
         sleep sleep_duration
@@ -322,6 +322,10 @@ end
 
 def c_green
   "\e[0;32m"
+end
+
+def c_blue
+  "\e[0;34m"
 end
 
 def c_reset


### PR DESCRIPTION
Plus additional output to better demarcate code locations and sections.

## Description

Additional output statements to mark code sections in verbose log output.
Change `wait_for_namespace` to get status of kubectl command instead of aborting in the low level. Failure may be a glitch in the kube foundation. Treat it as __namespace not ready__ and continue retrying to overcome.

## Motivation and Context

References:
  - https://jira.suse.com/browse/CAP-1043
  - https://jira.suse.com/browse/CAP-1042

## How Has This Been Tested?

In the vagrant box, started a cluster, and ran brain tests `01[24]_*` to see modified output and that the change is not breaking successful runs.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
