### PR TITLE
Expose uaa.ca_file as a bosh property

### DIFF
--- a/container-host-files/etc/scf/config/scripts/patches/cc_expose_uaa_ca_file_as_bosh_property.sh
+++ b/container-host-files/etc/scf/config/scripts/patches/cc_expose_uaa_ca_file_as_bosh_property.sh
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+
+# This exposes uaa.ca_file as a configurable bosh property.
+
+set -e
+
+PATCH_DIR=/var/vcap/jobs-src/cloud_controller_ng/templates
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+patch -d "$PATCH_DIR" --force -p0 <<'PATCH'
+--- cloud_controller_ng.yml.erb
++++ cloud_controller_ng.yml.erb
+@@ -198,7 +198,7 @@ uaa:
+   internal_url: <%= "https://#{p("cc.uaa.internal_url")}:#{p("uaa.ssl.port")}" %>
+   resource_id: <%= p("cc.uaa_resource_id") %>
+   client_timeout: <%= p("cc.uaa.client_timeout")%>
+-  ca_file: /var/vcap/jobs/cloud_controller_ng/config/certs/uaa_ca.crt
++  ca_file: <%= p("cc.uaa.ca_file", "/var/vcap/jobs/cloud_controller_ng/config/certs/uaa_ca.crt") %>
+   <% if_p("uaa.cc.token_secret") do |token_secret| %>
+   symmetric_secret: "<%= token_secret %>"
+   <% end %>
+
+PATCH
+
+touch "${SENTINEL}"
+
+exit 0


### PR DESCRIPTION
Being able to override this is helpful when using SSL with upstream load balancers.

<!--- Provide a general summary of your changes in the Title above -->

## Description

This exposes uaa.ca_file as a configurable bosh property.

## Motivation and Context

`uaa.ca_file` has a fixed value, this is the smallest change that allows deploy-time customization of this value, while defaulting to the fixed value.

This change allows Issue #3187 to be addressed by setting `uaa.ca_file` to `/var/lib/ca-certificates/ca-bundle.pem`.

## How Has This Been Tested?

This was tested by manually copying the included script into a live `api-group` pod, attaching to the `api-group` container, executing the script, and confirming that it had the intended effect.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
