### PR TITLE
Omnibus PR to get from RC2 to RC3

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -338,7 +338,6 @@ properties:
       sql:
         db_port: 3306
         db_schema: diego
-        db_username: diego
     executor:
       garden:
         address: 127.0.0.1:7777
@@ -349,7 +348,6 @@ properties:
       sql:
         db_port: 3306
         db_schema: diego_locket
-        db_username: diego_locket
     rep:
       evacuation_timeout_in_seconds: 60
       preloaded_rootfses:
@@ -405,7 +403,6 @@ properties:
     user: nats
   nfsbroker:
     db_driver: 'mysql'
-    db_username: 'nfsvolume'
     db_port: 3306
     db_name: 'nfsvolume'
     services:
@@ -437,7 +434,6 @@ properties:
       type: mysql
       port: 3306
       schema: routing-api
-      username: routing-api
   scalablesyslog:
     adapter:
       tls:

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -3776,6 +3776,7 @@ variables:
 - name: CREDHUB_DB_CA_CERT
   options:
     description: CA trusted for making TLS connections to targeted database server.
+    secret: true
 - name: CREDHUB_DB_HOST_VALIDATION
   options:
     default: true

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2375,7 +2375,7 @@ instance_groups:
       properties.credhub.data_storage.password: ((MYSQL_CREDHUB_USER_PASSWORD))
       properties.credhub.data_storage.port: *cf-internal-database-port
       properties.credhub.data_storage.require_tls: ((CREDHUB_DB_REQUIRE_TLS))
-      properties.credhub.data_storage.tls_ca: ((INTERNAL_CA_CERT))
+      properties.credhub.data_storage.tls_ca: ((CREDHUB_DB_CA_CERT))((^CREDHUB_DB_CA_CERT))((INTERNAL_CA_CERT))((/CREDHUB_DB_CA_CERT))
       properties.credhub.data_storage.type: "mysql"
       properties.credhub.data_storage.username: "credhub_user"
       properties.credhub.encryption.keys: '[{"provider_name":"internal-provider", "active":true, "key_properties":{"encryption_password":"((CREDHUB_ENCRYPT_KEY))"}}]'
@@ -3773,6 +3773,9 @@ variables:
     default: 2
     description: "'version' attribute in the /v2/info endpoint"
     required: true
+- name: CREDHUB_DB_CA_CERT
+  options:
+    description: CA trusted for making TLS connections to targeted database server.
 - name: CREDHUB_DB_HOST_VALIDATION
   options:
     default: true

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -685,14 +685,14 @@ instance_groups:
       properties.monit_startup_timeout: 300
       properties.seeded_databases: &seeded_databases >
         [
-          {"name":"ccdb","username":"ccadmin","password":"((MYSQL_CCDB_ROLE_PASSWORD))"},
-          {"name":"diego","username":"diego","password":"((MYSQL_DIEGO_PASSWORD))"},
-          {"name":"routing-api","username":"routing-api","password":"((MYSQL_ROUTING_API_PASSWORD))"},
+          {"name":"ccdb","username":"ccadmin((DB_EXTERNAL_USER_HOST_SUFFIX))","password":"((MYSQL_CCDB_ROLE_PASSWORD))"},
+          {"name":"diego","username":"diego((DB_EXTERNAL_USER_HOST_SUFFIX))","password":"((MYSQL_DIEGO_PASSWORD))"},
+          {"name":"routing-api","username":"routing-api((DB_EXTERNAL_USER_HOST_SUFFIX))","password":"((MYSQL_ROUTING_API_PASSWORD))"},
           {"name":"usb","username":"usb","password":"((MYSQL_CF_USB_PASSWORD))"},
-          {"name":"nfsvolume","username":"nfsvolume","password":"((MYSQL_PERSI_NFS_PASSWORD))"},
-          {"name":"diego_locket","username":"diego_locket","password":"((MYSQL_DIEGO_LOCKET_PASSWORD))"},
-          {"name":"credhub_user","username":"credhub_user","password":"((MYSQL_CREDHUB_USER_PASSWORD))"},
-          {"name":"uaadb", "username": "uaaadmin", "password":"((UAADB_PASSWORD))"}
+          {"name":"nfsvolume","username":"nfsvolume((DB_EXTERNAL_USER_HOST_SUFFIX))","password":"((MYSQL_PERSI_NFS_PASSWORD))"},
+          {"name":"diego_locket","username":"diego_locket((DB_EXTERNAL_USER_HOST_SUFFIX))","password":"((MYSQL_DIEGO_LOCKET_PASSWORD))"},
+          {"name":"credhub_user","username":"credhub_user((DB_EXTERNAL_USER_HOST_SUFFIX))","password":"((MYSQL_CREDHUB_USER_PASSWORD))"},
+          {"name":"uaadb", "username": "uaaadmin((DB_EXTERNAL_USER_HOST_SUFFIX))", "password":"((UAADB_PASSWORD))"}
         ]
       properties.tls.galera.ca: ((INTERNAL_CA_CERT))
       properties.tls.galera.certificate: ((GALERA_SERVER_CERT))
