### PR TITLE
Fix pod restarts in HA setups

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -328,7 +328,7 @@ pipeline {
         )
         string(
             name: 'FISSILE_STEMCELL_VERSION',
-            defaultValue: '12SP4-11.g2837aef-0.230',
+            defaultValue: '12SP4-14.g5ed8b15-0.234',
             description: 'Fissile stemcell version used as docker image tag',
         )
         booleanParam(

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -27,7 +27,7 @@ export ISTIO_VERSION="1.1.5"
 export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$//')
 
 # Used in: .envrc
-export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-47.g08810ad-30.95}
+export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-50.gc0d15f1-30.95}
 
 # Used in: bin/generate-dev-certs.sh
 

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -587,6 +587,9 @@ instance_groups:
       bosh_containerization:
         run:
           privileged: true
+  configuration:
+    templates:
+      properties.nats.machines: ((KUBE_NATS_CLUSTER_IPS))((#KUBE_SIZING_NATS_COUNT))((/KUBE_SIZING_NATS_COUNT))
 - name: mysql
   default_feature: mysql
   scripts:
@@ -768,7 +771,7 @@ instance_groups:
       properties.api_force_https: false
       properties.api_password: ((MYSQL_PROXY_ADMIN_PASSWORD))
       properties.api_port: 8083
-      properties.api_uri: mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))((#KUBE_SIZING_MYSQL_COUNT))((/KUBE_SIZING_MYSQL_COUNT))
+      properties.api_uri: mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
       properties.api_username: mysql_proxy
 - name: cf-usb-group
   default_feature: cf_usb
@@ -3199,7 +3202,7 @@ configuration:
     properties.diego.route_emitter.bbs.client_cert: '"((BBS_CLIENT_CRT))"'
     properties.diego.route_emitter.bbs.client_key: '"((BBS_CLIENT_CRT_KEY))"'
     properties.diego.route_emitter.log_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
-    properties.diego.route_emitter.nats.machines: ((KUBE_NATS_CLUSTER_IPS))((#KUBE_SIZING_NATS_COUNT))((/KUBE_SIZING_NATS_COUNT))
+    properties.diego.route_emitter.nats.machines: ((KUBE_NATS_CLUSTER_IPS))
     properties.diego.route_emitter.nats.password: '"((NATS_PASSWORD))"'
     properties.diego.ssh_proxy.bbs.api_location: diego-api-bbs.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8889
     properties.diego.ssh_proxy.bbs.ca_cert: '"((INTERNAL_CA_CERT))"'
@@ -3289,7 +3292,7 @@ configuration:
     properties.login.url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
     # CLUSTER_NAME is not wrapped in quotes because it has quotes in the dev env file.
     properties.name: ((CLUSTER_NAME))
-    properties.nats.machines: ((KUBE_NATS_CLUSTER_IPS))((#KUBE_SIZING_NATS_COUNT))((/KUBE_SIZING_NATS_COUNT))
+    properties.nats.machines: ((KUBE_NATS_CLUSTER_IPS))
     properties.nats.password: '"((NATS_PASSWORD))"'
     properties.nfsbroker.allowed_options: '"((PERSI_NFS_ALLOWED_OPTIONS))"'
     properties.nfsbroker.db_hostname: *cf-internal-database-host
@@ -4358,10 +4361,6 @@ variables:
     description: >
       This is an environment variable built-in by fissile.
       Its default value is 'secret-1' and cannot be set by the user.
-- name: KUBE_SIZING_MYSQL_COUNT
-  options:
-    description: The number of mysql replicas deployed. This value is set automatically
-      by the helm charts of SCF.
 - name: KUBE_SIZING_NATS_COUNT
   options:
     description: The number of nats replicas deployed. This value is set automatically


### PR DESCRIPTION
Remove unnecessary `KUBE_SIZING_*_COUNT` variables

* Remove `KUBE_SIZING_MYSQL_COUNT` environment variable

It is provided by fissile and always corresponds to the number of  mysql instances. This used to be used to set `KUBE_MYSQL_CLUSTER_IPS` in `configure-HA-hosts.sh`. But this logic is only used for `hats` anymore, so there is no reason to restart all `mysql-proxy` pods whenever the `mysql` replica count changes.

* Remove `KUBE_SIZING_NATS_COUNT` for every role except `nats`

This avoids restarting all roles that use the route emitter job any time the number of `nats` instances changes. Only other `nats` pods need to restart to get an up-to-date list of available instances.

* Bump configgin version to 0.20.2

This includes a bug fix to avoid erroneously restarting pods due to incorrectly checking for changed properties.

[jsc#CAP-1148]