### PR TITLE
Bump fissile to add feature-flag support for colocated containers

### DIFF
--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -10,7 +10,7 @@ set -o errexit -o nounset
 export BOSH_CLI_VERSION="fcaa9c6caff58ab8da8c56481320681cdea492ee"
 export CFCLI_VERSION="6.42.0"
 export FISSILE_FLAVOR="develop"
-export FISSILE_VERSION="7.0.0+372.ge3509601"
+export FISSILE_VERSION="7.0.0+374.gb8e8e6af"
 
 export HELM_VERSION="2.11.0"
 export KK_VERSION="576a42386770423ced46ab4ae9955bee59b0d4dd"


### PR DESCRIPTION
Nothing to see here; this feature is not currently being used by SCF