@@ -2239,7 +2239,7 @@ instance_groups:
         ]
       properties.uaadb.address: *cf-internal-database-host
       properties.uaadb.port: *cf-internal-database-port
-      properties.uaadb.roles: '[{"name": "uaaadmin", "password": "((UAADB_PASSWORD))", "tag": "admin"}]'
+      properties.uaadb.roles: '[{"name": "uaaadmin((DB_EXTERNAL_USER_HOST_SUFFIX))", "password": "((UAADB_PASSWORD))", "tag": "admin"}]'
       properties.uaadb.tls: "((UAADB_TLS))"
       properties.wait-for-database.hostname: *cf-internal-database-host
       properties.wait-for-database.port: *cf-internal-database-port
@@ -2377,7 +2377,7 @@ instance_groups:
       properties.credhub.data_storage.require_tls: ((CREDHUB_DB_REQUIRE_TLS))
       properties.credhub.data_storage.tls_ca: ((CREDHUB_DB_CA_CERT))((^CREDHUB_DB_CA_CERT))((INTERNAL_CA_CERT))((/CREDHUB_DB_CA_CERT))
       properties.credhub.data_storage.type: "mysql"
-      properties.credhub.data_storage.username: "credhub_user"
+      properties.credhub.data_storage.username: "credhub_user((DB_EXTERNAL_USER_HOST_SUFFIX))"
       properties.credhub.encryption.keys: '[{"provider_name":"internal-provider", "active":true, "key_properties":{"encryption_password":"((CREDHUB_ENCRYPT_KEY))"}}]'
       properties.credhub.encryption.providers: '[{"name":"internal-provider", "type":"internal"}]'
       properties.credhub.log_level: '"((CREDHUB_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
@@ -3000,7 +3000,7 @@ configuration:
     properties.cc.uaa.internal_url: ((KUBERNETES_NAMESPACE)).((UAA_HOST))
     properties.ccdb.address: *cf-internal-database-host
     properties.ccdb.port: *cf-internal-database-port
-    properties.ccdb.roles: '[{"name": "ccadmin", "password": "((MYSQL_CCDB_ROLE_PASSWORD))", "tag": "admin"}]'
+    properties.ccdb.roles: '[{"name": "ccadmin((DB_EXTERNAL_USER_HOST_SUFFIX))", "password": "((MYSQL_CCDB_ROLE_PASSWORD))", "tag": "admin"}]'
     properties.cf-sle12.trusted_certs: '"((ROOTFS_TRUSTED_CERTS))((#ROOTFS_TRUSTED_CERTS))\n((/ROOTFS_TRUSTED_CERTS))((INTERNAL_CA_CERT))"'
     properties.cf-usb.broker.external_url: '"https://cf-usb.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):24054"'
     properties.cf-usb.broker.password: '"((CF_USB_PASSWORD))"'
@@ -3043,12 +3043,14 @@ configuration:
     properties.diego.bbs.sql.ca_cert: ((INTERNAL_CA_CERT))
     properties.diego.bbs.sql.db_host: *cf-internal-database-host
     properties.diego.bbs.sql.db_password: ((MYSQL_DIEGO_PASSWORD))
+    properties.diego.bbs.sql.db_username: "diego((DB_EXTERNAL_USER_HOST_SUFFIX))"
     properties.diego.executor.disk_capacity_mb: ((DIEGO_CELL_DISK_CAPACITY_MB))
     properties.diego.executor.memory_capacity_mb: ((DIEGO_CELL_MEMORY_CAPACITY_MB))
     properties.diego.file_server.log_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
     properties.diego.locket.log_level: '"((GO_LOG_LEVEL))((#LOG_LEVEL))((/LOG_LEVEL))"'
     properties.diego.locket.sql.db_host: *cf-internal-database-host
     properties.diego.locket.sql.db_password: '"((MYSQL_DIEGO_LOCKET_PASSWORD))"'
