### PR TITLE
Use apps/v1 apiVersion for statefulsets

### DIFF
--- a/container-host-files/etc/scf/config/scripts/configure-HA-hosts.sh
+++ b/container-host-files/etc/scf/config/scripts/configure-HA-hosts.sh
@@ -48,7 +48,7 @@ find_cluster_ha_hosts() {
         local statefulset_name replicas i
         for ((i = 0 ; i < 5 ; i ++)) ; do
             statefulset_name="$(k8s_api api/v1 "/pods/${HOSTNAME}" | json_get [\'metadata\'][\'labels\'][\'app.kubernetes.io/component\'])"
-            replicas=$(k8s_api apis/apps/v1beta1 "/statefulsets/${statefulset_name}" | json_get [\'spec\'][\'replicas\'])
+            replicas=$(k8s_api apis/apps/v1 "/statefulsets/${statefulset_name}" | json_get [\'spec\'][\'replicas\'])
 
             if [ "${statefulset_name}" != "" -a "${replicas}" != "" ]; then
                 break


### PR DESCRIPTION
apps/v1beta1 is deprecated and will be removed in kube 1.16.