### PR TITLE
Use separate service account for configgin

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+367.g6b06e343"
+export FISSILE_VERSION="7.0.0+372.ge3509601"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -180,9 +180,9 @@ releases:
   version: "1.0.5"
   sha1: "eed1eed8d1b2bb20968c4a028d67fb095b606ae8"
 - name: scf-helper
-  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.9.tgz"
-  version: "1.0.9"
-  sha1: "8e8c03d7fbd4e7664fc8ebc19fcf3baa3c1c579f"
+  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.10.tgz"
+  version: "1.0.10"
+  sha1: "9bd4aca7178014b7b7d84b4dbf331d01cdbf3878"
 - name: "bits-service"
   version: "2.28.0"
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=2.28.0"
@@ -201,6 +201,25 @@ releases:
   sha1: 7130e5ac640ed1e1f52c09e76995e4d0680f3b45
 
 instance_groups:
+- name: configgin-helper
+  scripts:
+  - scripts/forward_logfiles.sh
+  - scripts/patches/fix_monit_rsyslog.sh
+  jobs:
+  - name: global-properties # needs to be first so images use it for processing monit templates.
+    release: scf-helper
+  - name: configgin-helper
+    release: scf-helper
+    properties:
+      bosh_containerization:
+        run:
+          service-account: configgin
+          scaling:
+            min: 1
+            max: 65535
+            ha: 2
+          memory: 64
+          virtual-cpus: 1
 - name: eirini
   if_feature: eirini
   environment_scripts:
@@ -704,6 +723,7 @@ instance_groups:
           protocol: TCP
           internal: 1936
         run:
+          service-account: active-passive
           scaling:
             min: 1
             max: 5
@@ -818,6 +838,7 @@ instance_groups:
         colocated_containers:
         - loggregator-agent
         run:
+          service-account: active-passive
           scaling:
             min: 1
             max: 3
@@ -1074,6 +1095,7 @@ instance_groups:
         colocated_containers:
         - loggregator-agent
         run:
+          service-account: active-passive
           scaling:
             min: 1
             max: 3
@@ -1781,6 +1803,7 @@ instance_groups:
         colocated_containers:
         - loggregator-agent
         run:
+          service-account: active-passive
           scaling:
             min: 1
             max: 3
@@ -2762,29 +2785,45 @@ instance_groups:
 configuration:
   auth:
     roles:
-      configgin-role:
+      active-passive:
       - apiGroups: [""]
         resources: [pods]
-        verbs: [get, list, patch]
+        verbs: [patch]
+      # switchboard-leader for mysql-proxy is annotating services
       - apiGroups: [""]
         resources: [services]
         verbs: [get, list, patch]
+      configgin:
+      - apiGroups: [""]
+        resources: [pods]
+        verbs: [get, list]
+      - apiGroups: [""]
+        resources: [services]
+        verbs: [get]
       - apiGroups: [apps]
         resources: [statefulsets]
         verbs: [get, patch]
       - apiGroups: [""]
         resources: [secrets]
         verbs: [create, get, update, delete]
-      psp-role:
+      garden-runc:
+      - apiGroups: [""]
+        resources: [pods]
+        verbs: [get]
+      psp:
       - apiGroups: [extensions]
         resourceNames: [default]
         resources: [podsecuritypolicies]
         verbs: [use]
-      secrets-role:
+      secrets:
       - apiGroups: [""]
         resources: [configmaps, secrets]
         verbs: [create, get, list, patch, update, delete]
-      test-role-brain:
+      services:
+      - apiGroups: [""]
+        resources: [services]
+        verbs: [get]
+      test-brain:
       - apiGroups: [""]
         resources: [services]
         verbs: [create, get, delete]
@@ -2806,12 +2845,15 @@ configuration:
       - apiGroups: [""]
         resources: [secrets]
         verbs: [get, list]
-      test-role-sits:
+      test-sits:
       - apiGroups: [""]
-        resources: [pods/portforward]
-        verbs: [create]
+        resources: [pods, pods/portforward]
+        verbs: [get, list, create]
+      - apiGroups: [""]
+        resources: [services]
+        verbs: [get]
     cluster-roles:
-      test-cluster-role:
+      test-cluster:
       - apiGroups: [""]
         resources: [namespaces]
         verbs: [create, get, delete]
@@ -2826,7 +2868,7 @@ configuration:
         verbs: [delete]
       - apiGroups: [""]
         resources: [persistentvolumes, persistentvolumeclaims]