+    properties.diego.locket.sql.db_username: "diego_locket((DB_EXTERNAL_USER_HOST_SUFFIX))"
     properties.diego.rep.bbs.api_location: diego-api-bbs.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8889
     properties.diego.rep.cell_id: ((HOSTNAME))
     properties.diego.rep.locket.api_location: locket-locket.((KUBERNETES_NAMESPACE)):8891
@@ -3162,6 +3164,7 @@ configuration:
     properties.nfsbroker.allowed_options: '"((PERSI_NFS_ALLOWED_OPTIONS))"'
     properties.nfsbroker.db_hostname: *cf-internal-database-host
     properties.nfsbroker.db_password: '"((MYSQL_PERSI_NFS_PASSWORD))"'
+    properties.nfsbroker.db_username: "nfsvolume((DB_EXTERNAL_USER_HOST_SUFFIX))"
     properties.nfsbroker.default_options: '"((PERSI_NFS_DEFAULT_OPTIONS))"'
     properties.nfsbroker.password: '"((PERSI_NFS_BROKER_PASSWORD))"'
     properties.nfsbroker.url: 'http://nfs-broker-nfsbroker.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN)):8999'
@@ -3230,6 +3233,7 @@ configuration:
     properties.routing_api.router_groups: '[{"name":"default-tcp", "type":"tcp", "reservable_ports":"((KUBE_SIZING_TCP_ROUTER_PORTS_TCP_ROUTE_MIN))-((KUBE_SIZING_TCP_ROUTER_PORTS_TCP_ROUTE_MAX))"}]'
     properties.routing_api.sqldb.host: *cf-internal-database-host
     properties.routing_api.sqldb.password: "((MYSQL_ROUTING_API_PASSWORD))"
+    properties.routing_api.sqldb.username: "routing-api((DB_EXTERNAL_USER_HOST_SUFFIX))"
     properties.routing_api.system_domain: '"((DOMAIN))"'
     properties.routing_api.uri: '"http://routing-api-routing-api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"'
     properties.routing_api.url: '"http://routing-api-routing-api.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))"'
@@ -3867,6 +3871,13 @@ variables:
     description: >
       Administrator user name for an external database server; this is required
       to create the necessary databases.  Only used if DB_EXTERNAL_HOST is set.
+- name: DB_EXTERNAL_USER_HOST_SUFFIX
+  options:
+    immutable: true
+    description: >
+      A suffix that has to be appended to every user name for the external
+      database; usualy '@host'. Only used if DB_EXTERNAL_HOST is set.
+    default: ""
 - name: DEFAULT_APP_DISK_IN_MB
   options:
     default: 1024

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -3859,7 +3859,8 @@ variables:
     description: >
       TLS configuration for the external database server to use for the
       CF-internal databases.  Only used if DB_EXTERNAL_HOST is set.  Valid
-      values depend on which database driver is in use.
+      calues are true and false.
+    default: true
 - name: DB_EXTERNAL_USER
   options:
     immutable: true

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2240,6 +2240,7 @@ instance_groups:
       properties.uaadb.address: *cf-internal-database-host
       properties.uaadb.port: *cf-internal-database-port
       properties.uaadb.roles: '[{"name": "uaaadmin", "password": "((UAADB_PASSWORD))", "tag": "admin"}]'
+      properties.uaadb.tls: "((UAADB_TLS))"
       properties.wait-for-database.hostname: *cf-internal-database-host
       properties.wait-for-database.port: *cf-internal-database-port
 - name: secret-generation
@@ -4931,6 +4932,16 @@ variables:
     secret: true
     description: The password for access to the UAA database.
   type: password
+- name: UAADB_TLS
+  options:
+    description: |
+      Use TLS connection for UAA database.
+      Valid options are:
+      enabled (use TLS with full certificate validation),
+      enabled_skip_hostname_validation (use TLS but skip validation of common and alt names in the host certificate),
+      enabled_skip_all_validation (use TLS but do not validate anything about the host certificate),
+      disabled (do not use TLS)
+    default: enabled
 - name: UAA_ADMIN_CLIENT_SECRET
   options:
     secret: true

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2321,6 +2321,7 @@ instance_groups:
   - scripts/configure-HA-hosts.sh
   - scripts/credhub_log_level.sh
   scripts:
