### PR TITLE
Remove NFS mount for .fissile/.bosh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ personal-setup
 /OSCTEMP/
 /source-output/
 .final_releases
+.Trashes

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,7 +115,6 @@ Vagrant.configure(2) do |config|
 
     # Mount NFS volumes.
     # https://github.com/mitchellh/vagrant/issues/351
-    override.vm.synced_folder ".fissile/.bosh", "#{HOME}/.bosh", type: "nfs"
     override.vm.synced_folder ".", "#{HOME}/scf", type: "nfs"
 
     if ENV.include? custom_setup_scripts_env
@@ -164,7 +163,6 @@ Vagrant.configure(2) do |config|
       args: ["/dev/vdc", KUBERNETES_HOSTPATH_DIR]
 
     # Mount NFS volumes.
-    override.vm.synced_folder ".fissile/.bosh", "#{HOME}/.bosh", type: "nfs"
     override.vm.synced_folder ".", "#{HOME}/scf", type: "nfs"
 
     if ENV.include? custom_setup_scripts_env


### PR DESCRIPTION
It doesn't seem to be used at all anymore, and mounting more than one folder in vagrant via NFS seems to be broken in macOS Catalina.