### PR TITLE
Revert "Bump sle15 release to 10.74"

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -164,9 +164,9 @@ releases:
   version: "1.81.64"
   sha1: "a12e92cd51f066ddd5cddd6dbac06c1c687a6b7d"
 - name: sle15
-  url: "https://s3.amazonaws.com/suse-final-releases/sle15-release-10.74.tgz"
-  version: "10.74"
-  sha1: "4a46a108938801ccee17c188c2c5557991c9db73"
+  url: "https://s3.amazonaws.com/suse-final-releases/sle15-release-10.72.tgz"
+  version: "10.72"
+  sha1: "3a7b79192a62bf535a932d2d489a6d5087ed421e"
 - name: app-autoscaler
   version: "1.2.1"
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=1.2.1"


### PR DESCRIPTION
This reverts commit f3f1a4a09a02319ad7f709f7a0f9a999ae7a2e47.

Jenkins fails consistently with this error (3 times, because `-flakeAttemtps=3`):

```
[Fail] [detect] Buildpacks php [It] makes the app reachable via its bound route
/var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests/detect/buildpacks.go:98
```