+  - scripts/authorize_internal_ca.sh
   - scripts/forward_logfiles.sh
   - scripts/patches/fix_monit_rsyslog.sh
   - scripts/patches/uaa_ca_cert_credhub.sh
@@ -2363,7 +2364,7 @@ instance_groups:
           privileged: true
   configuration:
     templates:
-      properties.credhub.authentication.uaa.ca_certs: '["((UAA_CA_CERT))"]'
+      properties.credhub.authentication.uaa.ca_certs: '["((UAA_CA_CERT))((#INTERNAL_CA_CERT))((/INTERNAL_CA_CERT))"]'
       properties.credhub.authentication.uaa.internal_url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
       properties.credhub.authentication.uaa.url: https://((KUBERNETES_NAMESPACE)).((UAA_HOST)):((UAA_PORT))
       properties.credhub.authorization.acls.enabled: false
@@ -2371,8 +2372,7 @@ instance_groups:
       properties.credhub.data_storage.host: *cf-internal-database-host
       properties.credhub.data_storage.password: ((MYSQL_CREDHUB_USER_PASSWORD))
       properties.credhub.data_storage.port: *cf-internal-database-port
-      # require_tls must be set also when UAA is using the INTERNAL_CA_CERT
-      properties.credhub.data_storage.require_tls: true
+      properties.credhub.data_storage.require_tls: false
       properties.credhub.data_storage.tls_ca: ((INTERNAL_CA_CERT))
       properties.credhub.data_storage.type: "mysql"
       properties.credhub.data_storage.username: "credhub_user"

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -40,9 +40,9 @@ releases:
   url: https://s3-us-west-2.amazonaws.com/suse-garden-runc-release/garden-runc-release-v1.19.9.tgz
   sha1: b1801e4ad91f4c176d9efe4166e1aee0cfd0c4ac
 - name: loggregator
-  version: 106.3.0
-  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=106.3.0
-  sha1: f61a6ff8ca558899de8e992ba0271a06d7ae7c85
+  version: 105.6.3
+  url: https://s3.amazonaws.com/cap-release-archives/manual/bosh-releases/loggregator-release-105.6.3.tgz
+  sha1: 5e06ed130f0a2724d000b421133b969f99f89e6d
 - name: log-cache
   version: 2.6.4
   url: https://bosh.io/d/github.com/cloudfoundry/log-cache-release?v=2.6.4

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2371,9 +2371,10 @@ instance_groups:
       properties.credhub.authorization.acls.enabled: false
       properties.credhub.data_storage.database: "credhub_user"
       properties.credhub.data_storage.host: *cf-internal-database-host
+      properties.credhub.data_storage.hostname_verification.enabled: ((CREDHUB_DB_HOST_VALIDATION))
       properties.credhub.data_storage.password: ((MYSQL_CREDHUB_USER_PASSWORD))
       properties.credhub.data_storage.port: *cf-internal-database-port
-      properties.credhub.data_storage.require_tls: false
+      properties.credhub.data_storage.require_tls: ((CREDHUB_DB_REQUIRE_TLS))
       properties.credhub.data_storage.tls_ca: ((INTERNAL_CA_CERT))
       properties.credhub.data_storage.type: "mysql"
       properties.credhub.data_storage.username: "credhub_user"
@@ -3772,6 +3773,16 @@ variables:
     default: 2
     description: "'version' attribute in the /v2/info endpoint"
     required: true
+- name: CREDHUB_DB_HOST_VALIDATION
+  options:
+    default: true
+    description: Enables hostname verification for TLS connections to targeted database server.
+      This property is only respected when targeting a MariaDB database.
+      Hostname verification cannot be disabled for TLS connections to postgres databases.
+- name: CREDHUB_DB_REQUIRE_TLS
+  options:
+    default: true
+    description: Requires only TLS connections to targeted database server.
 - name: CREDHUB_ENCRYPT_KEY
   options:
     secret: true

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -2314,7 +2314,7 @@ instance_groups:
       properties.database-seeder.password: ((DB_EXTERNAL_PASSWORD))
       properties.database-seeder.port: ((DB_EXTERNAL_PORT))
       properties.database-seeder.sslmode: ((DB_EXTERNAL_SSL_MODE))