-        verbs: [get, list]
+        verbs: [get, list, delete]
       - apiGroups: [storage.k8s.io]
         resources: [storageclasses]
         verbs: [get, list]
@@ -2853,19 +2895,25 @@ configuration:
         - persistentVolumeClaim
         - nfs
     accounts:
+      active-passive:
+        roles: [active-passive, psp]
+      configgin:
+        roles: [configgin, psp]
       default:
-        roles: [configgin-role, psp-role]
-      secret-generator:
-        roles: [configgin-role, secrets-role, psp-role]
-      tests-brain:
-        roles: [configgin-role, test-role-brain, psp-role]
-        cluster-roles: [test-cluster-role]
-      tests-sits:
-        roles: [configgin-role, test-role-sits, psp-role]
-      garden-runc:
-        roles: [configgin-role, psp-role]
+        roles: [psp]
       eirini:
-        roles: [configgin-role, secrets-role, psp-role]
+        # etc/scf/config/scripts/set-opi-registry-port.sh needs "get service"
+        roles: [services, psp]
+      garden-runc:
+        roles: [garden-runc, psp]
+      secret-generator:
+        # Include configgin role so that we don't deadlock with configgin-helper
+        roles: [configgin, secrets, psp]
+      tests-brain:
+        roles: [test-brain, psp]
+        cluster-roles: [test-cluster]
+      tests-sits:
+        roles: [test-sits, psp]
   templates:
     az: '"((KUBE_AZ))"'
     id: ((HOSTNAME))

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2196,7 +2196,7 @@ instance_groups:
       properties.sync_integration_tests.bbs.svc.port: 8889
       properties.sync_integration_tests.config.bbs_client_cert_contents: '"((BBS_CLIENT_CRT))"'
       properties.sync_integration_tests.config.bbs_client_key_contents: '"((BBS_CLIENT_CRT_KEY))"'
-      properties.sync_integration_tests.config.cf_admin_password: '"((CLUSTER_ADMIN_PASSWORD))"((#INTERNAL_CA_CERT_KEY))((/INTERNAL_CA_CERT_KEY))'
+      properties.sync_integration_tests.config.cf_admin_password: '"((CLUSTER_ADMIN_PASSWORD))"'
       properties.sync_integration_tests.config.cf_api: api.((DOMAIN))
       properties.sync_integration_tests.config.cf_apps_domain: ((DOMAIN))
       properties.sync_integration_tests.setup.flake_attempts: "'((SYNC_INTEGRATION_TESTS_FLAKE_ATTEMPTS))'"
@@ -2923,9 +2923,11 @@ configuration:
     networks.default.ip: '"((IP_ADDRESS))"'
     # We include INTERNAL_CA_CERT_KEY here so validation doesn't complain that it's not being used.
     # we can't make it internal, as that exposes it everywhere. The acceptance tests are not used at runtime so it's safe.
-    properties.acceptance_tests.admin_password: '"((CLUSTER_ADMIN_PASSWORD))"((#INTERNAL_CA_CERT_KEY))((/INTERNAL_CA_CERT_KEY))'
+    properties.acceptance_tests.admin_password: '"((CLUSTER_ADMIN_PASSWORD))"'
     properties.acceptance_tests.api: '"api.((DOMAIN))"'
     properties.acceptance_tests.apps_domain: '"((DOMAIN))"'
+    properties.acceptance_tests_brain.ca_cert: '"((INTERNAL_CA_CERT))"'
+    properties.acceptance_tests_brain.ca_cert_uaa: '"((UAA_CA_CERT))((^UAA_CA_CERT))((INTERNAL_CA_CERT))((/UAA_CA_CERT))"'
     properties.acceptance_tests_brain.domain: '"((DOMAIN))"'
     properties.acceptance_tests_brain.namespace: '"((KUBERNETES_NAMESPACE))"'
     properties.acceptance_tests_brain.password: '"((CLUSTER_ADMIN_PASSWORD))"'

--- a/src/scf-release/jobs/acceptance-tests-brain/spec
+++ b/src/scf-release/jobs/acceptance-tests-brain/spec
@@ -19,6 +19,11 @@ templates:
   pre-start.erb: bin/pre-start
 
 properties:
