### PR TITLE
Expand ciphersuite to be compatible with more clients

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -3314,6 +3314,7 @@ configuration:
     properties.opi.server_key: "((EIRINI_SERVER_CERT_KEY))"
     properties.opi.uploader_image: "((EIRINI_UPLOADER_IMAGE))"
     properties.router.balancing_algorithm: '"((ROUTER_BALANCING_ALGORITHM))"'
+    properties.router.cipher_suites: "((CIPHER_SUITES))"
     properties.router.client_cert_validation: '"((ROUTER_CLIENT_CERT_VALIDATION))"'
     # We use mysql because it comes up without any other dependencies and its critical for the cluster
     properties.router.dns_health_check_host: 'nats-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)).'
@@ -3841,6 +3842,10 @@ variables:
     example: password
     description: The password for access to the Universal Service Broker.
   type: password
+- name: CIPHER_SUITES
+  options:
+    description: An ordered, colon-delimited list of golang supported TLS cipher suites in OpenSSL or RFC format.
+    default: ECDHE-ECDSA-CHACHA20-POLY1305:TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305:ECDHE-RSA-CHACHA20-POLY1305:TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:ECDHE-RSA-AES128-GCM-SHA256:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:ECDHE-RSA-AES256-GCM-SHA384:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384
 - name: CLUSTER_ADMIN_AUTHORITIES
   options:
     default: scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose,routing.router_groups.read,routing.router_groups.write


### PR DESCRIPTION
The default ciphersuite fails when AWS ELBs are using SSL.

The new default cipher list is similar to the intermediate one recommended by Mozilla, with some changes to preserve compatibility with gorouter defaults, and variant names to work regardless of ELB SSL Policies (it works with all the canned policies).

Ref https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29

Ref https://github.com/SUSE/scf/issues/3153

[jsc#CAP-1125]