-      properties.database-seeder.username: ((DB_EXTERNAL_USER))
+      properties.database-seeder.username: "((DB_EXTERNAL_USER))((DB_EXTERNAL_USER_HOST_SUFFIX))"
       properties.seeded_databases: *seeded_databases
 - name: credhub-user
   if_feature: credhub
@@ -3861,10 +3861,10 @@ variables:
   options:
     immutable: true
     description: >
-      TLS configuration for the external database server to use for the
+      SSL configuration for the external database server to use for the
       CF-internal databases.  Only used if DB_EXTERNAL_HOST is set.  Valid
-      calues are true and false.
-    default: true
+      values are 'false', 'skip-verify', 'preferred', and 'true'.
+    default: "true"
 - name: DB_EXTERNAL_USER
   options:
     immutable: true
@@ -3876,7 +3876,7 @@ variables:
     immutable: true
     description: >
       A suffix that has to be appended to every user name for the external
-      database; usualy '@host'. Only used if DB_EXTERNAL_HOST is set.
+      database; usually '@host'.
     default: ""
 - name: DEFAULT_APP_DISK_IN_MB
   options:

--- a/container-host-files/etc/scf/config/scripts/authorize_internal_ca.sh
+++ b/container-host-files/etc/scf/config/scripts/authorize_internal_ca.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This installs certificate authorities:
+# - if available, the internal CA used to identify the components in the cluster
+# - if available, the CA used for UAA (from the chosen backplane)
+
+# This file is (sometimes) sourced as an environment script, as it is required by
+# `fetch_uaa_verification_key.sh`, which itself must be an enviroment script.
+# As such, we need to do things to ensure we have an acceptable environment.
+
+os_type=$(get_os_type)
+if [ "$os_type" == "ubuntu" ]; then
+    ca_path=/usr/local/share/ca-certificates
+elif [ "$os_type" == "opensuse" ]; then
+    ca_path=/etc/pki/trust/anchors
+else
+    printf "Error: unknown operating system '${os_type}'"
+    exit 1
+fi
+
+if test -z "${BASH_SOURCE[1]:-}" ; then
+    # This is being run standalone
+    set -o errexit -o nounset
+else
+    # This is being sourced from a different script
+    if ! ( echo "${SHELLOPTS:-}" | tr ':' '\n' | grep --quiet errexit ) ; then
+        printf "Error: errexit not set\n" >&2
+        exit 1
+    fi
+fi
+
+if [ -r /etc/secrets/internal-ca-cert ]; then
+    cp /etc/secrets/internal-ca-cert "${ca_path}"/internalCA.crt
+elif [ -n "${INTERNAL_CA_CERT:-}" ]; then
+    printf "%b" "${INTERNAL_CA_CERT}" > "${ca_path}"/internalCA.crt
+fi
+
+update-ca-certificates


### PR DESCRIPTION
### Bump external UAA to cf-deployment-12.17 level

This update was overlooked when the SCF changes were merged, and the embedded and external UAA were out of sync.

The external UAA was also mistakenly using the database seeder credentials when using an external database; it now always uses `uaaadmin`.

### Bump back loggregator to v105.6.3

This is a hotfix releases for the v105 version and has been tagged in Dec 2019. There is no bosh.io release for it because v106 was already out, so we had to build a local dev release and put it into our own S3 bucket. The purpose of this change is to avoid the DNS spamming behaviour of v106 (see https://github.com/cloudfoundry/loggregator-release/issues/401).

### Disentangle credhub TLS from supporting an empty `UAA_CA_CERT`

The changes in RC2 required credhub to use TLS to get the `INTERNAL_CA_CERT` into the Java trust store. Now a release script, that runs before configgin, will install it into the system cert store, so it will always be copied by the credhub pre-start script.

### Make TLS usage for both UAA and credhub configurable via various variables

### Add `DB_EXTERNAL_USER_HOST_SUFFIX` variable

On Azure MariaDB the username must always include the hostname, like `'user@host'@'host.azure.com`. This variable is appended to all hostnames in the rolemanifest.

Note that the cf-usb username is hardcoded in the release, so it will be incompatible with external database support on Azure.