### PR TITLE
Extended PR creation script with command removing RC references from charts to be released.

### DIFF
--- a/bin/dev/create_helm_charts_pr.sh
+++ b/bin/dev/create_helm_charts_pr.sh
@@ -67,9 +67,6 @@ sed -i 's|-rc[0-9][0-9]*||' stable/cf/values.yaml
 sed -i 's|-rc[0-9][0-9]*||' stable/uaa/values.yaml
 
 # scfVersion: 2.20.2-rc1+cf12.17.0.0.g5c8dc458
-sed -i 's|-rc[0-9][0-9]*||' stable/cf/Chart.yaml
-sed -i 's|-rc[0-9][0-9]*||' stable/uaa/Chart.yaml
-
 # version: 2.20.2-rc1
 sed -i 's|-rc[0-9][0-9]*||' stable/cf/Chart.yaml
 sed -i 's|-rc[0-9][0-9]*||' stable/uaa/Chart.yaml

--- a/bin/dev/create_helm_charts_pr.sh
+++ b/bin/dev/create_helm_charts_pr.sh
@@ -44,7 +44,7 @@ bundle_readable=$(printf '%b' "${bundle//%/\\x}")
 product=`echo $bundle_readable | cut -d+ -f1`
 
 # Strip -rcN from the product version shown in PR description.
-product="$(echo "${product}" | sed -e 's|-rc.*||')"
+product="$(echo "${product}" | sed -e 's|-rc[0-9][0-9]*$||')"
 
 pr_title="Release $product"
 pr_description="Publish Helm charts for release $product created from $bundle_readable.zip built in Jenkins run $SOURCE_BUILD."
@@ -63,16 +63,16 @@ grep -rn '.-rc' stable/{cf,uaa}
 # Fixing RC references.
 
 # CLUSTER_BUILD: "2.20.2-rc1"
-sed -i 's|-rc.*"$|"|' stable/cf/values.yaml
-sed -i 's|-rc.*"$|"|' stable/uaa/values.yaml
+sed -i 's|-rc[0-9][0-9]*||' stable/cf/values.yaml
+sed -i 's|-rc[0-9][0-9]*||' stable/uaa/values.yaml
 
 # scfVersion: 2.20.2-rc1+cf12.17.0.0.g5c8dc458
-sed -i 's|-rc.*cf|+cf|' stable/cf/Chart.yaml
-sed -i 's|-rc.*cf|+cf|' stable/uaa/Chart.yaml
+sed -i 's|-rc[0-9][0-9]*||' stable/cf/Chart.yaml
+sed -i 's|-rc[0-9][0-9]*||' stable/uaa/Chart.yaml
 
 # version: 2.20.2-rc1
-sed -i 's|-rc.*$||'     stable/cf/Chart.yaml
-sed -i 's|-rc.*$||'     stable/uaa/Chart.yaml
+sed -i 's|-rc[0-9][0-9]*||' stable/cf/Chart.yaml
+sed -i 's|-rc[0-9][0-9]*||' stable/uaa/Chart.yaml
 
 # Fixing docker registry references.
 


### PR DESCRIPTION
## Description

Added commands to the script creating the release PR which squash `-rcN` strings from the
chart. Affected: `version`, `scfVersion`, `CLUSTER_BUILD`. The last is the information goes into the `v2/info` endpoint of a deployed CF.

## Motivation and Context

See https://jira.suse.com/browse/CAP-1120

## How Has This Been Tested?

Manual testing with github operations disabled and copying a fixed bundle into place instead of downloading anything.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

The documentation to change is the https://confluence.suse.com/display/CAP/CAP+Release+Process+Template, section `Shipping`.
