### PR TITLE
CHANGELOG Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - AUDIT_WRITE capabilities added for CRI-O
 
 ## Changed
-- Eirini will use cflinuxfs3 as its default stack
+- Eirini will use SLE15 as its default stack
 - Moved to stack-associated (or stackful) buildpacks, away from multi-stack
 - Enabled BPM for bits-service for reliability
 - garden.disable_swap_limit set to "true" to remove the need for swap accounting


### PR DESCRIPTION
Eirini uses sle15 as its default stack, not cflinuxfs3.