### PR TITLE
Bump stemcells to get configgin-0.20.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -328,7 +328,7 @@ pipeline {
         )
         string(
             name: 'FISSILE_STEMCELL_VERSION',
-            defaultValue: '12SP4-14.g5ed8b15-0.234',
+            defaultValue: '12SP4-15.ga717911-0.234',
             description: 'Fissile stemcell version used as docker image tag',
         )
         booleanParam(

--- a/bin/common/versions.sh
+++ b/bin/common/versions.sh
@@ -27,7 +27,7 @@ export ISTIO_VERSION="1.1.5"
 export STAMPY_MAJOR=$(echo "$STAMPY_VERSION" | sed -e 's/\.g.*//' -e 's/\.[^.]*$//')
 
 # Used in: .envrc
-export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-50.gc0d15f1-30.95}
+export FISSILE_STEMCELL_VERSION=${FISSILE_STEMCELL_VERSION:-42.3-51.g7fef1b7-30.95}
 
 # Used in: bin/generate-dev-certs.sh
 


### PR DESCRIPTION
Use versioned annotation names for the imported property digests, so we start with a blank slate on each chart update.

[jsc#CAP-1148]
