### PR TITLE
Keep exposing the file_server HTTP port for upgrades

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1842,6 +1842,9 @@ instance_groups:
         ports:
         - name: diego-files
           protocol: TCP
+          internal: 8080
+        - name: diego-files-tls
+          protocol: TCP
           internal: 8443
   configuration:
     templates:


### PR DESCRIPTION
Already deployed applications have the file_server URL stored in the LRP in the Diego database. They will break if these URLs stop working. With HTTPS enabled the HTTP should return a redirect to the new URL, so applications don't have to be restarted after an upgrade.

Ref: https://www.pivotaltracker.com/n/projects/1003146/stories/165872883