+  acceptance_tests_brain.ca_cert:
+    description: The Elastic Runtime CA Cert
+  acceptance_tests_brain.ca_cert_uaa:
+    description: The Elastic Runtime UAA CA Cert
+    default: ""
   acceptance_tests_brain.domain:
     description: The Elastic Runtime System Domain
   acceptance_tests_brain.tcp_domain:

--- a/src/scf-release/jobs/acceptance-tests-brain/templates/environment.sh.erb
+++ b/src/scf-release/jobs/acceptance-tests-brain/templates/environment.sh.erb
@@ -4,6 +4,8 @@ export CF_USERNAME="<%= properties.acceptance_tests_brain.user %>"
 export CF_PASSWORD="<%= properties.acceptance_tests_brain.password %>"
 export CF_ORG="<%= properties.acceptance_tests_brain.org %>"
 export CF_SPACE="<%= properties.acceptance_tests_brain.space %>"
+export CF_CA_CERT="<%= properties.acceptance_tests_brain.ca_cert %>"
+export CF_CA_CERT_UAA="<%= properties.acceptance_tests_brain.ca_cert_uaa %>"
 export KUBERNETES_NAMESPACE="<%= properties.acceptance_tests_brain.namespace %>"
 export KUBERNETES_STORAGE_CLASS_PERSISTENT="<%= properties.acceptance_tests_brain.storage_class %>"
 

--- a/src/scf-release/jobs/acceptance-tests-brain/templates/pre-start.erb
+++ b/src/scf-release/jobs/acceptance-tests-brain/templates/pre-start.erb
@@ -5,6 +5,6 @@ set -o nounset
 
 PATH=$PATH:/var/vcap/packages/cli/bin
 
-cf api --skip-ssl-validation "https://api.$DOMAIN"
-cf auth admin "${CLUSTER_ADMIN_PASSWORD}"
+cf api --skip-ssl-validation "https://api.<%= properties.acceptance_tests_brain.domain %>"
+cf auth admin "<%= properties.acceptance_tests_brain.password %>"
 cf enable-feature-flag diego_docker

--- a/src/scf-release/jobs/acceptance-tests/templates/pre-start.erb
+++ b/src/scf-release/jobs/acceptance-tests/templates/pre-start.erb
@@ -5,6 +5,10 @@ set -o nounset
 
 PATH=$PATH:/var/vcap/packages/cli/bin
 
+CLUSTER_ADMIN_PASSWORD="<%= p("acceptance_tests.admin_password") %>"
+DOMAIN="<%= p("acceptance_tests.apps_domain") %>"
+
+
 cf api --skip-ssl-validation "https://api.$DOMAIN"
 cf auth admin "${CLUSTER_ADMIN_PASSWORD}"
 cf enable-feature-flag diego_docker

--- a/src/scf-release/jobs/authorize-internal-ca/spec
+++ b/src/scf-release/jobs/authorize-internal-ca/spec
@@ -8,5 +8,7 @@ templates:
 packages: []
 
 properties:
+  scf.internal-ca-cert:
+    description: "The certificate authority being used by SCF internally"
   uaa.ca_cert:
     description: "The certificate authority being used by UAA"

--- a/src/scf-release/jobs/authorize-internal-ca/templates/pre-start.erb
+++ b/src/scf-release/jobs/authorize-internal-ca/templates/pre-start.erb
@@ -52,6 +52,7 @@ else
     fi
 fi
 
+INTERNAL_CA_CERT="<%= p("scf.internal-ca-cert") %>"
 if [ -r /etc/secrets/internal-ca-cert ]; then
     cp /etc/secrets/internal-ca-cert "${ca_path}"/internalCA.crt
 elif [ -n "${INTERNAL_CA_CERT:-}" ]; then

--- a/src/scf-release/jobs/sync-integration-tests/templates/pre-start.erb
+++ b/src/scf-release/jobs/sync-integration-tests/templates/pre-start.erb
@@ -5,6 +5,9 @@ set -o nounset
 
 PATH="/var/vcap/packages/cli/bin:${PATH}"
 
