### PR TITLE
Bump autoscaler to v1.2.4

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -25,6 +25,7 @@ export FISSILE_DOCKER_REPO=${FISSILE_DOCKER_REPO:-'fissile-stemcell-opensuse'}
 # of all the releases that make up SCF
 FISSILE_RELEASE=""
 FISSILE_RELEASE="${FISSILE_RELEASE},${PWD}/src/scf-release"
+FISSILE_RELEASE="${FISSILE_RELEASE},${PWD}/src/app-autoscaler-release"
 
 export FISSILE_RELEASE="${FISSILE_RELEASE#,}"
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "src/scf-release/src/acceptance-tests-brain/test-resources/rails-example"]
 	path = src/scf-release/src/acceptance-tests-brain/test-resources/rails-example
 	url = https://github.com/scf-samples/rails-example.git
+[submodule "src/app-autoscaler-release"]
+	path = src/app-autoscaler-release
+	url = https://github.com/cloudfoundry/app-autoscaler-release

--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,12 @@ uaa-helm: ${FISSILE_BINARY}
 scf-release:
 	make/bosh-release src/scf-release
 
+app-autoscaler-release:
+	make/bosh-release src/app-autoscaler-release
+
 releases: \
 	scf-release \
+	app-autoscaler-release \
 	uaa-releases \
 	${NULL}
 

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -167,10 +167,6 @@ releases:
   url: "https://s3.amazonaws.com/suse-final-releases/sle15-release-10.84.tgz"
   version: "10.84"
   sha1: "f379bece659bae5e8258469281089a76d4e4b734"
-- name: app-autoscaler
-  version: "1.2.1"
-  url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=1.2.1"
-  sha1: "1cc2cd3ed6c7c39f8c984316bb2afb95743ccba1"
 - name: cf-usb
   version: "1.0.1"
   url: "https://s3.amazonaws.com/suse-final-releases/cf-usb-release-1.0.1.tgz"


### PR DESCRIPTION

## Description
Bump autoscaler to the v1.2.4 release.
Note: This is done via submoduling as v1.2.4 is not available as a final release on bosh.io.

## Motivation and Context
This is a fix for https://jira.suse.com/browse/CAP-630

## How Has This Been Tested?
Vagrant / Jenkins will be run and should work.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