+CLUSTER_ADMIN_PASSWORD="<%= p("sync_integration_tests.config.cf_admin_password") %>"
+DOMAIN="<%= p("sync_integration_tests.config.cf_apps_domain") %>"
+
 cf api --skip-ssl-validation "https://api.${DOMAIN}"
 cf auth admin "${CLUSTER_ADMIN_PASSWORD}"
 

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/008_cf_usb_mysql_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/008_cf_usb_mysql_test.rb
@@ -54,20 +54,19 @@ class CFUSBMySQLTest < CFUSBTestBase
 
     def helm_chart_values
         ({
-            CF_ADMIN_PASSWORD: ENV['CLUSTER_ADMIN_PASSWORD'],
-            CF_ADMIN_USER: 'admin',
-            CF_CA_CERT: ENV['INTERNAL_CA_CERT'],
-            CF_DOMAIN: ENV['DOMAIN'],
+            CF_ADMIN_PASSWORD: ENV['CF_PASSWORD'],
+            CF_ADMIN_USER: ENV['CF_USERNAME'],
+            CF_CA_CERT: ENV['CF_CA_CERT'],
+            CF_DOMAIN: ENV['CF_DOMAIN'],
             SERVICE_LOCATION: "http://cf-usb-sidecar-mysql.#{helm_namespace}.svc.#{ENV['KUBERNETES_CLUSTER_DOMAIN']}:8081",
             SERVICE_MYSQL_HOST: tcp_domain,
             SERVICE_MYSQL_PORT: service_port,
             SERVICE_MYSQL_USER: MYSQL_USER,
             SERVICE_MYSQL_PASS: MYSQL_PASS,
             SERVICE_TYPE: service_type,
-            UAA_CA_CERT: ENV['UAA_CA_CERT'].empty? ? ENV['INTERNAL_CA_CERT'] : ENV['UAA_CA_CERT'],
+            UAA_CA_CERT: ENV['CF_CA_CERT_UAA'].empty? ? ENV['CF_CA_CERT'] : ENV['CF_CA_CERT_UAA'],
         })
     end
-
 end
 
 CFUSBMySQLTest.new.run_test

--- a/src/scf-release/src/acceptance-tests-brain/test-scripts/019_cf_usb_postgres_test.rb
+++ b/src/scf-release/src/acceptance-tests-brain/test-scripts/019_cf_usb_postgres_test.rb
@@ -71,10 +71,10 @@ class CFUSBPostgresTest < CFUSBTestBase
 
     def helm_chart_values
         ({
-            CF_ADMIN_PASSWORD: ENV['CLUSTER_ADMIN_PASSWORD'],
-            CF_ADMIN_USER: 'admin',
-            CF_CA_CERT: ENV['INTERNAL_CA_CERT'],
-            CF_DOMAIN: ENV['DOMAIN'],
+            CF_ADMIN_PASSWORD: ENV['CF_PASSWORD'],
+            CF_ADMIN_USER: ENV['CF_USERNAME'],
+            CF_CA_CERT: ENV['CF_CA_CERT'],
+            CF_DOMAIN: ENV['CF_DOMAIN'],
             SERVICE_LOCATION: "http://cf-usb-sidecar-postgres.#{helm_namespace}.svc.#{ENV['KUBERNETES_CLUSTER_DOMAIN']}:8081",
             SERVICE_POSTGRESQL_HOST: tcp_domain,
             SERVICE_POSTGRESQL_PORT: service_port,
@@ -82,7 +82,7 @@ class CFUSBPostgresTest < CFUSBTestBase
             SERVICE_POSTGRESQL_USER: postgres_user,
             SERVICE_POSTGRESQL_PASS: postgres_pass,
             SERVICE_TYPE: service_type,
-            UAA_CA_CERT: ENV['UAA_CA_CERT'].empty? ? ENV['INTERNAL_CA_CERT'] : ENV['UAA_CA_CERT'],
+            UAA_CA_CERT: ENV['CF_CA_CERT_UAA'].empty? ? ENV['CF_CA_CERT'] : ENV['CF_CA_CERT_UAA'],
         })
     end
 end


### PR DESCRIPTION
Configgin needs to read/write secrets, which is not a capability all pods should have. The `configgin` service account is passed automatically (via fissile) to each container via the `CONFIGGIN_SA_TOKEN` environment variable (from a secret maintained by `configgin-helper`).

`configgin-helper` imports the `MONIT_PASSWORD` from the generated secrets, so will not start until the `secret-generator` is done, so `secret-generator` has to be bound to the `configgin` role too to avoid a deadlock.

Active/passive roles now get their own service account because they need to modify annotations on pods and services (`switchboard-leader`).

`garden-runc` also has a separate service account because it needs to fetch its own pod spec to determine which node it is running on to determine the availability zone.

This PR also removes the `secrets` role from the `eirini` account; it is unknown why that was needed in the past.

[jsc#CAP-828]